### PR TITLE
$request->input returns array|string|null, string expected

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -36,3 +36,8 @@ services:
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\FormRequestExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+

--- a/src/ReturnTypes/FormRequestExtension.php
+++ b/src/ReturnTypes/FormRequestExtension.php
@@ -50,4 +50,3 @@ final class FormRequestExtension implements DynamicMethodReturnTypeExtension
         return new MixedType;
     }
 }
-

--- a/src/ReturnTypes/FormRequestExtension.php
+++ b/src/ReturnTypes/FormRequestExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use PHPStan\Type\Type;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Reflection\MethodReflection;
+use Illuminate\Foundation\Http\FormRequest;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+
+/**
+ * @internal
+ */
+final class FormRequestExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return FormRequest::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'input';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        return new MixedType;
+    }
+}
+


### PR DESCRIPTION
As stated in #112, Laravel's method signature for `Illuminate\Foundation\Http\FormRequest::input()` is `array|string|null`. From Laravel's perspective, this will be used together with the method `rules` which allows the developer to state the requirements for an input field (e.g. `array` or `string`).

This pull request instructs phpstan to consider the return type as dynamic instead. Since this is my first-ever contribution to a phpstan extension, I have a couple of concerns to highlight: 

- The method actually comes from `trait Illuminate\Http\Concerns\InteractsWithInput`. Should the extension target the trait or only concrete classes?
- This pull request only targets `FormRequest`, however `Illuminate\Http\Request` will have the same issue as it also uses the `InteractsWithInput` trait. Should there be one extension for each class or is there a way to have a single extension that targets both?

Any feedback is well appreciated and thanks for this wonderful tool, both larastan and phpstan!