### PR TITLE
Fix internal error caused by non-existing provider name

### DIFF
--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -53,7 +53,9 @@ final class Auths implements PipeContract
 
             $userModel = $config->get('auth.providers.users.model');
 
-            $found = $passable->sendToPipeline($userModel);
+            if ($userModel) {
+                $found = $passable->sendToPipeline($userModel);
+            }
         }
 
         if (! $found) {


### PR DESCRIPTION
I found an internal error in Larastan in my app, appeared because I don't have "users" provider in my auth config - renamed it to "client" (and added "admin"). Method `sendToPipeline` expects string, and null is given from `$config->get`. 