### PR TITLE
Model scope call after relation returns Builder

### DIFF
--- a/src/Methods/Kernel.php
+++ b/src/Methods/Kernel.php
@@ -70,6 +70,7 @@ final class Kernel
                     Pipes\BuilderLocalMacros::class,
                     Pipes\BuilderDynamicWheres::class,
                     Pipes\RedirectResponseWiths::class,
+                    Pipes\ModelScopeAfterRelations::class,
                 ]
             )
             ->then(

--- a/src/Methods/Pipes/ModelScopeAfterRelations.php
+++ b/src/Methods/Pipes/ModelScopeAfterRelations.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Methods\Pipes;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
+use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
+use NunoMaduro\Larastan\Reflection\ModelScopeMethodReflection;
+
+final class ModelScopeAfterRelations implements PipeContract
+{
+    /**
+     * @inheritDoc
+     */
+    public function handle(PassableContract $passable, Closure $next): void
+    {
+        $classReflection = $passable->getClassReflection();
+        $builderClass = $passable->getBroker()->getClass(Builder::class);
+        $isRelationSubclass = $classReflection->isSubclassOf(Relation::class);
+
+        $found = false;
+
+        if ($isRelationSubclass &&
+            ! $classReflection->isAbstract() &&
+            ! $builderClass->hasNativeMethod($passable->getMethodName())
+        ) {
+            $passable->setMethodReflection(
+                new ModelScopeMethodReflection(
+                    $passable->getMethodName(),
+                    $passable->getBroker()->getClass(Model::class)
+                )
+            );
+
+            $found = true;
+        }
+
+        if (! $found) {
+            $next($passable);
+        }
+    }
+}

--- a/src/Reflection/ModelScopeMethodReflection.php
+++ b/src/Reflection/ModelScopeMethodReflection.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Reflection;
+
+use Illuminate\Database\Eloquent\Builder;
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+
+final class ModelScopeMethodReflection implements MethodReflection
+{
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var ClassReflection
+     */
+    private $classReflection;
+
+    public function __construct(string $methodName, ClassReflection $classReflection)
+    {
+        $this->methodName = $methodName;
+        $this->classReflection = $classReflection;
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->classReflection;
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVariants(): array
+    {
+        return [
+            new FunctionVariant(
+                [],
+                false,
+                new ObjectType(Builder::class)
+            ),
+        ];
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
@@ -26,4 +27,9 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    public function scopeActive(Builder $query) : Builder
+    {
+        return $query->where('active', 1);
+    }
 }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Models;
+
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Scopes extends Model
+{
+    public function scopeAfterRelation() : Builder
+    {
+        return $this->hasOne(User::class)->active();
+    }
+}


### PR DESCRIPTION
Currently code like this `$this->hasOne(User::class)->active();` results in error saying `Call to an undefined method Illuminate\Database\Eloquent\Relations\HasOne::active()`. This PR fixes this.

`Relation` class in Laravel forwards unknown calls to `Builder`. And `Builder` can call scope methods on the model. So it is safe to call model scopes from the relation, like above.

There was one issue that I couldn't solve. As far as my understanding goes for the Reflection and PHPStan, there is no way to know the calling context from the reflection. 

So in this implementation, I'm treating every unknown call as a scope method call, if the method doesn't also exist in `Builder`

I'm open to suggestions if anyone knows how to get the actual scope method reflection from inside the `ModelScopeAfterRelations` pipe.
