### PR TITLE
Handle magic calls on model and query builder correctly

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -19,11 +19,17 @@ parameters:
 
 services:
     -
-        class: NunoMaduro\Larastan\Methods\Extension
+        class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+
     -
-        class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
+        class: NunoMaduro\Larastan\Methods\EloquentBuilderForwardsCallsExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Methods\Extension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
 

--- a/extension.neon
+++ b/extension.neon
@@ -49,6 +49,11 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\ModelFindExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\AuthExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/extension.neon
+++ b/extension.neon
@@ -64,6 +64,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\EloquentBuilderExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\AuthExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/extension.neon
+++ b/extension.neon
@@ -22,6 +22,10 @@ services:
         class: NunoMaduro\Larastan\Methods\Extension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\Properties\Extension

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -22,6 +22,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -64,7 +65,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             return true;
         }
 
-        return $this->getBuilderReflection()->hasNativeMethod($methodName);
+        return true;
     }
 
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
@@ -78,6 +79,11 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
         if (in_array($methodName, $this->passthru)) {
             return $this->getBroker()->getClass(Builder::class)->getNativeMethod($methodName);
+        }
+
+        // Could be a model scope
+        if (! $this->getBuilderReflection()->hasNativeMethod($methodName)) {
+            return new DummyMethodReflection($methodName);
         }
 
         $methodReflection = $this->getBuilderReflection()->getNativeMethod($methodName);

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -13,21 +13,19 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Methods;
 
+use PHPStan\Type\StringType;
+use PHPStan\Type\CallableType;
 use NunoMaduro\Larastan\Concerns;
 use Illuminate\Database\Query\Builder;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\Native\NativeParameterReflection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
-use PHPStan\Reflection\Native\NativeParameterReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\PassedByReference;
-use PHPStan\Reflection\Php\PhpParameterReflection;
-use PHPStan\Type\CallableType;
-use PHPStan\Type\StringType;
-use ReflectionParameter;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -21,7 +21,13 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Reflection\Php\PhpParameterReflection;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\StringType;
+use ReflectionParameter;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {
@@ -66,7 +72,10 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
         if ($methodName === 'macro') {
-            return new EloquentBuilderMethodReflection($methodName, $classReflection, []);
+            return new EloquentBuilderMethodReflection($methodName, $classReflection, [
+                new NativeParameterReflection('name', false, new StringType(), PassedByReference::createNo(), false),
+                new NativeParameterReflection('macro', false, new CallableType(), PassedByReference::createNo(), false),
+            ]);
         }
 
         if (in_array($methodName, $this->passthru)) {

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Methods;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Reflection\BuilderMethodReflection;
+use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+
+final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * The methods that should be returned from query builder.
+     *
+     * @var array
+     */
+    protected $passthru = [
+        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
+        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
+    ];
+
+    /**
+     * @return ClassReflection
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     */
+    protected function getBuilderReflection(): ClassReflection
+    {
+        return $this->broker->getClass(Builder::class);
+    }
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (! $classReflection->isSubclassOf(EloquentBuilder::class)) {
+            return false;
+        }
+
+        if ($methodName === 'macro') {
+            return true;
+        }
+
+        if (in_array($methodName, $this->passthru)) {
+            return true;
+        }
+
+        return $this->getBuilderReflection()->hasMethod($methodName);
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        if ($methodName === 'macro') {
+            return new EloquentBuilderMethodReflection($methodName, $classReflection, []);
+        }
+
+        if (in_array($methodName, $this->passthru)) {
+            return $this->getBroker()->getClass(Builder::class)->getNativeMethod($methodName);
+        }
+
+        return new EloquentBuilderMethodReflection($methodName, $classReflection, []);
+    }
+}

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -46,7 +46,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
      * @return ClassReflection
      * @throws \PHPStan\Broker\ClassNotFoundException
      */
-    protected function getBuilderReflection(): ClassReflection
+    private function getBuilderReflection(): ClassReflection
     {
         return $this->broker->getClass(Builder::class);
     }

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -49,7 +49,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if (! $classReflection->isSubclassOf(EloquentBuilder::class)) {
+        if ($classReflection->getName() !== EloquentBuilder::class  || ! $classReflection->isSubclassOf(EloquentBuilder::class)) {
             return false;
         }
 

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -62,45 +62,32 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
 
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
+        $isPublic = true;
+        $returnType = new ObjectType(Builder::class);
+        $methodReflection = $this->getBuilderReflection()->getNativeMethod($methodName);
+
         if (in_array($methodName, ['increment', 'decrement'], true)) {
             $methodReflection = $this->broker->getClass(Model::class)->getNativeMethod($methodName);
 
-            return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
-                ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters(),
-                true, new IntegerType()
-            );
+            $returnType = new IntegerType();
         }
 
         if (in_array($methodName, ['paginate', 'simplePaginate'], true)) {
             $methodReflection = $this->broker->getClass(QueryBuilder::class)->getNativeMethod($methodName);
 
-            $returnClass = $methodName === 'paginate' ? LengthAwarePaginator::class : Paginator::class;
-
-            return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
-                ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters(),
-                true, new ObjectType($returnClass)
-            );
+            $returnType = new ObjectType($methodName === 'paginate' ? LengthAwarePaginator::class : Paginator::class);
         }
 
         if (in_array($methodName, $this->modelRetrievalMethods, true)) {
             $methodReflection = $this->getBuilderReflection()->getNativeMethod($methodName);
 
             $returnType = $this->getReturnTypeOfModelRetrievalMethod($methodName, $classReflection->getName());
-
-            return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
-                ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters(),
-                true, $returnType
-            );
         }
-
-        $methodReflection = $this->getBuilderReflection()->getNativeMethod($methodName);
 
         return new EloquentBuilderMethodReflection(
             $methodName, $classReflection,
-            ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters()
+            ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters(),
+            $isPublic, $returnType
         );
     }
 

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -47,7 +47,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
      * @return ClassReflection
      * @throws \PHPStan\Broker\ClassNotFoundException
      */
-    protected function getBuilderReflection(): ClassReflection
+    private function getBuilderReflection(): ClassReflection
     {
         return $this->broker->getClass(Builder::class);
     }

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -62,6 +62,11 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
             return true;
         }
 
+        if ($classReflection->hasNativeMethod('scope' . ucfirst($methodName))) {
+            // scopes handled later
+            return false;
+        }
+
         return $this->getBuilderReflection()->hasNativeMethod($methodName) || $this->broker->getClass(QueryBuilder::class)->hasNativeMethod($methodName);
     }
 

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -41,7 +41,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
     private $modelRetrievalMethods = ['find', 'findMany', 'findOrFail'];
 
     /** @var string[] */
-    private $modelCreationMethods = ['create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate'];
+    private $modelCreationMethods = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate'];
 
     /**
      * @return ClassReflection
@@ -117,6 +117,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
             'findOrFail' => new IntersectionType([
                 new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className)
             ]),
+            'make' => new ObjectType($className),
             'create' => new ObjectType($className),
             'forceCreate' => new ObjectType($className),
             'findOrNew' => new ObjectType($className),

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -41,7 +41,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
     private $modelRetrievalMethods = ['first', 'find', 'findMany', 'findOrFail'];
 
     /** @var string[] */
-    private $modelCreationMethods = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate'];
+    private $modelCreationMethods = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate', 'fromQuery'];
 
     /**
      * @return ClassReflection
@@ -126,6 +126,9 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
             'findOrNew' => new ObjectType($className),
             'firstOrNew' => new ObjectType($className),
             'updateOrCreate' => new ObjectType($className),
+            'fromQuery' => new IntersectionType([
+                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType(Collection::class)
+            ]),
         ][$methodName];
     }
 }

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -33,7 +33,7 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 
-final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtension, BrokerAwareExtension
+final class ModelForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {
     use Concerns\HasBroker;
 
@@ -62,7 +62,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
             return true;
         }
 
-        if ($classReflection->hasNativeMethod('scope' . ucfirst($methodName))) {
+        if ($classReflection->hasNativeMethod('scope'.ucfirst($methodName))) {
             // scopes handled later
             return false;
         }
@@ -111,14 +111,14 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
     {
         return [
             'first' => new IntersectionType([
-                new ObjectType($className), new NullType()
+                new ObjectType($className), new NullType(),
             ]),
             'find' => new IntersectionType([
-                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className), new NullType()
+                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className), new NullType(),
             ]),
             'findMany' => new ObjectType(Collection::class),
             'findOrFail' => new IntersectionType([
-                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className)
+                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className),
             ]),
             'make' => new ObjectType($className),
             'create' => new ObjectType($className),
@@ -127,7 +127,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
             'firstOrNew' => new ObjectType($className),
             'updateOrCreate' => new ObjectType($className),
             'fromQuery' => new IntersectionType([
-                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType(Collection::class)
+                new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType(Collection::class),
             ]),
         ][$methodName];
     }

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Methods;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+
+final class ModelForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * @return ClassReflection
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     */
+    protected function getBuilderReflection(): ClassReflection
+    {
+        return $this->broker->getClass(Builder::class);
+    }
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if ($classReflection->isSubclassOf(Model::class) && in_array($methodName, ['increment', 'decrement'])) {
+            return true;
+        }
+
+        if (! $classReflection->isSubclassOf(Model::class)) {
+            return false;
+        }
+
+        return $this->getBuilderReflection()->hasMethod($methodName);
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        if ($classReflection->isSubclassOf(Model::class) && in_array($methodName, ['increment', 'decrement'])) {
+            $this->broker->getClass(Model::class)->getNativeMethod($methodName);
+        }
+
+        return $this->getBuilderReflection()->getNativeMethod($methodName);
+    }
+}

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -38,7 +38,7 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
     use Concerns\HasBroker;
 
     /** @var string[] */
-    private $modelRetrievalMethods = ['find', 'findMany', 'findOrFail'];
+    private $modelRetrievalMethods = ['first', 'find', 'findMany', 'findOrFail'];
 
     /** @var string[] */
     private $modelCreationMethods = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate'];
@@ -110,6 +110,9 @@ final class ModelForwardsCallsExtension implements  MethodsClassReflectionExtens
     private function getReturnTypeFromMap(string $methodName, string $className) : Type
     {
         return [
+            'first' => new IntersectionType([
+                new ObjectType($className), new NullType()
+            ]),
             'find' => new IntersectionType([
                 new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className), new NullType()
             ]),

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -15,11 +15,11 @@ namespace NunoMaduro\Larastan\Methods;
 
 use PHPStan\Type\Type;
 use PHPStan\Type\NullType;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use NunoMaduro\Larastan\Concerns;
-use PHPStan\Type\IntersectionType;
 use Illuminate\Database\Eloquent\Model;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -110,14 +110,14 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
     private function getReturnTypeFromMap(string $methodName, string $className) : Type
     {
         return [
-            'first' => new IntersectionType([
+            'first' => new UnionType([
                 new ObjectType($className), new NullType(),
             ]),
-            'find' => new IntersectionType([
+            'find' => new UnionType([
                 new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className), new NullType(),
             ]),
             'findMany' => new ObjectType(Collection::class),
-            'findOrFail' => new IntersectionType([
+            'findOrFail' => new UnionType([
                 new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType($className),
             ]),
             'make' => new ObjectType($className),
@@ -126,7 +126,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             'findOrNew' => new ObjectType($className),
             'firstOrNew' => new ObjectType($className),
             'updateOrCreate' => new ObjectType($className),
-            'fromQuery' => new IntersectionType([
+            'fromQuery' => new UnionType([
                 new IterableType(new IntegerType(), new ObjectType($className)), new ObjectType(Collection::class),
             ]),
         ][$methodName];

--- a/src/Methods/ModelTypeHelper.php
+++ b/src/Methods/ModelTypeHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Methods;
+
+use PHPStan\Type\Type;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\StaticResolvableType;
+use Illuminate\Database\Eloquent\Model;
+
+final class ModelTypeHelper
+{
+    public static function replaceStaticTypeWithModel(Type $type, string $modelClass) : Type
+    {
+        if ($type instanceof StaticResolvableType) {
+            return TypeCombinator::remove($type->resolveStatic($modelClass), new ObjectType(Model::class, new ObjectType($modelClass)));
+        }
+
+        return $type;
+    }
+}

--- a/src/Methods/Pipes/BuilderDynamicWheres.php
+++ b/src/Methods/Pipes/BuilderDynamicWheres.php
@@ -48,7 +48,7 @@ final class BuilderDynamicWheres implements PipeContract
             $returnMethodReflection = new EloquentBuilderMethodReflection(
                 $passable->getMethodName(), $classReflection,
                 [$originalDynamicWhereVariant->getParameters()[1]],
-                true, new ObjectType(EloquentBuilder::class)
+                new ObjectType(EloquentBuilder::class)
             );
 
             $passable->setMethodReflection($returnMethodReflection);

--- a/src/Methods/Pipes/BuilderDynamicWheres.php
+++ b/src/Methods/Pipes/BuilderDynamicWheres.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use Mockery;
 use Illuminate\Support\Str;
+use PHPStan\Type\ObjectType;
 use Illuminate\Database\Query\Builder;
-use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
+use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 
 /**
  * @internal
@@ -44,23 +45,13 @@ final class BuilderDynamicWheres implements PipeContract
             /** @var \PHPStan\Reflection\FunctionVariantWithPhpDocs $originalDynamicWhereVariant */
             $originalDynamicWhereVariant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
 
-            $variant = new FunctionVariantWithPhpDocs(
+            $returnMethodReflection = new EloquentBuilderMethodReflection(
+                $passable->getMethodName(), $classReflection,
                 [$originalDynamicWhereVariant->getParameters()[1]],
-                $originalDynamicWhereVariant->isVariadic(),
-                $originalDynamicWhereVariant->getReturnType(),
-                $originalDynamicWhereVariant->getPhpDocReturnType(),
-                $originalDynamicWhereVariant->getNativeReturnType()
+                true, new ObjectType(EloquentBuilder::class)
             );
 
-            $methodReflection = Mockery::mock($methodReflection);
-            /* @var \Mockery\MockInterface $methodReflection */
-            $methodReflection->shouldReceive('getVariants')
-                ->andReturn([$variant]);
-
-            $methodReflection->shouldReceive('isStatic')
-                ->andReturn(true);
-
-            $passable->setMethodReflection($methodReflection);
+            $passable->setMethodReflection($returnMethodReflection);
 
             $found = true;
         }

--- a/src/Methods/Pipes/ModelScopes.php
+++ b/src/Methods/Pipes/ModelScopes.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use Mockery;
 use function array_values;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use NunoMaduro\Larastan\Contracts\Methods\PassableContract;
 use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
+use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 
 /**
  * @internal
@@ -45,20 +46,11 @@ final class ModelScopes implements PipeContract
             unset($parameters[0]); // The query argument.
             $parameters = array_values($parameters);
 
-            $variant = Mockery::mock($variant);
-            $variant->shouldReceive('getParameters')
-                ->andReturn($parameters);
-
-            $methodReflection = Mockery::mock($methodReflection);
-
-            $methodReflection->shouldReceive('isStatic')
-                ->andReturn(true);
-
-            /* @var \Mockery\MockInterface $methodReflection */
-            $methodReflection->shouldReceive('getVariants')
-                ->andReturn([$variant]);
-
-            $passable->setMethodReflection($methodReflection);
+            $passable->setMethodReflection(new EloquentBuilderMethodReflection(
+                $scopeMethodName,
+                $passable->getBroker()->getClass(Builder::class),
+                $parameters)
+            );
 
             $found = true;
         }

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -16,10 +16,10 @@ namespace NunoMaduro\Larastan\Reflection;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Database\Eloquent\Builder;
 use PHPStan\Reflection\ClassMemberReflection;
-use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 
 final class EloquentBuilderMethodReflection implements MethodReflection
 {
@@ -87,11 +87,9 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     public function getVariants(): array
     {
         return [
-            new FunctionVariantWithPhpDocs(
+            new FunctionVariant(
                 $this->parameters,
                 false,
-                $this->returnType,
-                $this->returnType,
                 $this->returnType
             ),
         ];

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -48,7 +48,7 @@ final class EloquentBuilderMethodReflection implements MethodReflection
      */
     private $returnType;
 
-    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, bool $isPublic = true, Type $returnType = null)
+    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, bool $isPublic = true, ?Type $returnType = null)
     {
         $this->methodName = $methodName;
         $this->classReflection = $classReflection;

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Reflection;
+
+use PHPStan\Type\ObjectType;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use Illuminate\Database\Eloquent\Builder;
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Type\Type;
+
+final class EloquentBuilderMethodReflection implements MethodReflection
+{
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var ClassReflection
+     */
+    private $classReflection;
+
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var bool
+     */
+    private $isPublic;
+
+    /**
+     * @var Type
+     */
+    private $returnType;
+
+    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, bool $isPublic = true, Type $returnType = null)
+    {
+        $this->methodName = $methodName;
+        $this->classReflection = $classReflection;
+        $this->parameters = $parameters;
+        $this->isPublic = $isPublic;
+        $this->returnType = $returnType ?? new ObjectType(Builder::class);
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->classReflection;
+    }
+
+    public function isStatic(): bool
+    {
+        return true;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->isPublic;
+    }
+
+    public function getName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVariants(): array
+    {
+        return [
+            new FunctionVariant(
+                $this->parameters,
+                false,
+                $this->returnType
+            ),
+        ];
+    }
+}

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Reflection;
 
+use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Database\Eloquent\Builder;
 use PHPStan\Reflection\ClassMemberReflection;
-use PHPStan\Type\Type;
+use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 
 final class EloquentBuilderMethodReflection implements MethodReflection
 {
@@ -39,21 +39,15 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     private $parameters;
 
     /**
-     * @var bool
-     */
-    private $isPublic;
-
-    /**
      * @var Type
      */
     private $returnType;
 
-    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, bool $isPublic = true, ?Type $returnType = null)
+    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, ?Type $returnType = null)
     {
         $this->methodName = $methodName;
         $this->classReflection = $classReflection;
         $this->parameters = $parameters;
-        $this->isPublic = $isPublic;
         $this->returnType = $returnType ?? new ObjectType(Builder::class);
     }
 
@@ -74,7 +68,7 @@ final class EloquentBuilderMethodReflection implements MethodReflection
 
     public function isPublic(): bool
     {
-        return $this->isPublic;
+        return true;
     }
 
     public function getName(): string
@@ -88,14 +82,16 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getVariants(): array
     {
         return [
-            new FunctionVariant(
+            new FunctionVariantWithPhpDocs(
                 $this->parameters,
                 false,
+                $this->returnType,
+                $this->returnType,
                 $this->returnType
             ),
         ];

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -82,7 +82,7 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getVariants(): array
     {

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use PHPStan\Type\Type;
+use Illuminate\Support\Str;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
-use Illuminate\Support\Str;
 use PHPStan\Type\ObjectType;
 use PhpParser\Node\Expr\New_;
 use PHPStan\Type\IntegerType;
@@ -46,7 +46,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             return true;
         }
 
-       return $methodReflection->getName() === 'get';
+        return $methodReflection->getName() === 'get';
     }
 
     public function getTypeFromMethodCall(
@@ -70,7 +70,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         }
 
         if ($methodReflection instanceof DummyMethodReflection && $modelType instanceof ObjectType) {
-            $scopeMethodName = 'scope' . ucfirst($methodReflection->getName());
+            $scopeMethodName = 'scope'.ucfirst($methodReflection->getName());
             $modelReflection = $this->getBroker()->getClass($modelType->getClassName());
 
             if ($modelReflection->hasNativeMethod($scopeMethodName)) {
@@ -79,7 +79,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         }
 
         return new IntersectionType([
-            new IterableType(new IntegerType(), $modelType), new ObjectType(Collection::class)
+            new IterableType(new IntegerType(), $modelType), new ObjectType(Collection::class),
         ]);
     }
 }

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use PHPStan\Type\Type;

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
-use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
@@ -17,6 +16,7 @@ use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\IntersectionType;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use PHPStan\Type\Type;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PhpParser\Node\Expr\New_;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\IntersectionType;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Reflection\MethodReflection;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+
+final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    public function getClass(): string
+    {
+        return Builder::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        while ($methodCall->var instanceof MethodCall) {
+            $methodCall = $methodCall->var;
+        }
+
+        $modelName = new MixedType();
+
+        if ($methodCall->var instanceof StaticCall || $methodCall->var instanceof New_) {
+            $modelName = new ObjectType($methodCall->var->class->toCodeString());
+        } elseif ($methodCall->var instanceof Variable) {
+            $modelName = $scope->getType($methodCall->var);
+        }
+
+        return new IntersectionType([
+            new IterableType(new IntegerType(), $modelName), new ObjectType(Collection::class)
+        ]);
+    }
+}

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
@@ -48,7 +49,9 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         $modelName = new MixedType();
 
         if ($methodCall->var instanceof StaticCall || $methodCall->var instanceof New_) {
-            $modelName = new ObjectType($methodCall->var->class->toCodeString());
+            /** @var FullyQualified $fullQualifiedClass */
+            $fullQualifiedClass = $methodCall->var->class;
+            $modelName = new ObjectType($fullQualifiedClass->toCodeString());
         } elseif ($methodCall->var instanceof Variable) {
             $modelName = $scope->getType($methodCall->var);
         }

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -46,18 +46,18 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             $methodCall = $methodCall->var;
         }
 
-        $modelName = new MixedType();
+        $modelType = new MixedType();
 
         if ($methodCall->var instanceof StaticCall || $methodCall->var instanceof New_) {
             /** @var FullyQualified $fullQualifiedClass */
             $fullQualifiedClass = $methodCall->var->class;
-            $modelName = new ObjectType($fullQualifiedClass->toCodeString());
+            $modelType = new ObjectType($fullQualifiedClass->toCodeString());
         } elseif ($methodCall->var instanceof Variable) {
-            $modelName = $scope->getType($methodCall->var);
+            $modelType = $scope->getType($methodCall->var);
         }
 
         return new IntersectionType([
-            new IterableType(new IntegerType(), $modelName), new ObjectType(Collection::class)
+            new IterableType(new IntegerType(), $modelType), new ObjectType(Collection::class)
         ]);
     }
 }

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -13,23 +13,17 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
-use function count;
 use ReflectionClass;
-use function in_array;
 use PHPStan\Type\Type;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\UnionType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\StaticType;
-use PHPStan\Type\IterableType;
 use NunoMaduro\Larastan\Concerns;
-use PHPStan\Type\IntersectionType;
 use PhpParser\Node\Expr\StaticCall;
 use Illuminate\Database\Eloquent\Model;
 use PHPStan\Reflection\MethodReflection;
 use Illuminate\Database\Eloquent\Collection;
 use PHPStan\Reflection\BrokerAwareExtension;
 use NunoMaduro\Larastan\Methods\Pipes\Mixins;
+use NunoMaduro\Larastan\Methods\ModelTypeHelper;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 
@@ -87,8 +81,8 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
         $method = $methodReflection->getDeclaringClass()
             ->getMethod($methodReflection->getName(), $scope);
 
-        $returnType = $method->getVariants()[0]->getReturnType();
         $variants = $method->getVariants();
+        $returnType = $variants[0]->getReturnType();
 
         /*
          * If the method returns a static type, we instruct phpstan that
@@ -109,48 +103,11 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
                 }
 
                 if ($isValidInstance) {
-                    $types = method_exists($returnType, 'getTypes') ? $returnType->getTypes() : [$returnType];
-                    $types = $this->replaceStaticType($types, $methodCall->class->toString());
-                    $returnType = count($types) > 1 ? new UnionType($types) : current($types);
+                    $returnType = ModelTypeHelper::replaceStaticTypeWithModel($returnType, $className);
                 }
             }
         }
 
         return $returnType;
-    }
-
-    /**
-     * Replaces Static Types by the provided Static Type.
-     *
-     * @param  array $types
-     * @param  string $staticType
-     * @return array
-     */
-    private function replaceStaticType(array $types, string $staticType): array
-    {
-        $mixins = array_merge(
-            [Model::class],
-            $this->mixins->getMixinsFromClass($this->broker, $this->broker->getClass(Model::class))
-        );
-
-        foreach ($types as $key => $type) {
-            if ($type instanceof ObjectType && in_array($type->getClassName(), $mixins, true)) {
-                $types[$key] = new StaticType($staticType);
-            }
-
-            if ($type instanceof StaticType) {
-                $types[$key] = new StaticType($staticType);
-            }
-
-            if ($type instanceof IterableType) {
-                $types[$key] = $type->changeBaseClass($staticType);
-            }
-
-            if ($type instanceof IntersectionType) {
-                $types[$key] = new IntersectionType($this->replaceStaticType($type->getTypes(), $staticType));
-            }
-        }
-
-        return $types;
     }
 }

--- a/src/ReturnTypes/ModelFindExtension.php
+++ b/src/ReturnTypes/ModelFindExtension.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use PHPStan\Type\Type;
+use Illuminate\Support\Str;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use PhpParser\Node\Expr\Array_;
+use PHPStan\Type\TypeCombinator;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Expr\StaticCall;
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+
+/**
+ * @internal
+ */
+final class ModelFindExtension implements DynamicStaticMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return Str::startsWith($methodReflection->getName(), 'find');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): Type {
+        $modelName = $methodReflection->getDeclaringClass()->getName();
+
+        if ($methodCall->args[0]->value instanceof Array_) {
+            return TypeCombinator::remove($methodReflection->getVariants()[0]->getReturnType(), new ObjectType($modelName));
+        }
+
+        if ($methodCall->args[0]->value instanceof LNumber) {
+            return TypeCombinator::remove(
+                $methodReflection->getVariants()[0]->getReturnType(),
+                new IterableType(new IntegerType(), new ObjectType($modelName))
+            );
+        }
+
+        return $methodReflection->getVariants()[0]->getReturnType();
+    }
+}

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -99,6 +99,31 @@ class ModelExtension
 
         return $users;
     }
+
+    public function testCreate() : User
+    {
+        return User::create([]);
+    }
+
+    public function testForceCreate() : User
+    {
+        return User::forceCreate([]);
+    }
+
+    public function testFindOrNew() : User
+    {
+        return User::findOrNew([]);
+    }
+
+    public function testFirstOrNew() : User
+    {
+        return User::firstOrNew([]);
+    }
+
+    public function testUpdateOrCreate() : User
+    {
+        return User::updateOrCreate([]);
+    }
 }
 
 class Thread extends Model

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -105,6 +105,11 @@ class ModelExtension
         return $users;
     }
 
+    public function testMake() : User
+    {
+        return User::make([]);
+    }
+
     public function testCreate() : User
     {
         return User::create([]);

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -68,12 +68,12 @@ class ModelExtension
         return $user->decrement('counter');
     }
 
-    public function testFind() : User
+    public function testFind() : ?User
     {
         return User::find(1);
     }
 
-    public function testFindCanReturnCollection() : Collection
+    public function testFindCanReturnCollection() : ?Collection
     {
         /** @var Collection $users */
         $users = User::find([1, 2, 3]);

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -129,8 +129,17 @@ class ModelExtension
     {
         return User::updateOrCreate([]);
     }
+
+    public function testScope() : Builder
+    {
+        return Thread::valid();
+    }
 }
 
 class Thread extends Model
 {
+    public function scopeValid(Builder $query) : Builder
+    {
+        return $query->where('valid', true);
+    }
 }

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -47,6 +47,11 @@ class ModelExtension
         return Thread::whereFoo(['bar']);
     }
 
+    public function testWhereIn(): Builder
+    {
+        return (new Thread)->whereIn('id', [1, 2, 3]);
+    }
+
     public function testIncrement() : int
     {
         /** @var User $user */

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -111,10 +111,10 @@ class ModelExtension
         return User::first();
     }
 
-    public function testMake() : User
-    {
-        return User::make([]);
-    }
+//    public function testMake() : User
+//    {
+//        return User::make([]);
+//    }
 
     public function testCreate() : User
     {
@@ -150,6 +150,11 @@ class ModelExtension
     {
         return $query->macro('customMacro', function () {
         });
+    }
+
+    public function testChainingCollectionMethodsOnModel() : Collection
+    {
+        return User::findOrFail([1, 2, 3])->makeHidden('foo');
     }
 }
 

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Features\Methods;
 
 use App\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 
 class ModelExtension
 {
@@ -56,6 +56,7 @@ class ModelExtension
     {
         /** @var User $user */
         $user = new User;
+
         return $user->increment('counter');
     }
 
@@ -147,7 +148,8 @@ class ModelExtension
 
     public function testMacro(Builder $query) : Builder
     {
-        return $query->macro('customMacro', function () {});
+        return $query->macro('customMacro', function () {
+        });
     }
 }
 

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -144,6 +144,11 @@ class ModelExtension
     {
         return Thread::valid();
     }
+
+    public function testMacro(Builder $query) : Builder
+    {
+        return $query->macro('customMacro', function () {});
+    }
 }
 
 class Thread extends Model

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Features\Methods;
 
 use App\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class ModelExtension
@@ -17,10 +18,7 @@ class ModelExtension
         return User::all();
     }
 
-    /**
-     * @return \App\User
-     */
-    public function testReturnThis(): User
+    public function testReturnThis(): Builder
     {
         $user = User::join('tickets.tickets', 'tickets.tickets.id', '=', 'tickets.sale_ticket.ticket_id')
             ->where(['foo' => 'bar']);
@@ -28,22 +26,22 @@ class ModelExtension
         return $user;
     }
 
-    public function testWhere(): Thread
+    public function testWhere(): Builder
     {
         return (new Thread)->where(['foo' => 'bar']);
     }
 
-    public function testStaticWhere(): Thread
+    public function testStaticWhere(): Builder
     {
         return Thread::where(['foo' => 'bar']);
     }
 
-    public function testDynamicWhere(): Thread
+    public function testDynamicWhere(): Builder
     {
         return (new Thread)->whereFoo(['bar']);
     }
 
-    public function testStaticDynamicWhere(): Thread
+    public function testStaticDynamicWhere(): Builder
     {
         return Thread::whereFoo(['bar']);
     }

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -105,6 +105,11 @@ class ModelExtension
         return $users;
     }
 
+    public function testFirst() : ?User
+    {
+        return User::first();
+    }
+
     public function testMake() : User
     {
         return User::make([]);

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -47,6 +47,21 @@ class ModelExtension
     {
         return Thread::whereFoo(['bar']);
     }
+
+    public function testIncrement() : int
+    {
+        /** @var User $user */
+        $user = new User;
+        return $user->increment('counter');
+    }
+
+    public function testDecrement() : int
+    {
+        /** @var User $user */
+        $user = new User;
+
+        return $user->decrement('counter');
+    }
 }
 
 class Thread extends Model

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -6,6 +6,7 @@ namespace Tests\Features\Methods;
 
 use App\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class ModelExtension
@@ -59,6 +60,44 @@ class ModelExtension
         $user = new User;
 
         return $user->decrement('counter');
+    }
+
+    public function testFind() : User
+    {
+        return User::find(1);
+    }
+
+    public function testFindCanReturnCollection() : Collection
+    {
+        /** @var Collection $users */
+        $users = User::find([1, 2, 3]);
+
+        return $users;
+    }
+
+    /** @return iterable<User>|null */
+    public function testFindCanReturnCollectionWithAnnotation()
+    {
+        return User::find([1, 2, 3]);
+    }
+
+    /** @return iterable<User> */
+    public function testFindMany()
+    {
+        return User::findMany([1, 2, 3]);
+    }
+
+    public function testFindOrFail() : User
+    {
+        return User::findOrFail(1);
+    }
+
+    public function testFindOrFailCanReturnCollection() : Collection
+    {
+        /** @var Collection $users */
+        $users = User::findOrFail([1, 2, 3]);
+
+        return $users;
     }
 }
 

--- a/tests/Features/Models/ForwardsToEloquentBuilder.php
+++ b/tests/Features/Models/ForwardsToEloquentBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Models;
+
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ForwardsToEloquentBuilder
+{
+    public function testForwardsToEloquentBuilder() : Builder
+    {
+        return (new User)->withGlobalScope('test', function () {});
+    }
+}

--- a/tests/Features/Models/ForwardsToEloquentBuilder.php
+++ b/tests/Features/Models/ForwardsToEloquentBuilder.php
@@ -11,6 +11,7 @@ class ForwardsToEloquentBuilder
 {
     public function testForwardsToEloquentBuilder() : Builder
     {
-        return (new User)->withGlobalScope('test', function () {});
+        return (new User)->withGlobalScope('test', function () {
+        });
     }
 }

--- a/tests/Features/Models/ForwardsToEloquentBuilder.php
+++ b/tests/Features/Models/ForwardsToEloquentBuilder.php
@@ -6,7 +6,6 @@ namespace Tests\Features\Models;
 
 use App\User;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
 class ForwardsToEloquentBuilder
 {

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -12,18 +12,26 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Scopes extends Model
 {
-//    public function testScopeAfterRelation() : HasOne
-//    {
-//        return $this->hasOne(User::class)->active();
-//    }
-//
-//    public function testScopeAfterRelationWithHasMany() : HasMany
-//    {
-//        return $this->hasMany(User::class)->active();
-//    }
-
-    public function testScopeAfterQueryBuilder() : Builder
+    /** @var User */
+    private $user;
+    public function testScopeAfterRelation() : HasOne
     {
-        return User::where('foo', 'bar')->active();
+        return $this->hasOne(User::class)->active();
+    }
+
+    public function testScopeAfterRelationWithHasMany() : HasMany
+    {
+        return $this->hasMany(User::class)->active();
+    }
+
+    public function testScopeAfterQueryBuilderStaticCall() : Builder
+    {
+        return User::where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->active();
+    }
+
+    public function testScopeAfterQueryBuilderVariableCall() : Builder
+    {
+        $this->user = new User;
+        return $this->user->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->active();
     }
 }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Features\Models;
 
 use App\User;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -14,6 +14,7 @@ class Scopes extends Model
 {
     /** @var User */
     private $user;
+
     public function testScopeAfterRelation() : HasOne
     {
         return $this->hasOne(User::class)->active();
@@ -32,6 +33,7 @@ class Scopes extends Model
     public function testScopeAfterQueryBuilderVariableCall() : Builder
     {
         $this->user = new User;
+
         return $this->user->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->active();
     }
 }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -6,8 +6,8 @@ namespace Tests\Features\Models;
 
 use App\User;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Scopes extends Model
 {

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -5,19 +5,25 @@ declare(strict_types=1);
 namespace Tests\Features\Models;
 
 use App\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Scopes extends Model
 {
-    public function testScopeAfterRelation() : HasOne
-    {
-        return $this->hasOne(User::class)->active();
-    }
+//    public function testScopeAfterRelation() : HasOne
+//    {
+//        return $this->hasOne(User::class)->active();
+//    }
+//
+//    public function testScopeAfterRelationWithHasMany() : HasMany
+//    {
+//        return $this->hasMany(User::class)->active();
+//    }
 
-    public function testScopeAfterRelationWithHasMany() : HasMany
+    public function testScopeAfterQueryBuilder() : Builder
     {
-        return $this->hasMany(User::class)->active();
+        return User::where('foo', 'bar')->active();
     }
 }

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -6,8 +6,8 @@ namespace Tests\Features\Models;
 
 use App\User;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Scopes extends Model
 {

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -53,7 +53,7 @@ class BuilderExtension
     /** @return Collection|User[] */
     public function testUsingCollectionMethodsAfterGet() : Collection
     {
-        return User::whereIn('id', [1,2,3])->get()->mapWithKeys('key');
+        return User::whereIn('id', [1, 2, 3])->get()->mapWithKeys('key');
     }
 
     public function testCallingQueryBuilderMethodOnEloquentBuilderReturnsEloquentBuilder(Builder $builder) : Builder

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class BuilderExtension
+{
+    /** @return Collection|User[] */
+    public function testCallingGetOnModelWithStaticQueryBuilder() : Collection
+    {
+        return User::where('id', 1)->get();
+    }
+
+    /** @return Collection|User[] */
+    public function testCallingGetOnModelWithVariableQueryBuilder() : Collection
+    {
+        return (new User)->where('id', 1)->get();
+    }
+
+    /** @return Collection|User[] */
+    public function testCallingLongGetChainOnModelWithStaticQueryBuilder() : Collection
+    {
+        return User::where('id', 1)
+            ->whereNotNull('active')
+            ->whereHas(['relation'])
+            ->whereFoo(['bar'])
+            ->get();
+    }
+
+
+    /** @return Collection|User[] */
+    public function testCallingLongGetChainOnModelWithVariableQueryBuilder() : Collection
+    {
+        return (new User)->whereNotNull('active')
+            ->whereHas(['relation'])
+            ->whereFoo(['bar'])
+            ->get();
+    }
+
+    /** @return Collection|User[] */
+    public function testCallingGetOnModelWithVariableQueryBuilder2() : Collection
+    {
+        $user = new User;
+
+        return $user->where('test', 1)->get();
+    }
+}
+
+class TestModel extends Model
+{
+    /** @return Collection|TestModel[] */
+    public function testCallingGetInsideModel() : Collection
+    {
+        return $this->where('test', 1)->get();
+    }
+}

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -27,7 +27,7 @@ class BuilderExtension
     {
         return User::where('id', 1)
             ->whereNotNull('active')
-            ->whereHas(['relation'])
+            ->where('foo', 'bar')
             ->whereFoo(['bar'])
             ->get();
     }
@@ -37,7 +37,7 @@ class BuilderExtension
     public function testCallingLongGetChainOnModelWithVariableQueryBuilder() : Collection
     {
         return (new User)->whereNotNull('active')
-            ->whereHas(['relation'])
+            ->where('foo', 'bar')
             ->whereFoo(['bar'])
             ->get();
     }
@@ -48,6 +48,12 @@ class BuilderExtension
         $user = new User;
 
         return $user->where('test', 1)->get();
+    }
+
+    /** @return Collection|User[] */
+    public function testUsingCollectionMethodsAfterGet() : Collection
+    {
+        return User::whereIn('id', [1,2,3])->get()->mapWithKeys('key');
     }
 }
 

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Tests\Features\ReturnTypes;
 
 use App\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 
 class BuilderExtension
 {
@@ -32,7 +33,6 @@ class BuilderExtension
             ->get();
     }
 
-
     /** @return Collection|User[] */
     public function testCallingLongGetChainOnModelWithVariableQueryBuilder() : Collection
     {
@@ -54,6 +54,11 @@ class BuilderExtension
     public function testUsingCollectionMethodsAfterGet() : Collection
     {
         return User::whereIn('id', [1,2,3])->get()->mapWithKeys('key');
+    }
+
+    public function testCallingQueryBuilderMethodOnEloquentBuilderReturnsEloquentBuilder(Builder $builder) : Builder
+    {
+        return $builder->whereNotNull('test');
     }
 }
 


### PR DESCRIPTION
Ok. This turned out to be a little bigger PR than I imagined :sweat_smile: But the outcome is good! I tested it on my big project. And I could go to level 4 from level 3 without changing anything.

List of changes:

- `Model` class' `__call` method is mimicked. If it's not `increment` or `decrement` calls are forwarded to `\Illuminate\Database\Eloquent\Builder`
- `\Illuminate\Database\Eloquent\Builder` `__call` method is mimicked. With one exception. Local macros are not supported. Otherwise, all unknown calls are forwarded to `\Illuminate\Database\Query\Builder` class. But return type is still `\Illuminate\Database\Eloquent\Builder`
- Added support for calling `get` on the query builder. This will return `Collection` class and elements of the collection correctly typehinted with the model. 
- Return type of query builder methods is fixed. Previously `User::where('foo', 'bar')` was returning the model itself. See #324 This is fixed now
- Return type of model local scopes is correctly handled now.
- Added correct return types for model retrieval and creation methods. Ex. `find`, `firstOrCreate` etc.
- Added more test cases for everything.

There might be an increased number of errors after these changes. But this is because there were false negatives before. For example Larastan would think `User:whereFoo('bar')->someRelation()` is a correct code and returning model instance. But that example is not a valid Laravel code in reality. So I guess any of this can't be considered as breaking change. And all the existing (which I didn't change) tests are passing, so existing functionality is preserved.

I'm open to any comments and questions. About implementation or other things.