### PR TITLE
Simplify replacing type logic in ModelTypeHelper

### DIFF
--- a/src/Methods/ModelTypeHelper.php
+++ b/src/Methods/ModelTypeHelper.php
@@ -14,37 +14,27 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Model;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\IterableType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeWithClassName;
 
 final class ModelTypeHelper
 {
     public static function replaceStaticTypeWithModel(Type $type, string $modelClass) : Type
     {
         return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($modelClass): Type {
-            if ($type instanceof UnionType || $type instanceof IntersectionType) {
-                return $traverse($type);
-            }
-
-            if ($type instanceof IterableType && $type->getItemType() instanceof StaticType) {
-                return new IterableType($type->getIterableKeyType(), new ObjectType($modelClass));
-            }
-
             if ($type instanceof ObjectWithoutClassType || $type instanceof StaticType) {
                 return new ObjectType($modelClass);
             }
 
-            if ($type instanceof ObjectType && $type->getClassName() === Model::class) {
+            if ($type instanceof TypeWithClassName && $type->getClassName() === Model::class) {
                 return new ObjectType($modelClass);
             }
 
-            return $type;
+            return $traverse($type);
         });
     }
 }

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -79,10 +79,7 @@ class ModelExtension
      */
     public function testFindCanReturnCollection() : ?Collection
     {
-        /** @var Collection<\App\User> $users */
-        $users = User::find([1, 2, 3]);
-
-        return $users;
+        return User::find([1, 2, 3]);
     }
 
     /** @return iterable<User>|null */


### PR DESCRIPTION
This PR simplifies the logic in `ModelTypeHelper` according to the @ondrejmirtes's comment [here](https://github.com/phpstan/phpstan/issues/2766#issuecomment-568594782).