### PR TITLE
Use cross-platform value for default paths input option.

### DIFF
--- a/src/Console/OptionsResolver.php
+++ b/src/Console/OptionsResolver.php
@@ -74,7 +74,7 @@ final class OptionsResolver
 
         $definition->addOption(
             new InputOption(
-                'paths', 'p', InputOption::VALUE_REQUIRED, 'Paths with source code to run analysis on', base_path('app')
+                'paths', 'p', InputOption::VALUE_REQUIRED, 'Paths with source code to run analysis on', 'app'
             )
         );
 


### PR DESCRIPTION
As mentioned in https://github.com/nunomaduro/larastan/issues/56#issuecomment-407047456 running  larastan on Windows doesn't work well without specifying the directory to analyze. 

If the directory is not specified it uses: `base_path('app')` defined in `NunoMaduro\Larastan\Console\OptionsResolver`.  The `cmd` function in `NunoMaduro\Larastan\Console\CodeAnalyseCommand` will add a basepath again (see code snippet below), unless the the path is empty or starts with DIRECTORY_SEPARATOR.  This works properly on linux due to /  and will fail on Windows since C: doesn't match the DIRECTORY_SEPARATOR.

Using 'app' as default value should work on both platforms.
Another solution could be to verify the supplied path starts with the actual basepath?

```php
 $pathsValue = $this->option('paths');
if (is_array($pathsValue)) {
	$pathsValue = current($pathsValue);
}

$paths = array_map(
	function ($path) {
		return starts_with($path, DIRECTORY_SEPARATOR) || empty($path) ? $path : $this->laravel->basePath(
			trim($path)
		);
	},
	explode(',', $pathsValue)
);
```