### PR TITLE
Extend service provider search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,17 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/process": "^4.2",
-        "phpstan/phpstan": "^0.11.15",
-        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
+        "composer/composer": "^1.0",
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0",
-        "illuminate/database": "5.6.*|5.7.*|5.8.*|^6.0",
-        "illuminate/pipeline": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/container": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/contracts": "5.6.*|5.7.*|5.8.*|^6.0",
-        "mockery/mockery": "^1.0|0.9.*"
+        "illuminate/database": "5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/pipeline": "5.6.*|5.7.*|5.8.*|^6.0",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
+        "mockery/mockery": "^1.0|0.9.*",
+        "phpstan/phpstan": "^0.11.15",
+        "symfony/process": "^4.2"
     },
     "require-dev": {
         "orchestra/testbench": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
         "mockery/mockery": "^1.0|0.9.*",
         "phpstan/phpstan": "^0.11.15",
-        "symfony/process": "^4.2"
+        "symfony/process": "^4.2",
+        "ext-json": "*"
     },
     "require-dev": {
         "orchestra/testbench": "^3.8",

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -29,6 +29,7 @@ final class ApplicationResolver
      * Creates an application and registers service providers found.
      *
      * @return \Illuminate\Contracts\Foundation\Application
+     * @throws \ReflectionException
      */
     public static function resolve(): Application
     {
@@ -75,6 +76,7 @@ final class ApplicationResolver
      * @param string $namespace
      *
      * @return array
+     * @throws \ReflectionException
      */
     private static function getProjectClasses(string $namespace): array
     {

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -90,10 +90,10 @@ final class ApplicationResolver
     }
 
     /**
-     * @return string
+     * @return string[]
      */
-    private static function getProjectSearchDirs(): string
+    private static function getProjectSearchDirs(): array
     {
-        return getcwd() . DIRECTORY_SEPARATOR . 'src';
+        return [getcwd() . DIRECTORY_SEPARATOR . 'src'];
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan;
 
+use Composer\Autoload\ClassLoader;
 use function in_array;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Contracts\Foundation\Application;
@@ -98,6 +99,9 @@ final class ApplicationResolver
      */
     private static function getProjectSearchDirs(string $namespace): array
     {
-        return [getcwd() . DIRECTORY_SEPARATOR . 'src'];
+        $file = getcwd() . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'composer'
+                . DIRECTORY_SEPARATOR . 'autoload_psr4.php';
+        $raw = require_once $file;
+        return $raw[$namespace];
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan;
 
-use Composer\Autoload\ClassLoader;
 use function in_array;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Contracts\Foundation\Application;
@@ -99,9 +98,10 @@ final class ApplicationResolver
      */
     private static function getProjectSearchDirs(string $namespace): array
     {
-        $file = getcwd() . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'composer'
-                . DIRECTORY_SEPARATOR . 'autoload_psr4.php';
+        $file = getcwd().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer'
+                .DIRECTORY_SEPARATOR.'autoload_psr4.php';
         $raw = require_once $file;
+
         return $raw[$namespace];
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -39,7 +39,7 @@ final class ApplicationResolver
         if (file_exists($composerFile)) {
             $namespace = (string) key(json_decode((string) file_get_contents($composerFile), true)['autoload']['psr-4']);
 
-            $serviceProviders = array_values(array_filter(self::getProjectClasses(), function (string $class) use (
+            $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace), function (string $class) use (
                 $namespace
             ) {
                 return substr($class, 0, strlen($namespace)) === $namespace && self::isServiceProvider($class);
@@ -72,11 +72,13 @@ final class ApplicationResolver
     }
 
     /**
+     * @param string $namespace
+     *
      * @return array
      */
-    private static function getProjectClasses(): array
+    private static function getProjectClasses(string $namespace): array
     {
-        $files = Finder::create()->files()->name('*.php')->in(self::getProjectSearchDirs());
+        $files = Finder::create()->files()->name('*.php')->in(self::getProjectSearchDirs($namespace));
 
         foreach ($files->files() as $file) {
             try {
@@ -90,9 +92,11 @@ final class ApplicationResolver
     }
 
     /**
+     * @param string $namespace
+     *
      * @return string[]
      */
-    private static function getProjectSearchDirs(): array
+    private static function getProjectSearchDirs(string $namespace): array
     {
         return [getcwd() . DIRECTORY_SEPARATOR . 'src'];
     }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -76,7 +76,7 @@ final class ApplicationResolver
      */
     private static function getProjectClasses(): array
     {
-        $files = Finder::create()->files()->name('*.php')->in(getcwd().DIRECTORY_SEPARATOR.'src');
+        $files = Finder::create()->files()->name('*.php')->in(self::getProjectSearchDirs());
 
         foreach ($files->files() as $file) {
             try {
@@ -87,5 +87,13 @@ final class ApplicationResolver
         }
 
         return get_declared_classes();
+    }
+
+    /**
+     * @return string
+     */
+    private static function getProjectSearchDirs(): string
+    {
+        return getcwd() . DIRECTORY_SEPARATOR . 'src';
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -95,11 +95,16 @@ final class ApplicationResolver
      * @param string $namespace
      *
      * @return string[]
+     * @throws \ReflectionException
      */
     private static function getProjectSearchDirs(string $namespace): array
     {
-        $file = getcwd().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer'
-                .DIRECTORY_SEPARATOR.'autoload_psr4.php';
+        $reflection = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
+        /** @var string $filename */
+        $filename = $reflection->getFileName();
+        $vendorDir = dirname(dirname($filename));
+
+        $file = $vendorDir.DIRECTORY_SEPARATOR.'composer'.DIRECTORY_SEPARATOR.'autoload_psr4.php';
         $raw = require_once $file;
 
         return $raw[$namespace];

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -104,10 +104,10 @@ final class ApplicationResolver
         $reflection = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
         /** @var string $filename */
         $filename = $reflection->getFileName();
-        $vendorDir = dirname(dirname($filename));
+        $composerDir = dirname($filename);
 
-        $file = $vendorDir.DIRECTORY_SEPARATOR.'composer'.DIRECTORY_SEPARATOR.'autoload_psr4.php';
-        $raw = require_once $file;
+        $file = $composerDir.DIRECTORY_SEPARATOR.'autoload_psr4.php';
+        $raw = include $file;
 
         return $raw[$namespace];
     }

--- a/tests/ApplicationResolverTest.php
+++ b/tests/ApplicationResolverTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests;
 
+use Orchestra\Testbench\TestCase;
 use NunoMaduro\Larastan\ApplicationResolver;
 use NunoMaduro\Larastan\LarastanServiceProvider;
-use Orchestra\Testbench\TestCase;
 
 class ApplicationResolverTest extends TestCase
 {
@@ -14,7 +14,7 @@ class ApplicationResolverTest extends TestCase
         $resolve = $result->getProviders(LarastanServiceProvider::class);
         $this->assertTrue(
             is_array($resolve) && 0 < count($resolve),
-            "LarastanServiceProvider not loaded by ApplicationResolver"
+            'LarastanServiceProvider not loaded by ApplicationResolver'
         );
     }
 }

--- a/tests/ApplicationResolverTest.php
+++ b/tests/ApplicationResolverTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use NunoMaduro\Larastan\ApplicationResolver;
+use NunoMaduro\Larastan\LarastanServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class ApplicationResolverTest extends TestCase
+{
+    public function testDefaultResolve()
+    {
+        $result = ApplicationResolver::resolve();
+        $resolve = $result->getProviders(LarastanServiceProvider::class);
+        $this->assertTrue(
+            is_array($resolve) && 0 < count($resolve),
+            "LarastanServiceProvider not loaded by ApplicationResolver"
+        );
+    }
+}


### PR DESCRIPTION
My attempt to implement a suggestion implied in https://github.com/nunomaduro/larastan/issues/273#issuecomment-503291317 , namely getting a list of directories to check for service providers, directly from Composer data.

@szepeviktor , I wasn't sure exactly how to test the load-from-extra-search-directories without polluting production use with test code (such as a dummy service provider).  In lieu of a way to do that cleanly, I added a test that verified my changes didn't break the status quo on Larastan itself.