### PR TITLE
Macro implements MethodReflection instead of BuiltinMethodReflection

### DIFF
--- a/src/Contracts/Methods/PassableContract.php
+++ b/src/Contracts/Methods/PassableContract.php
@@ -13,7 +13,6 @@ namespace NunoMaduro\Larastan\Contracts\Methods;
 use PHPStan\Broker\Broker;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
 /**
@@ -97,9 +96,4 @@ interface PassableContract
      * @return \PHPStan\Broker\Broker
      */
     public function getBroker(): Broker;
-
-    /**
-     * @return \PHPStan\Reflection\Php\PhpMethodReflectionFactory
-     */
-    public function getMethodReflectionFactory(): PhpMethodReflectionFactory;
 }

--- a/src/Methods/Extension.php
+++ b/src/Methods/Extension.php
@@ -17,7 +17,6 @@ use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\BrokerAwareExtension;
-use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 
 /**
@@ -35,12 +34,11 @@ final class Extension implements MethodsClassReflectionExtension, BrokerAwareExt
     /**
      * Extension constructor.
      *
-     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
      * @param \NunoMaduro\Larastan\Methods\Kernel|null $kernel
      */
-    public function __construct(PhpMethodReflectionFactory $methodReflectionFactory, Kernel $kernel = null)
+    public function __construct(Kernel $kernel = null)
     {
-        $this->kernel = $kernel ?? new Kernel($methodReflectionFactory);
+        $this->kernel = $kernel ?? new Kernel();
     }
 
     /**

--- a/src/Methods/Kernel.php
+++ b/src/Methods/Kernel.php
@@ -17,7 +17,6 @@ use PHPStan\Broker\Broker;
 use Illuminate\Pipeline\Pipeline;
 use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 
 /**
@@ -26,22 +25,6 @@ use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 final class Kernel
 {
     use Concerns\HasContainer;
-
-    /**
-     * @var \PHPStan\Reflection\Php\PhpMethodReflectionFactory
-     */
-    private $methodReflectionFactory;
-
-    /**
-     * Kernel constructor.
-     *
-     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
-     */
-    public function __construct(
-        PhpMethodReflectionFactory $methodReflectionFactory
-    ) {
-        $this->methodReflectionFactory = $methodReflectionFactory;
-    }
 
     /**
      * @param \PHPStan\Broker\Broker $broker
@@ -54,7 +37,7 @@ final class Kernel
     {
         $pipeline = new Pipeline($this->getContainer());
 
-        $passable = new Passable($this->methodReflectionFactory, $broker, $pipeline, $classReflection, $methodName);
+        $passable = new Passable($broker, $pipeline, $classReflection, $methodName);
 
         $pipeline->send($passable)
             ->through(

--- a/src/Methods/Passable.php
+++ b/src/Methods/Passable.php
@@ -21,7 +21,6 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Contracts\Pipeline\Pipeline;
 use PHPStan\Reflection\Php\PhpMethodReflection;
-use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 
 /**
@@ -30,11 +29,6 @@ use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 final class Passable implements PassableContract
 {
     use Concerns\HasContainer;
-
-    /**
-     * @var \PHPStan\Reflection\Php\PhpMethodReflectionFactory
-     */
-    private $methodReflectionFactory;
 
     /**
      * @var \PHPStan\Broker\Broker
@@ -69,20 +63,17 @@ final class Passable implements PassableContract
     /**
      * Method constructor.
      *
-     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
      * @param \PHPStan\Broker\Broker $broker
      * @param \Illuminate\Contracts\Pipeline\Pipeline $pipeline
      * @param \PHPStan\Reflection\ClassReflection $classReflection
      * @param string $methodName
      */
     public function __construct(
-        PhpMethodReflectionFactory $methodReflectionFactory,
         Broker $broker,
         Pipeline $pipeline,
         ClassReflection $classReflection,
         string $methodName
     ) {
-        $this->methodReflectionFactory = $methodReflectionFactory;
         $this->broker = $broker;
         $this->pipeline = $pipeline;
         $this->classReflection = $classReflection;
@@ -228,13 +219,5 @@ final class Passable implements PassableContract
     public function getBroker(): Broker
     {
         return $this->broker;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodReflectionFactory(): PhpMethodReflectionFactory
-    {
-        return $this->methodReflectionFactory;
     }
 }

--- a/src/Methods/Pipes/BuilderLocalMacros.php
+++ b/src/Methods/Pipes/BuilderLocalMacros.php
@@ -16,13 +16,14 @@ namespace NunoMaduro\Larastan\Methods\Pipes;
 use Closure;
 use ReflectionClass;
 use function in_array;
-use ReflectionFunction;
-use PHPStan\Type\ObjectType;
+use PhpParser\Node\Name;
+use function array_values;
 use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\Macro;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
@@ -54,20 +55,22 @@ final class BuilderLocalMacros implements PipeContract
             $refProperty->setAccessible(true);
             $localMacros = $refProperty->getValue($builder);
 
+            $broker = $passable->getBroker();
+
             if (array_key_exists($passable->getMethodName(), $localMacros)) {
-                $reflectionFunction = new ReflectionFunction($localMacros[$passable->getMethodName()]);
-                $parameters = $reflectionFunction->getParameters();
-                unset($parameters[0]); // The query argument.
+                $functionName = new Name($localMacros[$passable->getMethodName()]);
+                if ($broker->hasFunction($functionName, null)) {
+                    $functionReflection = $broker->getFunction($functionName, null);
+                    $functionVariant = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+                    $parameters = $functionVariant->getParameters();
+                    unset($parameters[0]); // The query argument.
+                    $parameters = array_values($parameters);
 
-                $macro = new Macro($classReflection->getName(), $passable->getMethodName(), $reflectionFunction);
+                    $macro = new Macro($classReflection, $passable->getMethodName(), $parameters, $functionVariant->isVariadic(), $functionVariant->getReturnType(), true);
 
-                $macro->setParameters($parameters);
-                $macro->setIsStatic(true);
-
-                $passable->setMethodReflection($passable->getMethodReflectionFactory()->create($classReflection, null,
-                    $macro, $parameters, new ObjectType($classReflection->getName()), null, null, false, false,
-                    false));
-                $found = true;
+                    $passable->setMethodReflection($macro);
+                    $found = true;
+                }
             }
         }
 

--- a/src/Methods/Pipes/ModelScopes.php
+++ b/src/Methods/Pipes/ModelScopes.php
@@ -15,6 +15,7 @@ namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
 use Mockery;
+use function array_values;
 use Illuminate\Database\Eloquent\Model;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
@@ -42,6 +43,7 @@ final class ModelScopes implements PipeContract
             $variant = $methodReflection->getVariants()[0];
             $parameters = $variant->getParameters();
             unset($parameters[0]); // The query argument.
+            $parameters = array_values($parameters);
 
             $variant = Mockery::mock($variant);
             $variant->shouldReceive('getParameters')


### PR DESCRIPTION
This is fix for PHPStan 0.11.14. This PR changes what interface `Macro` implements, and some additonal cleanups stem from that.

This is closer to how PHPStan extensions should work. It's better to implement `MethodReflection` in a class directly rather than pass it through PhpMethodReflectionFactory.

I'm sorry about these BC breaks, it didn't occur to me that some extensions would be using the `BuiltinMethodReflection` interface. I want to have much clearer backwards compatibility boundary in the future, probably by tagging some classes and interfaces with `@api`. Everything else will be considered internal.

Right now, the rule of thumb is that backwards compatibility covers what's mentioned in the README.