### PR TITLE
Fix for paths with spaces

### DIFF
--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -100,7 +100,7 @@ final class CodeAnalyseCommand extends Command
             $value = is_array($value) ? implode(',', $value) : $value;
 
             if ($option->acceptValue() && $value !== null) {
-                $options .= " --$name=$value";
+                $options .= " --$name=".escapeshellarg($value);
             } else {
                 if ($this->option($name)) {
                     $options .= " --$name";


### PR DESCRIPTION
At this time analysis fails when the project path contains one or more spaces.

Fixes #152 