### PR TITLE
Verify analyse fails when extension is disabled.

### DIFF
--- a/tests/ExtensionsTest.php
+++ b/tests/ExtensionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Orchestra\Testbench\TestCase;
+use Composer\Autoload\ClassMapGenerator;
+
+class ExtensionsTest extends TestCase
+{
+    use RegisteredExtensions;
+
+    public function testExtensionsAreRegistered(): void
+    {
+        $loadedExtensions = $this->getLoadedExtensions();
+        $registeredExtensions = $this->getRegisteredExtensions();
+
+        $extensions = array_diff($loadedExtensions, $registeredExtensions);
+
+        $this->assertCount(
+            0,
+            $extensions,
+            'Extension ('.implode(', ', $extensions).') is not registered in extension.neon'
+        );
+    }
+
+    private function getLoadedExtensions(): array
+    {
+        $baseDir = __DIR__.'/../src';
+        $extensions = [];
+
+        foreach (ClassMapGenerator::createMap($baseDir) as $model => $path) {
+            if (strpos($model, 'Extension') !== false) {
+                $extensions[] = $model;
+            }
+        }
+
+        return $extensions;
+    }
+}

--- a/tests/Features/ReturnTypes/RelationCreateExtension.php
+++ b/tests/Features/ReturnTypes/RelationCreateExtension.php
@@ -9,7 +9,7 @@ use App\Account;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class ModelExtension
+class RelationCreateExtension
 {
     public function testCreateWithRelation() : Account
     {

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -85,7 +85,7 @@ class FeaturesTest extends TestCase
         ], $output = new BufferedOutput);
 
         if ($result != $shouldFail) {
-            $message = $shouldFail ? $output->fetch() : "Analysis fails, please check {$file}.";
+            $message = 'Analysis fails, please check '.$file.'.'.PHP_EOL.PHP_EOL.$output->fetch();
 
             $this->fail($message);
         }
@@ -107,7 +107,7 @@ class FeaturesTest extends TestCase
             }
         }
 
-        $path = $this->extensionPath . Str::random(16);
+        $path = str_replace('.neon', Str::random(16).'.neon', $this->extensionPath);
         file_put_contents($path, Neon::encode($extension, Neon::BLOCK));
 
         return $path;

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -50,10 +50,6 @@ class FeaturesTest extends TestCase
             $calls[str_replace($baseDir, '', $fullPath)] = [$fullPath];
         }
 
-        return [
-            'ReturnTypes/Helpers/RequestExtension.php' => ['/Users/bertvanhoekelen/Code/opensource/larastan/tests/Features/ReturnTypes/Helpers/RequestExtension.php']
-        ];
-
         return $calls;
     }
 

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -66,8 +66,6 @@ class FeaturesTest extends TestCase
             $configurationPath = $this->disableExtension($extension);
 
             $this->analyze($file, true, $configurationPath);
-
-            File::delete($configurationPath);
         }
     }
 
@@ -83,6 +81,10 @@ class FeaturesTest extends TestCase
             '--no-progress' => true,
             '--configuration' => $configurationPath ?? $this->extensionPath
         ], $output = new BufferedOutput);
+
+        if ($configurationPath) {
+            File::delete($configurationPath);
+        }
 
         if ($result != $shouldFail) {
             $message = 'Analysis fails, please check '.$file.'.'.PHP_EOL.PHP_EOL.$output->fetch();

--- a/tests/RegisteredExtensions.php
+++ b/tests/RegisteredExtensions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Nette\Neon\Neon;
+
+trait RegisteredExtensions
+{
+    /** @var string */
+    protected $extensionPath = __DIR__ . '/../extension.neon';
+
+    /** @var array|null */
+    private $registeredExtensions;
+
+    protected function getRegisteredExtensions(): array
+    {
+        $extensionFile = file_get_contents($this->extensionPath);
+        $extension = Neon::decode($extensionFile);
+
+        if (!$this->registeredExtensions) {
+            $this->registeredExtensions = array_map(function ($service) {
+                return $service['class'];
+            }, $extension['services']);
+        }
+
+        return $this->registeredExtensions;
+    }
+}


### PR DESCRIPTION
When working on https://github.com/nunomaduro/larastan/pull/362 test's succeeded while disabling the extension didn't change anything.

To make reviews easier without manually enabling/disabling the extension, I have added a test verifying the extension is really working or not.

I also added a test that checks if the extension is registered in the `extensions.neon` file.