### PR TITLE
Return custom builder if method exists on builder

### DIFF
--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -96,6 +96,14 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             if ($modelReflection->hasNativeMethod($scopeMethodName)) {
                 return new ObjectType(Builder::class);
             }
+
+            if ($modelReflection->hasNativeMethod('newEloquentBuilder')) {
+                $customBuilder = $modelReflection->getNativeMethod('newEloquentBuilder')->getVariants()[0]->getReturnType();
+
+                if ($customBuilder->hasMethod($methodReflection->getName())->yes()) {
+                    return $customBuilder;
+                }
+            }
         }
 
         if ($modelType instanceof ObjectType && in_array($methodReflection->getName(), array_merge(ModelForwardsCallsExtension::MODEL_CREATION_METHODS, ModelForwardsCallsExtension::MODEL_RETRIEVAL_METHODS), true)) {

--- a/tests/Features/ReturnTypes/EloquentBuilderExtension.php
+++ b/tests/Features/ReturnTypes/EloquentBuilderExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentBuilderExtension
+{
+    public function testModelScopeReturnsBuilder(): Builder
+    {
+        return TestScopesModel::query()
+            ->foo('piet');
+    }
+
+    public function testCustomBuilderMethodReturnsBuilder(): CustomBuilder
+    {
+        return TestScopesModel::query()
+            ->type('piet');
+    }
+}
+
+class TestScopesModel extends Model
+{
+    public function scopeFoo(string $foo)
+    {
+        $this->where(['foo' => $foo]);
+    }
+
+    /**
+     * @return \Tests\Features\ReturnTypes\CustomBuilder
+     */
+    public function newEloquentBuilder($query)
+    {
+        return new CustomBuilder($query);
+    }
+}
+
+class CustomBuilder extends Builder
+{
+    public function type(string $type)
+    {
+        $this->where(['type' => $type]);
+    }
+}


### PR DESCRIPTION
When chaining other query builder methods on custom builder scopes you get: `Method Illuminate\Support\Collection::METHOD() invoked with 0 parameters,  1-2 required.` or something similar. This PR makes sure that the custom builder is returned when the scope is called.

I also added extra tests: verify `Builder` is returned for local scopes, verify model is returned for creation/retrieval methods and the default return collection.