### PR TITLE
Allow nullable model relation

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -78,13 +78,11 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
 
         $phpDocs = $classReflection->getNativeReflection()->getDocComment();
 
-        if ($phpDocs) {
-            if ($this->hasNullableProperty($phpDocs, $relatedModel)) {
-                return new ModelRelationProperty($classReflection, new UnionType([
-                    new ObjectType($relatedModel),
-                    new NullType(),
-                ]));
-            }
+        if ($phpDocs && $this->hasNullableProperty($phpDocs, $relatedModel)) {
+            return new ModelRelationProperty($classReflection, new UnionType([
+                new ObjectType($relatedModel),
+                new NullType(),
+            ]));
         }
 
         return new ModelRelationProperty($classReflection, new ObjectType($relatedModel));

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -70,6 +70,14 @@ class ModelRelationsExtension
 
         return $dummyModel->relationWithoutReturnType;
     }
+
+    public function testNullableProperty(): DummyModel
+    {
+        /** @var DummyModelWithDocBlock $dummyModel */
+        $dummyModel = DummyModelWithDocBlock::firstOrFail();
+
+        return $dummyModel->belongsToRelation ? $dummyModel->belongsToRelation : new DummyModel();
+    }
 }
 
 class DummyModel extends Model
@@ -100,5 +108,16 @@ class OtherDummyModel extends Model
     public function morphToRelation() : MorphTo
     {
         return $this->morphTo('foo');
+    }
+}
+
+/**
+ * @property \Tests\Features\Properties\DummyModel|null $belongsToRelation
+ */
+class DummyModelWithDocBlock extends Model
+{
+    public function belongsToRelation() : BelongsTo
+    {
+        return $this->belongsTo(DummyModel::class);
     }
 }

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -71,7 +71,7 @@ class ModelRelationsExtension
         return $dummyModel->relationWithoutReturnType;
     }
 
-    public function testNullableProperty(): DummyModel
+    public function testDocBlockPropertyIsUsed(): DummyModel
     {
         /** @var DummyModelWithDocBlock $dummyModel */
         $dummyModel = DummyModelWithDocBlock::firstOrFail();


### PR DESCRIPTION
This PR fixes errors like `Call to function is_null() with DummyModelWithDocBlock will always evaluate to false.` when the property is explicitly marked as nullable by the phpdoc comment.