### PR TITLE
Add getEndLine() implementation in NunoMaduro\Larastan\Methods\Macro

### DIFF
--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -176,6 +176,14 @@ final class Macro implements BuiltinMethodReflection
     /**
      * {@inheritdoc}
      */
+    public function getEndLine()
+    {
+        return $this->reflectionFunction->getEndLine();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isDeprecated(): bool
     {
         return $this->reflectionFunction->isDeprecated();


### PR DESCRIPTION
Commit [f16bc87](https://github.com/phpstan/phpstan/commit/f16bc87b95f83bfdc1c720e32fc1a667157fa7ad#diff-b82d3e974bb18e9a251dc655fbb56adc) in phpstan/phpstan (not yet released) introduced a new `getEndLine()` method for PHPStan\Reflection\Php\BuiltinMethodReflection which is not yet updated in Larastan.
