### PR TITLE
Handle Carbon macros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.8",
-        "phpunit/phpunit": "^8.2"
+        "phpunit/phpunit": "^7.3 || ^8.2"
     },
     "suggest": {
         "orchestra/testbench": "^3.6"

--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -120,7 +120,7 @@ final class CodeAnalyseCommand extends Command
 
         $paths = array_map(
             function ($path) {
-                return escapeshellarg(starts_with($path, DIRECTORY_SEPARATOR) || empty($path) ? $path : $this->laravel->basePath(
+                return escapeshellarg(starts_with($path, DIRECTORY_SEPARATOR) || preg_match('/^[A-Z]:\\\\/', $path) || empty($path) ? $path : $this->laravel->basePath(
                     trim($path)
                 ));
             },

--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -74,7 +74,9 @@ final class Macro implements BuiltinMethodReflection
 
         if ($this->reflectionFunction->isClosure()) {
             try {
-                Closure::bind($this->reflectionFunction->getClosure(), new stdClass);
+                /** @var Closure $closure */
+                $closure = $this->reflectionFunction->getClosure();
+                Closure::bind($closure, new stdClass);
                 // The closure can be bound so it was not explicitly marked as static
             } catch (ErrorException $e) {
                 // The closure was explicitly marked as static

--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Methods;
 
+use Closure;
+use stdClass;
 use ReflectionClass;
+use ReflectionFunction;
 use PHPStan\Reflection\Php\BuiltinMethodReflection;
 
 final class Macro implements BuiltinMethodReflection
@@ -35,7 +38,7 @@ final class Macro implements BuiltinMethodReflection
     /**
      * The reflection function.
      *
-     * @var \ReflectionFunction
+     * @var ReflectionFunction
      */
     private $reflectionFunction;
 
@@ -58,15 +61,15 @@ final class Macro implements BuiltinMethodReflection
      *
      * @param string $className
      * @param string $methodName
-     * @param \ReflectionFunction $reflectionFunction
+     * @param ReflectionFunction $reflectionFunction
      */
-    public function __construct(string $className, string $methodName, \ReflectionFunction $reflectionFunction)
+    public function __construct(string $className, string $methodName, ReflectionFunction $reflectionFunction)
     {
         $this->className = $className;
         $this->methodName = $methodName;
         $this->reflectionFunction = $reflectionFunction;
         $this->parameters = $this->reflectionFunction->getParameters();
-        $this->isStatic = false;
+        $this->isStatic = $this->reflectionFunction->isClosure() && !@Closure::bind($this->reflectionFunction->getClosure(), new stdClass);
     }
 
     /**

--- a/tests/Features/Methods/CarbonExtension.php
+++ b/tests/Features/Methods/CarbonExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Methods;
+
+use Carbon\Carbon;
+
+class CarbonExtension
+{
+    public function testCarbonMacro(): string
+    {
+        Carbon::macro('foo', function (): string {
+            return 'foo';
+        });
+
+        return Carbon::foo().Carbon::now()->foo();
+    }
+}

--- a/tests/Features/Methods/CarbonExtension.php
+++ b/tests/Features/Methods/CarbonExtension.php
@@ -12,8 +12,13 @@ Carbon::macro('foo', static function (): string {
 
 class CarbonExtension
 {
-    public function testCarbonMacro(): string
+    public function testCarbonMacroCalledStatically(): string
     {
-        return Carbon::foo().Carbon::now()->foo();
+        return Carbon::foo();
+    }
+
+    public function testCarbonMacroCalledDynamically(): string
+    {
+        return Carbon::now()->foo();
     }
 }

--- a/tests/Features/Methods/CarbonExtension.php
+++ b/tests/Features/Methods/CarbonExtension.php
@@ -6,14 +6,14 @@ namespace Tests\Features\Methods;
 
 use Carbon\Carbon;
 
+Carbon::macro('foo', static function (): string {
+    return 'foo';
+});
+
 class CarbonExtension
 {
     public function testCarbonMacro(): string
     {
-        Carbon::macro('foo', function (): string {
-            return 'foo';
-        });
-
         return Carbon::foo().Carbon::now()->foo();
     }
 }

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -35,14 +35,14 @@ class FeaturesTest extends TestCase
     public function getFeatures(): array
     {
         $calls = [];
-        $baseDir = __DIR__.'/Features/';
+        $baseDir = __DIR__.DIRECTORY_SEPARATOR.'Features'.DIRECTORY_SEPARATOR;
 
         /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ((new Finder())->in($baseDir)->files() as $file) {
             if ($file->getExtension() !== 'php') {
                 continue;
             }
-            $fullPath = (string) $file;
+            $fullPath = realpath((string) $file);
             $calls[str_replace($baseDir, '', $fullPath)] = [$fullPath];
         }
 
@@ -64,7 +64,7 @@ class FeaturesTest extends TestCase
         $result = $this->kernel->call('code:analyse', [
             '--level' => 'max',
             '--paths' => $file,
-            '--bin-path' => __DIR__.'/../vendor/bin',
+            '--bin-path' => __DIR__.'/../vendor/phpstan/phpstan/bin',
             '--autoload-file' => __DIR__.'/../vendor/autoload.php',
             '--error-format' => 'raw',
             '--no-tty' => true,


### PR DESCRIPTION
Hi,

I would like to propose a compatibility support for Carbon macros, it uses the same public API as Laravel macros but is different internally.

I tested the code above in Laravel apps and it works fine.

But I couldn't get a correct unit tests I mimicked other ones but if I revert my change in source, the `CarbonExtension` test still pass while I should get "undefined method" PHPStan errors.

If you're OK to include this feature, could you help me to write this unit test?