### PR TITLE
Fix return type of mock, partialMock and spy methods in TestCase

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -83,6 +83,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\TestCaseExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\AuthExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/TestCaseExtension.php
+++ b/src/ReturnTypes/TestCaseExtension.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Foundation\Testing\TestCase;
@@ -14,6 +23,9 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+/**
+ * @internal
+ */
 final class TestCaseExtension implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string

--- a/src/ReturnTypes/TestCaseExtension.php
+++ b/src/ReturnTypes/TestCaseExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Foundation\Testing\TestCase;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class TestCaseExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return TestCase::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), [
+            'mock',
+            'partialMock',
+            'spy',
+        ], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $defaultReturnType = new ObjectType('Mockery\\MockInterface');
+
+        $classType = $scope->getType($methodCall->args[0]->value);
+
+        if (! $classType instanceof ConstantStringType) {
+            return $defaultReturnType;
+        }
+
+        $objectType = new ObjectType($classType->getValue());
+
+        return TypeCombinator::intersect($defaultReturnType, $objectType);
+    }
+}

--- a/tests/Features/ReturnTypes/TestCaseExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseExtension.php
@@ -6,26 +6,48 @@ namespace Tests\Features\ReturnTypes;
 
 use App\User;
 use Illuminate\Foundation\Application;
-use PHPStan\Testing\TestCase;
 
-class TestCaseExtension extends TestCase
+class TestCaseExtension
 {
-    public function testTestCaseExtension(): void
+    public function testMockMethod(): void
     {
-        $testCase = new TestTestCase();
+        (new TestTestCase())->testMockMethod();
+    }
 
-        $testCase->testMockingMethod('mock');
-        $testCase->testMockingMethod('partialMock');
-        $testCase->testMockingMethod('spy');
+    public function testPartialMockMethod(): void
+    {
+        (new TestTestCase())->testPartialMockMethod();
+    }
+
+    public function testSpyMethod(): void
+    {
+        (new TestTestCase())->testSpyMethod();
     }
 }
 
 class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
 {
-    public function testMockingMethod($method): void
+    public function testMockMethod(): void
     {
-        if (method_exists($this, $method)) {
-            $mock = $this->{$method}(User::class);
+        if (method_exists($this, 'mock')) {
+            $bla = 'mock';
+            $mock = $this->{$bla}(User::class);
+            $mock->accounts();
+        }
+    }
+
+    public function testPartialMockMethod(): void
+    {
+        if (method_exists($this, 'partialMock')) {
+            $mock = $this->partialMock(User::class);
+            $mock->accounts();
+        }
+    }
+
+    public function testSpyMethod(): void
+    {
+        if (method_exists($this, 'spy')) {
+            $mock = $this->spy(User::class);
             $mock->accounts();
         }
     }
@@ -34,5 +56,4 @@ class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
     {
         return new Application('');
     }
-
 }

--- a/tests/Features/ReturnTypes/TestCaseExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseExtension.php
@@ -29,10 +29,8 @@ class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
 {
     public function testMockMethod(): void
     {
-        if (method_exists($this, 'mock')) {
-            $mock = $this->mock(User::class);
-            $mock->accounts();
-        }
+        $mock = $this->mock(User::class);
+        $mock->accounts();
     }
 
     public function testPartialMockMethod(): void
@@ -45,10 +43,8 @@ class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
 
     public function testSpyMethod(): void
     {
-        if (method_exists($this, 'spy')) {
-            $mock = $this->spy(User::class);
-            $mock->accounts();
-        }
+        $mock = $this->spy(User::class);
+        $mock->accounts();
     }
 
     public function createApplication()

--- a/tests/Features/ReturnTypes/TestCaseExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+use Illuminate\Foundation\Application;
+use PHPStan\Testing\TestCase;
+
+class TestCaseExtension extends TestCase
+{
+    public function testTestCaseExtension(): void
+    {
+        $testCase = new TestTestCase();
+
+        $testCase->testMock();
+        $testCase->testPartialMock();
+        $testCase->testSpy();
+    }
+}
+
+class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
+{
+    public function testMock() {
+        $mock = $this->mock(User::class);
+        $mock->accounts();
+    }
+
+    public function testPartialMock() {
+        $mock = $this->partialMock(User::class);
+        $mock->accounts();
+    }
+
+    public function testSpy() {
+        $mock = $this->spy(User::class);
+        $mock->accounts();
+    }
+
+    public function createApplication()
+    {
+        return new Application('');
+    }
+
+}

--- a/tests/Features/ReturnTypes/TestCaseExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseExtension.php
@@ -30,8 +30,7 @@ class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
     public function testMockMethod(): void
     {
         if (method_exists($this, 'mock')) {
-            $bla = 'mock';
-            $mock = $this->{$bla}(User::class);
+            $mock = $this->mock(User::class);
             $mock->accounts();
         }
     }

--- a/tests/Features/ReturnTypes/TestCaseExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseExtension.php
@@ -14,27 +14,20 @@ class TestCaseExtension extends TestCase
     {
         $testCase = new TestTestCase();
 
-        $testCase->testMock();
-        $testCase->testPartialMock();
-        $testCase->testSpy();
+        $testCase->testMockingMethod('mock');
+        $testCase->testMockingMethod('partialMock');
+        $testCase->testMockingMethod('spy');
     }
 }
 
 class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
 {
-    public function testMock() {
-        $mock = $this->mock(User::class);
-        $mock->accounts();
-    }
-
-    public function testPartialMock() {
-        $mock = $this->partialMock(User::class);
-        $mock->accounts();
-    }
-
-    public function testSpy() {
-        $mock = $this->spy(User::class);
-        $mock->accounts();
+    public function testMockingMethod($method): void
+    {
+        if (method_exists($this, $method)) {
+            $mock = $this->{$method}(User::class);
+            $mock->accounts();
+        }
     }
 
     public function createApplication()


### PR DESCRIPTION
This PR add support for the return type of the `mock`, `partialMock` and `spy` methods in `Illuminate\Foundation\Testing\TestCase`.

Without it you get the following error when calling a method.
`Call to an undefined method  Mockery\MockInterface::someMethod()`

Or when `phpstan/phpstan-mockery` is installed and you declare it as a property:
`Tests\FooTest::$mock (App\Foo&Mockery\MockInterface) does not accept Mockery\MockInterface.`