### PR TITLE
Make it possible to customize the default config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ You may use [Composer](https://getcomposer.org) to install Larastan as a develop
 composer require --dev nunomaduro/larastan
 ```
 
+Publish the configuration file:
+```bash
+php artisan vendor:publish --tag=larastan-config
+```
+
 ### Usage in Laravel Applications
 
 Once you have installed Larastan, you may start analyzing your code using the `code:analyse` Artisan command.

--- a/config-laravel/larastan.php
+++ b/config-laravel/larastan.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to set the path to the phpstan configuration file.
+    |
+    */
+    'configuration' => base_path('vendor/nunomaduro/larastan/extension.neon'),
+];

--- a/src/Console/OptionsResolver.php
+++ b/src/Console/OptionsResolver.php
@@ -67,7 +67,7 @@ final class OptionsResolver
             ->setDefault(base_path('vendor/autoload.php'));
 
         $definition->getOption('configuration')
-            ->setDefault(__DIR__.'/../../extension.neon');
+            ->setDefault($this->defaultConfiguration());
 
         $definition->getOption('memory-limit')
             ->setDefault(self::DEFAULT_MEMORY_LIMIT);
@@ -79,5 +79,20 @@ final class OptionsResolver
         );
 
         return $this->definition = $definition;
+    }
+
+    /**
+     * Determines the default configuration.
+     *
+     * @return string
+     */
+    private function defaultConfiguration() : string
+    {
+        $configPath = config('larastan.configuration');
+        if (!$configPath) {
+            $configPath = __DIR__ . '/../../extension.neon';
+        }
+
+        return $configPath;
     }
 }

--- a/src/Console/OptionsResolver.php
+++ b/src/Console/OptionsResolver.php
@@ -89,8 +89,8 @@ final class OptionsResolver
     private function defaultConfiguration() : string
     {
         $configPath = config('larastan.configuration');
-        if (!$configPath) {
-            $configPath = __DIR__ . '/../../extension.neon';
+        if (! $configPath) {
+            $configPath = __DIR__.'/../../extension.neon';
         }
 
         return $configPath;

--- a/src/LarastanServiceProvider.php
+++ b/src/LarastanServiceProvider.php
@@ -27,7 +27,7 @@ final class LarastanServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishes([
-            __DIR__ . '/../config-laravel/larastan.php' => config_path('larastan.php'),
+            __DIR__.'/../config-laravel/larastan.php' => config_path('larastan.php'),
         ], 'larastan-config');
     }
 

--- a/src/LarastanServiceProvider.php
+++ b/src/LarastanServiceProvider.php
@@ -24,6 +24,16 @@ final class LarastanServiceProvider extends ServiceProvider
     /**
      * {@inheritdoc}
      */
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__ . '/../config-laravel/larastan.php' => config_path('larastan.php'),
+        ], 'larastan-config');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function register(): void
     {
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
I found it cumbersome having to define my own configuration file every time. So I made it configurable.

So before this PR I had to run:
`artisan code:analyse --configuration=$PWD/phpstan.neon`

The solution is adding a customizable Laravel config file that you can publish by running:
`artisan vendor:publish --tag=larastan-config`

And now I simply change the default:
`'configuration' => base_path('vendor/nunomaduro/larastan/extension.neon'),`

To:
`'configuration' => base_path('phpstan.neon'),`

Now I can just run:
`artisan code:analyse`

I made it backward compatible, so people without the `larastan.php` config file do not run into issues.

Fixes #134 