### PR TITLE
Fix for auth guard method calls on auth helper and facade

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -39,6 +39,11 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\AuthManagerExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\RequestExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use function in_array;
-use NunoMaduro\Larastan\Concerns;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword;
-use Illuminate\Contracts\Auth\Access\Authorizable;
+use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
+use PHPStan\Reflection\Native\NativeMethodReflection;
+use function in_array;
 
 /**
  * @internal
@@ -56,6 +57,10 @@ final class Auths implements PipeContract
             if ($userModel) {
                 $found = $passable->sendToPipeline($userModel);
             }
+        } else if ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
+            $found = $passable->searchOn(
+                get_class($this->resolve(\Illuminate\Contracts\Auth\Guard::class))
+            );
         }
 
         if (! $found) {

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -14,14 +14,13 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use Illuminate\Contracts\Auth\Access\Authorizable;
+use function in_array;
+use NunoMaduro\Larastan\Concerns;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword;
-use NunoMaduro\Larastan\Concerns;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
-use PHPStan\Reflection\Native\NativeMethodReflection;
-use function in_array;
 
 /**
  * @internal
@@ -57,7 +56,7 @@ final class Auths implements PipeContract
             if ($userModel) {
                 $found = $passable->sendToPipeline($userModel);
             }
-        } else if ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
+        } elseif ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
             $found = $passable->searchOn(
                 get_class($this->resolve(\Illuminate\Contracts\Auth\Guard::class))
             );

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -2,17 +2,16 @@
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
+use PHPStan\Type\Type;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Contracts\Auth\Guard;
+use PHPStan\Type\TypeCombinator;
 use NunoMaduro\Larastan\Concerns;
 use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 
 final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use PHPStan\Type\Type;

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Guard;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
+{
+    use Concerns\HasContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return AuthManager::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'user';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $config = $this->getContainer()
+            ->get('config');
+
+        if ($userModel = $config->get('auth.providers.users.model')) {
+            return TypeCombinator::addNull(new ObjectType($userModel));
+        }
+
+        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+    }
+}

--- a/src/ReturnTypes/Helpers/AuthExtension.php
+++ b/src/ReturnTypes/Helpers/AuthExtension.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
 use PhpParser\Node\Expr\FuncCall;
+use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 
@@ -25,6 +26,8 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
  */
 final class AuthExtension implements DynamicFunctionReturnTypeExtension
 {
+    use Concerns\HasContainer;
+
     /**
      * {@inheritdoc}
      */
@@ -42,7 +45,7 @@ final class AuthExtension implements DynamicFunctionReturnTypeExtension
         Scope $scope
     ): Type {
         if (! isset($functionCall->args[0]->value) || (isset($functionCall->args[0]->value) && $functionCall->args[0]->value === null)) {
-            return new ObjectType(\Illuminate\Contracts\Auth\Factory::class);
+            return new ObjectType(get_class($this->resolve(\Illuminate\Contracts\Auth\Factory::class)));
         }
 
         return new ObjectType(\Illuminate\Contracts\Auth\Guard::class);

--- a/src/ReturnTypes/Helpers/AuthExtension.php
+++ b/src/ReturnTypes/Helpers/AuthExtension.php
@@ -16,8 +16,8 @@ namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
 use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
-use PhpParser\Node\Expr\FuncCall;
 use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 

--- a/tests/Features/ReturnTypes/AuthExtension.php
+++ b/tests/Features/ReturnTypes/AuthExtension.php
@@ -13,4 +13,14 @@ class AuthExtension
     {
         return Auth::user();
     }
+
+    public function testCheck(): bool
+    {
+        return Auth::check();
+    }
+
+    public function testId(): ?int
+    {
+        return Auth::id();
+    }
 }

--- a/tests/Features/ReturnTypes/Helpers/AuthExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AuthExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes\Helpers;
 
+use App\User;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\Factory;
 
@@ -17,5 +18,20 @@ class AuthExtension
     public function testAuthGuard(): Guard
     {
         return auth('web');
+    }
+
+    public function testUser(): ?User
+    {
+        return auth()->user();
+    }
+
+    public function testCheck(): bool
+    {
+        return auth()->check();
+    }
+
+    public function testId(): ?int
+    {
+        return auth()->id();
     }
 }


### PR DESCRIPTION
Fixes #309 

Also adds tests for `user`, `check` and `id` method calls on both auth helper and facade.

I'm not %100 sure if this does not break anything else (auth related) but according to my tests, it looks fine.