### PR TITLE
Allow Larastan to run in CI

### DIFF
--- a/src/LarastanServiceProvider.php
+++ b/src/LarastanServiceProvider.php
@@ -26,7 +26,7 @@ final class LarastanServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        if ($this->app->runningInConsole() && ! $this->app->runningUnitTests()) {
+        if ($this->app->runningInConsole()) {
             $this->commands(CodeAnalyseCommand::class);
         }
     }

--- a/tests/LarastanServiceProviderTest.php
+++ b/tests/LarastanServiceProviderTest.php
@@ -35,7 +35,7 @@ class LarastanServiceProviderTest extends TestCase
         $this->assertNotContains(CodeAnalyseCommand::class, $this->getCommandClasses());
     }
 
-    public function testCommandNotAddedInTests(): void
+    public function testCommandAddedInTests(): void
     {
         $app = $this->createMockApplication();
         $app->method('runningInConsole')
@@ -44,7 +44,7 @@ class LarastanServiceProviderTest extends TestCase
             ->willReturn(true);
         (new LarastanServiceProvider($app))->register();
 
-        $this->assertNotContains(CodeAnalyseCommand::class, $this->getCommandClasses());
+        $this->assertContains(CodeAnalyseCommand::class, $this->getCommandClasses());
     }
 
     /**


### PR DESCRIPTION
This allows us to run the tool during out CI process.

Maybe there is a reason you disable this for AP_ENV=testing?

Thanks!