### PR TITLE
Use AnnotationExtension as first extension

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -19,6 +19,11 @@ parameters:
 
 services:
     -
+        class: NunoMaduro\Larastan\Methods\AnnotationExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension

--- a/src/Methods/AnnotationExtension.php
+++ b/src/Methods/AnnotationExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Methods;
+
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
+
+/**
+ * @internal
+ */
+final class AnnotationExtension implements MethodsClassReflectionExtension
+{
+    use Concerns\HasBroker;
+    
+    /** @var AnnotationsMethodsClassReflectionExtension */
+    private $annotationsMethodsClassReflectionExtension;
+    
+    public function __construct(AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension)
+    {
+        $this->annotationsMethodsClassReflectionExtension = $annotationsMethodsClassReflectionExtension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $this->annotationsMethodsClassReflectionExtension->hasMethod($classReflection, $methodName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->annotationsMethodsClassReflectionExtension->getMethod($classReflection, $methodName);
+    }
+}

--- a/src/Methods/AnnotationExtension.php
+++ b/src/Methods/AnnotationExtension.php
@@ -25,10 +25,10 @@ use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 final class AnnotationExtension implements MethodsClassReflectionExtension
 {
     use Concerns\HasBroker;
-    
+
     /** @var AnnotationsMethodsClassReflectionExtension */
     private $annotationsMethodsClassReflectionExtension;
-    
+
     public function __construct(AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension)
     {
         $this->annotationsMethodsClassReflectionExtension = $annotationsMethodsClassReflectionExtension;

--- a/tests/Features/ReturnTypes/GateFacade.php
+++ b/tests/Features/ReturnTypes/GateFacade.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+use Illuminate\Support\Facades\Gate;
+
+class GateFacade
+{
+    public function testGateForUser() :\Illuminate\Contracts\Auth\Access\Gate
+    {
+        return Gate::forUser(new User());
+    }
+}


### PR DESCRIPTION
When phpstan loads the extension,`AnnotationExtension` is executed at last.

This PR, adds our own extension which just mimics the `AnnotationExtension` and runs it **first**.

This allows to first check the class annotations, and if a magic method is documented there, it'll use the return type and parameters from there.

I think this is ok in our case. Laravel has some useful annotations for classes that defines methods by magic `__call` or `__callStatic` functions.

Fixes #251