### PR TITLE
Support paginators

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -42,6 +42,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\PaginatorExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\CookieExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/PaginatorExtension.php
+++ b/src/ReturnTypes/PaginatorExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use function is_a;
+use function in_array;
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use Illuminate\Database\Eloquent\Collection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use Illuminate\Contracts\Pagination\Paginator;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+
+/**
+ * @internal
+ */
+final class PaginatorExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (is_a($classReflection->getName(), Paginator::class, true)) {
+            return in_array($methodName, get_class_methods(Collection::class));
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->broker->getClass(Collection::class)->getNativeMethod($methodName);
+    }
+}

--- a/tests/Features/ReturnTypes/PaginatorExtension.php
+++ b/tests/Features/ReturnTypes/PaginatorExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+
+class PaginatorExtension
+{
+    public function testPaginate(): array
+    {
+        return User::paginate()->all();
+    }
+
+    public function testSimplePaginate(): array
+    {
+        return User::simplePaginate()->all();
+    }
+}


### PR DESCRIPTION
Adds support for `LengthAwarePaginator` and `Paginator` which [forward](https://github.com/laravel/framework/blob/0060d98a8601a360ebd679560053ea162cd11876/src/Illuminate/Pagination/AbstractPaginator.php#L628) undefined method calls to the `Collection` of items:

```php
User::paginate()->map(function ($user) {
    return $user;
});

User::simplePaginate()->map(function ($user) {
    return $user;
});
````

Fixes #205.