### PR TITLE
Less ambitious fix to BuiltinMethodReflection woes

### DIFF
--- a/src/Contracts/Methods/PassableContract.php
+++ b/src/Contracts/Methods/PassableContract.php
@@ -13,6 +13,7 @@ namespace NunoMaduro\Larastan\Contracts\Methods;
 use PHPStan\Broker\Broker;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
 /**
@@ -96,4 +97,9 @@ interface PassableContract
      * @return \PHPStan\Broker\Broker
      */
     public function getBroker(): Broker;
+
+    /**
+     * @return \PHPStan\Reflection\Php\PhpMethodReflectionFactory
+     */
+    public function getMethodReflectionFactory(): PhpMethodReflectionFactory;
 }

--- a/src/Methods/Extension.php
+++ b/src/Methods/Extension.php
@@ -17,6 +17,7 @@ use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 
 /**
@@ -34,11 +35,12 @@ final class Extension implements MethodsClassReflectionExtension, BrokerAwareExt
     /**
      * Extension constructor.
      *
+     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
      * @param \NunoMaduro\Larastan\Methods\Kernel|null $kernel
      */
-    public function __construct(Kernel $kernel = null)
+    public function __construct(PhpMethodReflectionFactory $methodReflectionFactory, Kernel $kernel = null)
     {
-        $this->kernel = $kernel ?? new Kernel();
+        $this->kernel = $kernel ?? new Kernel($methodReflectionFactory);
     }
 
     /**

--- a/src/Methods/Kernel.php
+++ b/src/Methods/Kernel.php
@@ -17,6 +17,7 @@ use PHPStan\Broker\Broker;
 use Illuminate\Pipeline\Pipeline;
 use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 
 /**
@@ -25,6 +26,22 @@ use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 final class Kernel
 {
     use Concerns\HasContainer;
+
+    /**
+     * @var \PHPStan\Reflection\Php\PhpMethodReflectionFactory
+     */
+    private $methodReflectionFactory;
+
+    /**
+     * Kernel constructor.
+     *
+     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
+     */
+    public function __construct(
+        PhpMethodReflectionFactory $methodReflectionFactory
+    ) {
+        $this->methodReflectionFactory = $methodReflectionFactory;
+    }
 
     /**
      * @param \PHPStan\Broker\Broker $broker
@@ -37,7 +54,7 @@ final class Kernel
     {
         $pipeline = new Pipeline($this->getContainer());
 
-        $passable = new Passable($broker, $pipeline, $classReflection, $methodName);
+        $passable = new Passable($this->methodReflectionFactory, $broker, $pipeline, $classReflection, $methodName);
 
         $pipeline->send($passable)
             ->through(

--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -93,6 +93,21 @@ final class Macro implements BuiltinMethodReflection
         return true;
     }
 
+    public function isFinal(): bool
+    {
+        return false;
+    }
+
+    public function isInternal(): bool
+    {
+        return false;
+    }
+
+    public function isAbstract(): bool
+    {
+        return false;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -13,20 +13,17 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Methods;
 
-use PHPStan\Type\Type;
-use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionVariant;
-use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ClassMemberReflection;
+use ReflectionClass;
+use PHPStan\Reflection\Php\BuiltinMethodReflection;
 
-final class Macro implements MethodReflection
+final class Macro implements BuiltinMethodReflection
 {
     /**
      * The class name.
      *
-     * @var ClassReflection
+     * @var string
      */
-    private $declaringClass;
+    private $className;
 
     /**
      * The method name.
@@ -36,53 +33,48 @@ final class Macro implements MethodReflection
     private $methodName;
 
     /**
-     * @var \PHPStan\Reflection\ParameterReflection[]
+     * The reflection function.
+     *
+     * @var \ReflectionFunction
+     */
+    private $reflectionFunction;
+
+    /**
+     * The parameters.
+     *
+     * @var array
      */
     private $parameters;
-
-    /**
-     * @var bool
-     */
-    private $isVariadic;
-
-    /**
-     * @var \PHPStan\Type\Type
-     */
-    private $returnType;
 
     /**
      * The is static.
      *
      * @var bool
      */
-    private $isStatic;
+    private $isStatic = false;
 
     /**
      * Macro constructor.
      *
-     * @param \PHPStan\Reflection\ClassReflection $declaringClass
+     * @param string $className
      * @param string $methodName
-     * @param \PHPStan\Reflection\ParameterReflection[] $parameters
-     * @param bool $isVariadic
-     * @param \PHPStan\Type\Type $returnType
-     * @param bool $isStatic
+     * @param \ReflectionFunction $reflectionFunction
      */
-    public function __construct(ClassReflection $declaringClass, string $methodName, array $parameters, bool $isVariadic, Type $returnType, bool $isStatic)
+    public function __construct(string $className, string $methodName, \ReflectionFunction $reflectionFunction)
     {
-        $this->declaringClass = $declaringClass;
+        $this->className = $className;
         $this->methodName = $methodName;
-        $this->parameters = $parameters;
-        $this->isVariadic = $isVariadic;
-        $this->returnType = $returnType;
-        $this->isStatic = $isStatic;
+        $this->reflectionFunction = $reflectionFunction;
+        $this->parameters = $this->reflectionFunction->getParameters();
+        $this->isStatic = false;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDeclaringClass(): ClassReflection
+    public function getDeclaringClass(): ReflectionClass
     {
-        return $this->declaringClass;
+        return new ReflectionClass($this->className);
     }
 
     /**
@@ -110,6 +102,34 @@ final class Macro implements MethodReflection
     }
 
     /**
+     * Set the is static value.
+     *
+     * @param bool $isStatic
+     *
+     * @return void
+     */
+    public function setIsStatic(bool $isStatic): void
+    {
+        $this->isStatic = $isStatic;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocComment()
+    {
+        return $this->reflectionFunction->getDocComment();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileName()
+    {
+        return $this->reflectionFunction->getFileName();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName(): string
@@ -117,17 +137,70 @@ final class Macro implements MethodReflection
         return $this->methodName;
     }
 
-    public function getVariants(): array
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameters(): array
     {
-        return [
-            new FunctionVariant($this->parameters, $this->isVariadic, $this->returnType),
-        ];
+        return $this->parameters;
+    }
+
+    /**
+     * Set the parameters value.
+     *
+     * @param array $parameters
+     *
+     * @return void
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getPrototype(): ClassMemberReflection
+    public function getReturnType(): ?\ReflectionType
+    {
+        return $this->reflectionFunction->getReturnType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStartLine()
+    {
+        return $this->reflectionFunction->getStartLine();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndLine()
+    {
+        return $this->reflectionFunction->getEndLine();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeprecated(): bool
+    {
+        return $this->reflectionFunction->isDeprecated();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isVariadic(): bool
+    {
+        return $this->reflectionFunction->isVariadic();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrototype(): BuiltinMethodReflection
     {
         return $this;
     }

--- a/src/Methods/Passable.php
+++ b/src/Methods/Passable.php
@@ -21,6 +21,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Contracts\Pipeline\Pipeline;
 use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 
 /**
@@ -29,6 +30,11 @@ use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 final class Passable implements PassableContract
 {
     use Concerns\HasContainer;
+
+    /**
+     * @var \PHPStan\Reflection\Php\PhpMethodReflectionFactory
+     */
+    private $methodReflectionFactory;
 
     /**
      * @var \PHPStan\Broker\Broker
@@ -63,17 +69,20 @@ final class Passable implements PassableContract
     /**
      * Method constructor.
      *
+     * @param \PHPStan\Reflection\Php\PhpMethodReflectionFactory $methodReflectionFactory
      * @param \PHPStan\Broker\Broker $broker
      * @param \Illuminate\Contracts\Pipeline\Pipeline $pipeline
      * @param \PHPStan\Reflection\ClassReflection $classReflection
      * @param string $methodName
      */
     public function __construct(
+        PhpMethodReflectionFactory $methodReflectionFactory,
         Broker $broker,
         Pipeline $pipeline,
         ClassReflection $classReflection,
         string $methodName
     ) {
+        $this->methodReflectionFactory = $methodReflectionFactory;
         $this->broker = $broker;
         $this->pipeline = $pipeline;
         $this->classReflection = $classReflection;
@@ -219,5 +228,13 @@ final class Passable implements PassableContract
     public function getBroker(): Broker
     {
         return $this->broker;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethodReflectionFactory(): PhpMethodReflectionFactory
+    {
+        return $this->methodReflectionFactory;
     }
 }

--- a/src/Methods/Pipes/BuilderLocalMacros.php
+++ b/src/Methods/Pipes/BuilderLocalMacros.php
@@ -58,6 +58,7 @@ final class BuilderLocalMacros implements PipeContract
                 $reflectionFunction = new ReflectionFunction($localMacros[$passable->getMethodName()]);
                 $parameters = $reflectionFunction->getParameters();
                 unset($parameters[0]); // The query argument.
+                $parameters = array_values($parameters);
 
                 $macro = new Macro($classReflection->getName(), $passable->getMethodName(), $reflectionFunction);
 

--- a/src/Methods/Pipes/BuilderLocalMacros.php
+++ b/src/Methods/Pipes/BuilderLocalMacros.php
@@ -16,14 +16,13 @@ namespace NunoMaduro\Larastan\Methods\Pipes;
 use Closure;
 use ReflectionClass;
 use function in_array;
-use PhpParser\Node\Name;
-use function array_values;
+use ReflectionFunction;
+use PHPStan\Type\ObjectType;
 use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\Macro;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
@@ -55,22 +54,20 @@ final class BuilderLocalMacros implements PipeContract
             $refProperty->setAccessible(true);
             $localMacros = $refProperty->getValue($builder);
 
-            $broker = $passable->getBroker();
-
             if (array_key_exists($passable->getMethodName(), $localMacros)) {
-                $functionName = new Name($localMacros[$passable->getMethodName()]);
-                if ($broker->hasFunction($functionName, null)) {
-                    $functionReflection = $broker->getFunction($functionName, null);
-                    $functionVariant = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
-                    $parameters = $functionVariant->getParameters();
-                    unset($parameters[0]); // The query argument.
-                    $parameters = array_values($parameters);
+                $reflectionFunction = new ReflectionFunction($localMacros[$passable->getMethodName()]);
+                $parameters = $reflectionFunction->getParameters();
+                unset($parameters[0]); // The query argument.
 
-                    $macro = new Macro($classReflection, $passable->getMethodName(), $parameters, $functionVariant->isVariadic(), $functionVariant->getReturnType(), true);
+                $macro = new Macro($classReflection->getName(), $passable->getMethodName(), $reflectionFunction);
 
-                    $passable->setMethodReflection($macro);
-                    $found = true;
-                }
+                $macro->setParameters($parameters);
+                $macro->setIsStatic(true);
+
+                $passable->setMethodReflection($passable->getMethodReflectionFactory()->create($classReflection, null,
+                    $macro, $parameters, new ObjectType($classReflection->getName()), null, null, false, false,
+                    false));
+                $found = true;
             }
         }
 

--- a/src/Methods/Pipes/Macros.php
+++ b/src/Methods/Pipes/Macros.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use PhpParser\Node\Name;
 use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\Macro;
 use Illuminate\Support\Traits\Macroable;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
 
@@ -65,22 +63,27 @@ final class Macros implements PipeContract
             $className = (string) $className;
 
             if ($found = $className::hasMacro($passable->getMethodName())) {
-                $functionName = new Name($refProperty->getValue()[$passable->getMethodName()]);
-                $broker = $passable->getBroker();
-                if ($broker->hasFunction($functionName, null)) {
-                    $functionReflection = $broker->getFunction($functionName, null);
-                    $functionVariant = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
-                    $passable->setMethodReflection(
-                        new Macro(
+                $reflectionFunction = new \ReflectionFunction($refProperty->getValue()[$passable->getMethodName()]);
+                /** @var \PHPStan\Type\Type[] $parameters */
+                $parameters = $reflectionFunction->getParameters();
+
+                $passable->setMethodReflection(
+                    $passable->getMethodReflectionFactory()
+                        ->create(
                             $classReflection,
-                            $passable->getMethodName(),
-                            $functionVariant->getParameters(),
-                            $functionVariant->isVariadic(),
-                            $functionVariant->getReturnType(),
+                            null,
+                            new Macro(
+                                $classReflection->getName(), $passable->getMethodName(), $reflectionFunction
+                            ),
+                            $parameters,
+                            null,
+                            null,
+                            null,
+                            false,
+                            false,
                             false
                         )
-                    );
-                }
+                );
             }
         }
 


### PR DESCRIPTION
I probably got too ambitious with the last fix.

The problem is that I didn' realize that `localMacros` don't contain strings but anonymous functions. So I reverted this change and did the minimal work required to fix the actual issue.

PHPStan currently does not have a better way of converting anonymous function (as in the actual closure in memory, not just a reflection) to `ParametersAcceptor`.

This should probably have some kind of test but since I'm not familiar with Laravel, I don't know how the code that's touched by these changes looks like in a Laravel app.

I hope that following versions of PHPStan will be less turbulent for you 👍