### PR TITLE
Make Travis much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ env:
     - COMPOSER_FLAGS=""
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml


### PR DESCRIPTION
Checking out git repos takes longer than getting ZIP files.
Travis already includes composer self-update, see the build logs.