### PR TITLE
Add support for the trans() helper return types

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -70,3 +70,8 @@ services:
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\ViewExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\TransExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/Helpers/TransExtension.php
+++ b/src/ReturnTypes/Helpers/TransExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use PHPStan\Type\Type;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+
+class TransExtension implements DynamicFunctionReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'trans';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        // No path provided, so it returns a Translator instance
+        if (count($functionCall->args) === 0) {
+            return new ObjectType(\Illuminate\Contracts\Translation\Translator::class);
+        }
+
+        return new MixedType();
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/CookieExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/CookieExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Illuminate\Cookie\CookieJar;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class CookieExtension
+{
+    public function testCookie(): Cookie
+    {
+        return cookie('test');
+    }
+
+    public function testCookieJar(): CookieJar
+    {
+        return cookie();
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/RedirectExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/RedirectExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Illuminate\Routing\Redirector;
+use Illuminate\Http\RedirectResponse;
+
+class RedirectExtension
+{
+    public function testRedirect(): RedirectResponse
+    {
+        return redirect('/');
+    }
+
+    public function testRedirector(): Redirector
+    {
+        return redirect();
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/RequestExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/RequestExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Illuminate\Http\Request;
+
+class RequestExtension
+{
+    public function testRequest(): Request
+    {
+        return \request();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testMixed()
+    {
+        return \request('name');
+    }
+
+    public function testArrayMixed(): array
+    {
+        return \request(['a', 'b']);
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/TransExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/TransExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Illuminate\Contracts\Translation\Translator;
+
+class TransExtension
+{
+    /**
+     * @return mixed
+     */
+    public function testTrans()
+    {
+        return trans('foo');
+    }
+
+    public function testTranslator(): Translator
+    {
+        return trans();
+    }
+}


### PR DESCRIPTION
This adds support for the return type of `trans()` vs `trans('key')`.

I also added test for the other helper return type extensions