### PR TITLE
Fix return type of calling scope on relation

### DIFF
--- a/src/Methods/Pipes/ModelScopeAfterRelations.php
+++ b/src/Methods/Pipes/ModelScopeAfterRelations.php
@@ -41,7 +41,8 @@ final class ModelScopeAfterRelations implements PipeContract
             $passable->setMethodReflection(
                 new ModelScopeMethodReflection(
                     $passable->getMethodName(),
-                    $passable->getBroker()->getClass(Model::class)
+                    $passable->getBroker()->getClass(Model::class),
+                    $classReflection
                 )
             );
 

--- a/src/Reflection/ModelScopeMethodReflection.php
+++ b/src/Reflection/ModelScopeMethodReflection.php
@@ -17,7 +17,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
-use Illuminate\Database\Eloquent\Builder;
 use PHPStan\Reflection\ClassMemberReflection;
 
 final class ModelScopeMethodReflection implements MethodReflection

--- a/src/Reflection/ModelScopeMethodReflection.php
+++ b/src/Reflection/ModelScopeMethodReflection.php
@@ -32,10 +32,16 @@ final class ModelScopeMethodReflection implements MethodReflection
      */
     private $classReflection;
 
-    public function __construct(string $methodName, ClassReflection $classReflection)
+    /**
+     * @var ClassReflection
+     */
+    private $relation;
+
+    public function __construct(string $methodName, ClassReflection $classReflection, ClassReflection $relation)
     {
         $this->methodName = $methodName;
         $this->classReflection = $classReflection;
+        $this->relation = $relation;
     }
 
     public function getDeclaringClass(): ClassReflection
@@ -77,7 +83,7 @@ final class ModelScopeMethodReflection implements MethodReflection
             new FunctionVariant(
                 [],
                 false,
-                new ObjectType(Builder::class)
+                new ObjectType($this->relation->getName())
             ),
         ];
     }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -6,12 +6,18 @@ namespace Tests\Features\Models;
 
 use App\User;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Scopes extends Model
 {
-    public function scopeAfterRelation() : Builder
+    public function testScopeAfterRelation() : HasOne
     {
         return $this->hasOne(User::class)->active();
+    }
+
+    public function testScopeAfterRelationWithHasMany() : HasMany
+    {
+        return $this->hasMany(User::class)->active();
     }
 }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -6,8 +6,8 @@ namespace Tests\Features\Models;
 
 use App\User;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Scopes extends Model
 {


### PR DESCRIPTION
I introduced a bug with my previous PR.

The return type of relation should always be the original relation. No matter if a scope is called or not.

This PR changes the return type to the original relation model.