### PR TITLE
Makes relation properties nullable and uses annotations first

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -23,6 +23,11 @@ services:
             - phpstan.broker.methodsClassReflectionExtension
 
     -
+        class: NunoMaduro\Larastan\Methods\AnnotationExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\Methods\ModelForwardsCallsExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension

--- a/src/Methods/AnnotationExtension.php
+++ b/src/Methods/AnnotationExtension.php
@@ -15,23 +15,32 @@ namespace NunoMaduro\Larastan\Methods;
 
 use NunoMaduro\Larastan\Concerns;
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
 
 /**
  * @internal
  */
-final class AnnotationExtension implements MethodsClassReflectionExtension
+final class AnnotationExtension implements MethodsClassReflectionExtension, PropertiesClassReflectionExtension
 {
     use Concerns\HasBroker;
 
     /** @var AnnotationsMethodsClassReflectionExtension */
     private $annotationsMethodsClassReflectionExtension;
 
-    public function __construct(AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension)
-    {
+    /** @var AnnotationsPropertiesClassReflectionExtension */
+    private $annotationsPropertiesClassReflectionExtension;
+
+    public function __construct(
+        AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension,
+        AnnotationsPropertiesClassReflectionExtension $annotationsPropertiesClassReflectionExtension
+    ) {
         $this->annotationsMethodsClassReflectionExtension = $annotationsMethodsClassReflectionExtension;
+        $this->annotationsPropertiesClassReflectionExtension = $annotationsPropertiesClassReflectionExtension;
     }
 
     /**
@@ -48,5 +57,21 @@ final class AnnotationExtension implements MethodsClassReflectionExtension
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
         return $this->annotationsMethodsClassReflectionExtension->getMethod($classReflection, $methodName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        return $this->annotationsPropertiesClassReflectionExtension->hasProperty($classReflection, $propertyName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+    {
+        return $this->annotationsPropertiesClassReflectionExtension->getProperty($classReflection, $propertyName);
     }
 }

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -26,6 +26,7 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\UnionType;
 
@@ -75,6 +76,9 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
             ]));
         }
 
-        return new ModelRelationProperty($classReflection, new ObjectType($relatedModel));
+        return new ModelRelationProperty($classReflection, new UnionType([
+            new ObjectType($relatedModel),
+            new NullType(),
+        ]));
     }
 }

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -70,6 +70,14 @@ class ModelRelationsExtension
 
         return $dummyModel->relationWithoutReturnType;
     }
+
+    public function testModelCanOverwriteRelationPropertyWithAnnotation() : DummyModel
+    {
+        /** @var OtherDummyModel $otherDummyModel */
+        $otherDummyModel = OtherDummyModel::firstOrFail();
+
+        return $otherDummyModel->belongsToRelationWithoutNull;
+    }
 }
 
 class DummyModel extends Model
@@ -90,9 +98,15 @@ class DummyModel extends Model
     }
 }
 
+/** @property-read DummyModel $belongsToRelationWithoutNull */
 class OtherDummyModel extends Model
 {
     public function belongsToRelation() : BelongsTo
+    {
+        return $this->belongsTo(DummyModel::class);
+    }
+
+    public function belongsToRelationWithoutNull() : BelongsTo
     {
         return $this->belongsTo(DummyModel::class);
     }

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -46,7 +46,7 @@ class ModelRelationsExtension
         return $dummyModel->hasManyThroughRelation;
     }
 
-    public function testBelongsTo() : DummyModel
+    public function testBelongsTo() : ?DummyModel
     {
         /** @var OtherDummyModel $otherDummyModel */
         $otherDummyModel = OtherDummyModel::firstOrFail();


### PR DESCRIPTION
This PR changes return type for relation properties by returning `UnionType` with `NullType` included. Since Laravel returns if the relation is empty.

Also, class annotations for the properties now checked before any other extension.