### PR TITLE
Test PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 cache:

--- a/tests/Features/Methods/PaginatorExtension.php
+++ b/tests/Features/Methods/PaginatorExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Features\Methods;
 
 use App\User;
-use Illuminate\Database\Eloquent\Model;
 
 class PaginatorExtension
 {


### PR DESCRIPTION
Adds PHP 7.3 to Travis CI tests and removes unused import.

The Travis CI tests are not failing because of these changes. Travis CI has made some [infrastructure changes](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) in the last weeks. The logs show that the tests are now running on different machines ("Worker information").

The tests work after removing the `test "$(find ...)` line.