### PR TITLE
fix: removes usage of global helpers

### DIFF
--- a/src/Console/CodeAnalyseCommand.php
+++ b/src/Console/CodeAnalyseCommand.php
@@ -15,6 +15,7 @@ namespace NunoMaduro\Larastan\Console;
 
 use function implode;
 use function is_array;
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Process\Process;
 use Illuminate\Console\Application as Artisan;
@@ -120,7 +121,7 @@ final class CodeAnalyseCommand extends Command
 
         $paths = array_map(
             function ($path) {
-                return escapeshellarg(starts_with($path, DIRECTORY_SEPARATOR) || empty($path) ? $path : $this->laravel->basePath(
+                return escapeshellarg(Str::startsWith($path, DIRECTORY_SEPARATOR) || empty($path) ? $path : $this->laravel->basePath(
                     trim($path)
                 ));
             },

--- a/src/Methods/Pipes/BuilderDynamicWheres.php
+++ b/src/Methods/Pipes/BuilderDynamicWheres.php
@@ -15,6 +15,7 @@ namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
 use Mockery;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\ParametersAcceptorSelector;
@@ -37,7 +38,7 @@ final class BuilderDynamicWheres implements PipeContract
                 Builder::class
             );
 
-        if ($isInstanceOfBuilder && starts_with($passable->getMethodName(), 'where')) {
+        if ($isInstanceOfBuilder && Str::startsWith($passable->getMethodName(), 'where')) {
             $methodReflection = $classReflection->getNativeMethod('dynamicWhere');
 
             /** @var \PHPStan\Reflection\FunctionVariantWithPhpDocs $originalDynamicWhereVariant */


### PR DESCRIPTION
This pull request removes the usage of global string helpers of Laravel, as they will be removed in Laravel `6.0`.