### PR TITLE
Fix issue with Laravel 5.7 also keeping compatibility with version 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1.3",
         "symfony/process": "^4.1",
         "phpstan/phpstan": "^0.10.2",
-        "orchestra/testbench": "^3.6",
+        "orchestra/testbench": "^3.6|^3.7",
         "illuminate/http": "5.6.*|5.7.*",
         "illuminate/support": "5.6.*|5.7.*",
         "illuminate/console": "5.6.*|5.7.*",


### PR DESCRIPTION
This modification enable Larastan to be compatible with Laravel 5.7 without undoing #155. 