### PR TITLE
Adds support for resolving types of model relations accessed as property

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,7 +1,6 @@
 parameters:
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
-        - Illuminate\Database\Eloquent\Model
         - Illuminate\Http\Resources\Json\JsonResource
         - Illuminate\Http\Request
         - Illuminate\Contracts\Auth\Authenticatable
@@ -37,6 +36,11 @@ services:
         class: NunoMaduro\Larastan\Methods\Extension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+
+    -
+            class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
+            tags:
+                - phpstan.broker.propertiesClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\Properties\Extension

--- a/src/Properties/ModelRelationProperty.php
+++ b/src/Properties/ModelRelationProperty.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Properties;
+
+use PHPStan\Type\Type;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+
+class ModelRelationProperty implements PropertyReflection
+{
+    /**
+     * @var ClassReflection
+     */
+    private $declaringClass;
+
+    /**
+     * @var Type
+     */
+    private $type;
+
+    /**
+     * Property constructor.
+     *
+     * @param ClassReflection $declaringClass
+     * @param mixed           $type
+     */
+    public function __construct(ClassReflection $declaringClass, $type)
+    {
+        $this->declaringClass = $declaringClass;
+        $this->type = $type;
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Properties;
+
+use Illuminate\Support\Str;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\IterableType;
+use NunoMaduro\Larastan\Concerns;
+use PHPStan\Type\IntersectionType;
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use Illuminate\Database\Eloquent\Collection;
+use PHPStan\Reflection\BrokerAwareExtension;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use PHPStan\Reflection\Dummy\DummyPropertyReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+
+/**
+ * @internal
+ */
+final class ModelRelationsExtension implements PropertiesClassReflectionExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+    use Concerns\HasContainer;
+
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (! $classReflection->isSubclassOf(Model::class)) {
+            return false;
+        }
+
+        return $classReflection->hasNativeMethod($propertyName);
+    }
+
+    public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+    {
+        $method = $classReflection->getNativeMethod($propertyName);
+
+        if (! (new ObjectType(Relation::class))->isSuperTypeOf($method->getVariants()[0]->getReturnType())->yes()) {
+            return new DummyPropertyReflection();
+        }
+
+        /** @var ObjectType $relationType */
+        $relationType = $method->getVariants()[0]->getReturnType();
+        $relationClass = $relationType->getClassName();
+        $relatedModel = get_class($this->getContainer()->make($classReflection->getName())->{$propertyName}()->getRelated());
+
+        if (Str::contains($relationClass, 'Many')) {
+            return new ModelRelationProperty(
+                $classReflection,
+                new IntersectionType([
+                    new ObjectType(Collection::class),
+                    new IterableType(new MixedType(), new ObjectType($relatedModel))
+                ]));
+        }
+
+        if (Str::endsWith($relationClass, 'MorphTo')) {
+            return new ModelRelationProperty($classReflection, new UnionType([
+                new ObjectType(Model::class),
+                new MixedType()
+            ]));
+        }
+
+        return new ModelRelationProperty($classReflection, new ObjectType($relatedModel));
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -2,15 +2,11 @@
 
 namespace App;
 
-use Illuminate\Support\Collection;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-/**
- * @property Collection|Account[] $accounts
- */
 class User extends Authenticatable
 {
     use Notifiable;

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Properties;
+
+use App\User;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class ModelRelationsExtension
+{
+    /** @return iterable<OtherDummyModel>&Collection */
+    public function testHasMany()
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        return $dummyModel->hasManyRelation;
+    }
+
+    public function testHasManyForEach() : OtherDummyModel
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        foreach($dummyModel->hasManyRelation as $related) {
+            if (random_int(0,1)) {
+                return $related;
+            }
+        }
+
+        return new OtherDummyModel;
+    }
+
+    /** @return iterable<OtherDummyModel>&Collection */
+    public function testHasManyThroughRelation()
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        return $dummyModel->hasManyThroughRelation;
+    }
+
+    public function testBelongsTo() : DummyModel
+    {
+        /** @var OtherDummyModel $otherDummyModel */
+        $otherDummyModel = OtherDummyModel::firstOrFail();
+
+        return $otherDummyModel->belongsToRelation;
+    }
+
+    public function testMorphTo() : DummyModel
+    {
+        /** @var OtherDummyModel $otherDummyModel */
+        $otherDummyModel = OtherDummyModel::firstOrFail();
+
+        return $otherDummyModel->morphToRelation;
+    }
+
+    /** @return mixed */
+    public function testRelationWithoutReturnType()
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        return $dummyModel->relationWithoutReturnType;
+    }
+}
+
+class DummyModel extends Model
+{
+    public function hasManyRelation() : HasMany
+    {
+        return $this->hasMany(OtherDummyModel::class);
+    }
+
+    public function hasManyThroughRelation() : HasManyThrough
+    {
+        return $this->hasManyThrough(OtherDummyModel::class, User::class);
+    }
+
+    public function relationWithoutReturnType()
+    {
+        return $this->hasMany(OtherDummyModel::class);
+    }
+}
+
+class OtherDummyModel extends Model
+{
+    public function belongsToRelation() : BelongsTo
+    {
+        return $this->belongsTo(DummyModel::class);
+    }
+
+    public function morphToRelation() : MorphTo
+    {
+        return $this->morphTo('foo');
+    }
+}


### PR DESCRIPTION
This PR adds support for specifying types for model relations accessed as model properties.

`$user->posts` for example, returns a collection of posts.

There is one thing though. I had to remove `Illuminate\Database\Eloquent\Model` from the `universalObjectCratesClasses` for this to work. So this can result in some new errors for the users. Because now all the property accesses will be checked by PHPStan. But as  I said, this is also required for this extension to work.