### PR TITLE
Respect the exit code from phpstan and exit with the same.

### DIFF
--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -62,7 +62,7 @@ final class CodeAnalyseCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function handle(): void
+    public function handle(): ?int
     {
         $process = new Process($this->cmd(), $this->laravel->basePath('vendor/phpstan/phpstan/bin'));
 
@@ -77,6 +77,8 @@ final class CodeAnalyseCommand extends Command
         foreach ($process as $type => $data) {
             $this->output->writeln($data);
         }
+
+        return $process->getExitCode();
     }
 
     /**


### PR DESCRIPTION
Right now, larastan always exits with `0` regardless of the errors phpstan finds. This change exits the process with the same exit code as phpstan did, allowing a better integration of larastan on build services.