### PR TITLE
Add option --path & --memory-limit

### DIFF
--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\LaravelCodeAnalyse\Console;
 
-use function substr;
 use function implode;
-use function strtoupper;
 use Illuminate\Console\Command;
 use Symfony\Component\Process\Process;
 use Illuminate\Console\Application as Artisan;
@@ -57,14 +55,14 @@ final class CodeAnalyseCommand extends Command
         $params = [
             static::phpstanBinary(),
             'analyse',
-            '--level=' . $level,
-            '--autoload-file=' . $this->laravel->basePath('vendor/autoload.php'),
-            '--configuration=' . __DIR__ . '/../../extension.neon',
+            '--level='.$level,
+            '--autoload-file='.$this->laravel->basePath('vendor/autoload.php'),
+            '--configuration='.__DIR__.'/../../extension.neon',
             $path,
         ];
 
         if ($this->hasOption('memory-limit') && $this->option('memory-limit')) {
-            $params[] = '--memory-limit=' . $this->option('memory-limit');
+            $params[] = '--memory-limit='.$this->option('memory-limit');
         }
 
         $process = new Process(implode(' ', $params), $this->laravel->basePath('vendor/bin'));

--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -30,7 +30,11 @@ final class CodeAnalyseCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected $signature = 'code:analyse {--level=1}';
+    protected $signature = 'code:analyse 
+            {--level=1} 
+            {--path= : Path to directory which need to analyse}
+            {--memory-limit= : Memory limit}
+    ';
 
     /**
      * {@inheritdoc}
@@ -44,14 +48,24 @@ final class CodeAnalyseCommand extends Command
     {
         $level = is_string($this->option('level')) ? $this->option('level') : 'max';
 
+        $path = $this->laravel['path'];
+
+        if ($this->hasOption('path') && $this->option('path')) {
+            $path = base_path($this->option('path'));
+        }
+
         $params = [
             static::phpstanBinary(),
             'analyse',
-            '--level='.$level,
-            '--autoload-file='.$this->laravel->basePath('vendor/autoload.php'),
-            '--configuration='.__DIR__.'/../../extension.neon',
-            $this->laravel['path'],
+            '--level=' . $level,
+            '--autoload-file=' . $this->laravel->basePath('vendor/autoload.php'),
+            '--configuration=' . __DIR__ . '/../../extension.neon',
+            $path,
         ];
+
+        if ($this->hasOption('memory-limit') && $this->option('memory-limit')) {
+            $params[] = '--memory-limit=' . $this->option('memory-limit');
+        }
 
         $process = new Process(implode(' ', $params), $this->laravel->basePath('vendor/bin'));
 


### PR DESCRIPTION
Example:
```
php artisan code:analyse --path=packages/comment/src --memory-limit=120M
```

I'm working on package development so I need to have the option to change path and some packages are very big so sometimes it has an error.

```
Fatal error: Allowed memory size of 10485760 bytes exhausted (tried to allocate 131072 bytes) in /Users/mac/workspace/cms/vendor/phpstan/phpstan/src/Analyser/NodeScopeResolver.php on line 675
```

`--memory-limit` will resolve it.

Thank you!