### PR TITLE
feature: allows array access on objects that respects container's contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan": "^0.10.2",
         "symfony/process": "^4.1",
         "laravel/framework": "5.6.*",
         "mockery/mockery": "^1.0|0.9.*"

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,5 @@
 parameters:
+    scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
         - Illuminate\Database\Eloquent\Model
         - Illuminate\Http\Resources\Json\JsonResource

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Analyser;
+
+use NunoMaduro\Larastan\Properties\ReflectionTypeContainer;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+use function get_class;
+use function is_object;
+use function gettype;
+use PhpParser\Node\Expr;
+use PHPStan\Type\ObjectType;
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Analyser\Scope as BaseScope;
+use Illuminate\Contracts\Container\Container;
+use PHPStan\Type\TypehintHelper;
+use ReflectionClass;
+
+/**
+ * @internal
+ */
+class Scope extends BaseScope
+{
+    use Concerns\HasContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(Expr $node): Type
+    {
+        $type = parent::getType($node);
+
+        if ($this->isContainer($type)) {
+            $type = \Mockery::mock($type);
+
+            $type->shouldReceive('isOffsetAccessible')
+                ->andReturn(TrinaryLogic::createYes());
+        }
+
+        return $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTypeFromArrayDimFetch(
+        Expr\ArrayDimFetch $arrayDimFetch,
+        Type $offsetType,
+        Type $offsetAccessibleType
+    ): Type {
+
+        if ($this->isContainer($offsetAccessibleType)) {
+
+            $concrete = $this->resolve($arrayDimFetch->dim->value);
+
+            $type = is_object($concrete) ? get_class($concrete) : gettype($concrete);
+
+            $reflectionType = new ReflectionTypeContainer($type);
+
+            return TypehintHelper::decideTypeFromReflection(
+                $reflectionType,
+                null,
+                is_object($concrete) ? get_class($concrete) : null
+            );
+        }
+
+        return parent::getTypeFromArrayDimFetch($arrayDimFetch, $offsetType, $offsetAccessibleType);
+    }
+
+    /**
+     * Checks if the provided type implements
+     * the Illuminate Container Contract.
+     *
+     * @param \PHPStan\Type\Type $type
+     *
+     * @return bool
+     */
+    private function isContainer(Type $type): bool
+    {
+        foreach ($type->getReferencedClasses() as $referencedClass) {
+            if ((new ReflectionClass($referencedClass))->implementsInterface(Container::class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -13,19 +13,18 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Analyser;
 
-use NunoMaduro\Larastan\Properties\ReflectionTypeContainer;
-use PHPStan\TrinaryLogic;
+use ReflectionClass;
+use function gettype;
 use PHPStan\Type\Type;
 use function get_class;
 use function is_object;
-use function gettype;
 use PhpParser\Node\Expr;
-use PHPStan\Type\ObjectType;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\TypehintHelper;
 use NunoMaduro\Larastan\Concerns;
 use PHPStan\Analyser\Scope as BaseScope;
 use Illuminate\Contracts\Container\Container;
-use PHPStan\Type\TypehintHelper;
-use ReflectionClass;
+use NunoMaduro\Larastan\Properties\ReflectionTypeContainer;
 
 /**
  * @internal
@@ -59,9 +58,7 @@ class Scope extends BaseScope
         Type $offsetType,
         Type $offsetAccessibleType
     ): Type {
-
         if ($this->isContainer($offsetAccessibleType)) {
-
             $concrete = $this->resolve($arrayDimFetch->dim->value);
 
             $type = is_object($concrete) ? get_class($concrete) : gettype($concrete);

--- a/src/Contracts/Methods/PassableContract.php
+++ b/src/Contracts/Methods/PassableContract.php
@@ -10,11 +10,11 @@
 
 namespace NunoMaduro\Larastan\Contracts\Methods;
 
-use Illuminate\Contracts\Container\Container as ContainerContract;
 use PHPStan\Broker\Broker;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 /**
  * @internal

--- a/src/Methods/Kernel.php
+++ b/src/Methods/Kernel.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods;
 
 use PHPStan\Broker\Broker;
-use NunoMaduro\Larastan\Concerns;
 use Illuminate\Pipeline\Pipeline;
+use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;


### PR DESCRIPTION
This PR fixes the issue https://github.com/nunomaduro/larastan/issues/31 allowing the array access on objects that respects illuminate container's contract.