### PR TITLE
Fixes relation create return type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -29,6 +29,11 @@ services:
             - phpstan.broker.propertiesClassReflectionExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\RelationCreateExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\ModelExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/RelationCreateExtension.php
+++ b/src/ReturnTypes/RelationCreateExtension.php
@@ -13,23 +13,23 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
-use PHPStan\Analyser\Scope;
+use PHPStan\Type\Type;
 use PHPStan\Broker\Broker;
-use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
-use PHPStan\Reflection\BrokerAwareExtension;
-use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
-use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\IntersectionType;
+use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\Type;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Expr\Variable;
+use Illuminate\Support\Collection;
+use PHPStan\Type\IntersectionType;
+use PhpParser\Node\Expr\MethodCall;
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 
 class RelationCreateExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
@@ -105,7 +105,7 @@ class RelationCreateExtension implements DynamicMethodReturnTypeExtension, Broke
     private function determineCallingClass(Scope $scope, string $context) : ClassReflection
     {
         /** @var string $className */
-        $className = current(array_filter($scope->debug(), function (string $key) use($context) {
+        $className = current(array_filter($scope->debug(), function (string $key) use ($context) {
             return mb_strpos($key, $context) !== false;
         }, ARRAY_FILTER_USE_KEY));
 

--- a/src/ReturnTypes/RelationCreateExtension.php
+++ b/src/ReturnTypes/RelationCreateExtension.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class RelationCreateExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    /**
+     * @var Broker
+     */
+    private $broker;
+
+    /**
+     * @var AnnotationsPropertiesClassReflectionExtension
+     */
+    private $annotationsPropertiesClassReflectionExtension;
+
+    public function __construct(AnnotationsPropertiesClassReflectionExtension $annotationsPropertiesClassReflectionExtension)
+    {
+        $this->annotationsPropertiesClassReflectionExtension = $annotationsPropertiesClassReflectionExtension;
+    }
+
+    public function getClass(): string
+    {
+        return Relation::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'create';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var MethodCall $methodCallNode */
+        $methodCallNode = $methodCall->var;
+
+        /** @var Variable $methodCallVariable */
+        $methodCallVariable = $methodCallNode->var;
+
+        /** @var Identifier $methodCallIdentifier */
+        $methodCallIdentifier = $methodCallNode->name;
+
+        /** @var string $context */
+        $context = $methodCallVariable->name;
+
+        /** @var string $relationName */
+        $relationName = $methodCallIdentifier->name;
+
+        $callingClass = $this->determineCallingClass($scope, $context);
+
+        $returnType = new MixedType(true);
+
+        if ($this->annotationsPropertiesClassReflectionExtension->hasProperty($callingClass, $relationName)) {
+            $returnType = $this->annotationsPropertiesClassReflectionExtension->getProperty($callingClass, $relationName)->getType();
+
+            if ($returnType instanceof IntersectionType) {
+                return $this->determineReturnTypeFromIntersection($returnType);
+            }
+
+            if ($returnType instanceof ObjectType && $this->isModel($returnType->getClassName())) {
+                return $returnType;
+            }
+        }
+
+        return $returnType;
+    }
+
+    public function setBroker(Broker $broker): void
+    {
+        $this->broker = $broker;
+    }
+
+    private function determineCallingClass(Scope $scope, string $context) : ClassReflection
+    {
+        /** @var string $className */
+        $className = current(array_filter($scope->debug(), function (string $key) use($context) {
+            return mb_strpos($key, $context) !== false;
+        }, ARRAY_FILTER_USE_KEY));
+
+        if (mb_strpos($className, '$this') !== false) {
+            $className = $this->stripThisFromClassName($className);
+        }
+
+        return $this->broker->getClass($className);
+    }
+
+    private function stripThisFromClassName(string $className) : string
+    {
+        preg_match('/\$this\((.*?)\)/', $className, $out);
+
+        return $out[1];
+    }
+
+    private function determineReturnTypeFromIntersection(IntersectionType $returnType) : Type
+    {
+        [$collectionClass, $model] = $returnType->getReferencedClasses();
+
+        if ($collectionClass === Collection::class || $this->broker->getClass($collectionClass)->isSubclassOf(Collection::class)) {
+            if (! $this->isModel($model)) {
+                return new MixedType(true);
+            }
+
+            return new ObjectType($model);
+        }
+
+        return new MixedType(true);
+    }
+
+    private function isModel(string $className) : bool
+    {
+        return $this->broker->getClass($className)->isSubclassOf(Model::class);
+    }
+}

--- a/tests/Application/app/Account.php
+++ b/tests/Application/app/Account.php
@@ -6,5 +6,4 @@ use Illuminate\Database\Eloquent\Model;
 
 class Account extends Model
 {
-
 }

--- a/tests/Application/app/Account.php
+++ b/tests/Application/app/Account.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Account extends Model
+{
+
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -2,10 +2,15 @@
 
 namespace App;
 
+use Illuminate\Support\Collection;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
+/**
+ * @property Collection|Account[] $accounts
+ */
 class User extends Authenticatable
 {
     use Notifiable;
@@ -31,5 +36,10 @@ class User extends Authenticatable
     public function scopeActive(Builder $query) : Builder
     {
         return $query->where('active', 1);
+    }
+
+    public function accounts() : HasMany
+    {
+        return $this->hasMany(Account::class);
     }
 }

--- a/tests/Features/ReturnTypes/ModelExtension.php
+++ b/tests/Features/ReturnTypes/ModelExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\Account;
+use App\User;
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+
+class ModelExtension
+{
+    public function testCreateWithRelation() : Account
+    {
+        /** @var User $user */
+        $user = User::first();
+
+        return $user->accounts()->create();
+    }
+}
+
+/**
+ * @property-read User $relation
+ */
+class RelationCreateExample extends Model
+{
+    public function relation() : HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function addRelation() : User
+    {
+        return $this->relation()->create([]);
+    }
+}
+
+class ModelWithoutPropertyAnnotation extends Model
+{
+    public function relation() : HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    public function addRelation() : User
+    {
+        return $this->relation()->create([]);
+    }
+}

--- a/tests/Features/ReturnTypes/ModelExtension.php
+++ b/tests/Features/ReturnTypes/ModelExtension.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes;
 
-use App\Account;
 use App\User;
-use Exception;
+use App\Account;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Collection;
 
 class ModelExtension
 {


### PR DESCRIPTION
This one fixes the return type of `create` method on relations. For example `$user->accounts()->create()` should return newly created `Account` model.

The code makes a couple of assumptions. First of all, the model needs to define the property in the docblock of the class. [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) can write PHP docs for the models automatically. If a phpdoc does not exist for the given property, MixedType return type is used to avoid errors.

Secondly, I followed the convention from [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) so typehint should be either `Collection|ModelName[]` or `ModelName`. If it can't match it, MixedType is returned again.