### PR TITLE
Filter out non existing classes from mixins

### DIFF
--- a/src/Methods/Pipes/Mixins.php
+++ b/src/Methods/Pipes/Mixins.php
@@ -68,7 +68,11 @@ final class Mixins implements PipeContract
         $mixins = array_filter(
             $mixins,
             function ($mixin) use ($classReflection) {
-                return (new \ReflectionClass($mixin))->getName() !== $classReflection->getName();
+                try {
+                    return (new \ReflectionClass($mixin))->getName() !== $classReflection->getName();
+                } catch (\ReflectionException $e) {
+                    return false;
+                }
             }
         );
 


### PR DESCRIPTION
Mixins declared by @mixin and @see might not always be loaded classes. Exclude them from the list of mixins when they cannot be instantiated.