### PR TITLE
Support LengthAwarePaginator

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -42,6 +42,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\LengthAwarePaginatorExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\CookieExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/LengthAwarePaginatorExtension.php
+++ b/src/ReturnTypes/LengthAwarePaginatorExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use function in_array;
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use Illuminate\Database\Eloquent\Collection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+/**
+ * @internal
+ */
+final class LengthAwarePaginatorExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if ($classReflection->getName() === LengthAwarePaginator::class) {
+            return in_array($methodName, get_class_methods(Collection::class));
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->broker->getClass(Collection::class)->getNativeMethod($methodName);
+    }
+}

--- a/tests/Features/ReturnTypes/LengthAwarePaginatorExtension.php
+++ b/tests/Features/ReturnTypes/LengthAwarePaginatorExtension.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+
+class LengthAwarePaginatorExtension
+{
+    public function testCollection(): array
+    {
+        return User::paginate()->all();
+    }
+}


### PR DESCRIPTION
Adds support for `LengthAwarePaginator` which [forwards](https://github.com/laravel/framework/blob/0060d98a8601a360ebd679560053ea162cd11876/src/Illuminate/Pagination/AbstractPaginator.php#L628) undefined calls to the `Collection` of items:

```php
User::paginate()->map(function ($user) {
    return $user;
});
````

Fixes #205.