### PR TITLE
Check argument count in abort_if extension

### DIFF
--- a/src/Types/AbortIfFunctionTypeSpecifyingExtension.php
+++ b/src/Types/AbortIfFunctionTypeSpecifyingExtension.php
@@ -41,6 +41,10 @@ final class AbortIfFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
         Scope $scope,
         TypeSpecifierContext $context
     ): SpecifiedTypes {
+        if (count($node->args) < 2) {
+            return new SpecifiedTypes();
+        }
+
         return $this->typeSpecifier->specifyTypesInCondition($scope, $node->args[0]->value, TypeSpecifierContext::createFalsey());
     }
 


### PR DESCRIPTION
As per the comment from @ondrejmirtes, this PR adds check for the argument count. `abort_if` requires at least 2 arguments, so it checks if it's less than 2.