### PR TITLE
Exit with process exit code on failure

### DIFF
--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -62,7 +62,7 @@ final class CodeAnalyseCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function handle(): void
+    public function handle(): int
     {
         $process = new Process($this->cmd(), $this->laravel->basePath('vendor/phpstan/phpstan/bin'));
 
@@ -78,9 +78,7 @@ final class CodeAnalyseCommand extends Command
             $this->output->writeln($data);
         }
 
-        if (! $process->isSuccessful()) {
-            exit($process->getExitCode());
-        }
+        return $process->getExitCode();
     }
 
     /**

--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -77,6 +77,10 @@ final class CodeAnalyseCommand extends Command
         foreach ($process as $type => $data) {
             $this->output->writeln($data);
         }
+
+        if (!$process->isSuccessful()) {
+            exit($process->getExitCode());
+        }
     }
 
     /**

--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -78,7 +78,7 @@ final class CodeAnalyseCommand extends Command
             $this->output->writeln($data);
         }
 
-        if (!$process->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             exit($process->getExitCode());
         }
     }


### PR DESCRIPTION
If the process was not successful (non-zero exit code), return that exit code from the artisan call.

This allows `larastan` to be run as part of scripts that require non-zero exit codes on failure, like git pre-commit hooks to block commit unless `phpstan` passes.