### PR TITLE
Require appropriate orchestra/testbench version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1.3",
         "symfony/process": "^4.2",
         "phpstan/phpstan": "^0.11.15",
-        "orchestra/testbench": "^3.6",
+        "orchestra/testbench": "3.6.*|3.7.*|3.8.*|3.9.*",
         "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0",


### PR DESCRIPTION
In #295 the proposed solution is remove `orchestra/testbench` from as required dependency and add it as a suggestion. I think this is a better solution because in most cases users won't notice anything of the testbench version stuff. Composer will figure out the right version. 

People will get wonky Composer errors when non compatible PHPUnit versions are required. But that's also the case when the described solution is in place.