### PR TITLE
Better return type support for find* methods

### DIFF
--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -8,6 +8,7 @@ use App\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
 
 class ModelExtension
 {
@@ -185,17 +186,17 @@ class ModelExtension
             ->first();
     }
 
-    public function testFindOnVariableClassName() : ?User
+    /** @return Collection<User>|null */
+    public function testFindWithCastingToArray(FormRequest $request) : ?Collection
     {
-        $class = foo();
+        $requestData = $request->validated();
 
-        return $class::query()->find(5);
+        return User::find((array) $requestData['user_ids']);
     }
 
-    /** @return iterable<Thread>&Collection */
-    public function testCustomMethodsStartingWithFind()
+    public function testFindWithCastingToInt() : ?User
     {
-        return Thread::findAllFooBarThreads();
+        return User::find((int) '1');
     }
 
     public function testCustomAccessorOnModels() : string


### PR DESCRIPTION
From the issue #379, if the given argument is iterable we will return the collection. If its type can't be determined (`MixedType`) we will return the default return value. 