### PR TITLE
Support for model accessors

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -43,9 +43,14 @@ services:
             - phpstan.broker.methodsClassReflectionExtension
 
     -
-            class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
-            tags:
-                - phpstan.broker.propertiesClassReflectionExtension
+        class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Properties\ModelAccessorExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\Properties\Extension

--- a/src/Properties/ModelAccessorExtension.php
+++ b/src/Properties/ModelAccessorExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\Properties;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+
+/**
+ * @internal
+ */
+final class ModelAccessorExtension implements PropertiesClassReflectionExtension
+{
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (! $classReflection->isSubclassOf(Model::class)) {
+            return false;
+        }
+
+        return $classReflection->hasNativeMethod('get'.Str::studly($propertyName).'Attribute');
+    }
+
+    public function getProperty(
+        ClassReflection $classReflection,
+        string $propertyName
+    ): PropertyReflection {
+        $method = $classReflection->getNativeMethod('get'.Str::studly($propertyName).'Attribute');
+
+        return new ModelProperty($classReflection, $method->getVariants()[0]->getReturnType());
+    }
+}

--- a/src/Properties/ModelProperty.php
+++ b/src/Properties/ModelProperty.php
@@ -19,7 +19,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 
-class ModelRelationProperty implements PropertyReflection
+class ModelProperty implements PropertyReflection
 {
     /**
      * @var ClassReflection

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -61,7 +61,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         $relatedModel = get_class($this->getContainer()->make($classReflection->getName())->{$propertyName}()->getRelated());
 
         if (Str::contains($relationClass, 'Many')) {
-            return new ModelRelationProperty(
+            return new ModelProperty(
                 $classReflection,
                 new IntersectionType([
                     new ObjectType(Collection::class),
@@ -70,13 +70,13 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         if (Str::endsWith($relationClass, 'MorphTo')) {
-            return new ModelRelationProperty($classReflection, new UnionType([
+            return new ModelProperty($classReflection, new UnionType([
                 new ObjectType(Model::class),
                 new MixedType(),
             ]));
         }
 
-        return new ModelRelationProperty($classReflection, new UnionType([
+        return new ModelProperty($classReflection, new UnionType([
             new ObjectType($relatedModel),
             new NullType(),
         ]));

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -197,6 +197,14 @@ class ModelExtension
     {
         return Thread::findAllFooBarThreads();
     }
+
+    public function testCustomAccessorOnModels() : string
+    {
+        /** @var Thread $thread */
+        $thread = Thread::findOrFail(5);
+
+        return $thread->custom_property;
+    }
 }
 
 function foo() : string
@@ -225,5 +233,10 @@ class Thread extends Model
     public static function findAllFooBarThreads()
     {
         return self::query()->where('foo', 'bar')->get();
+    }
+
+    public function getCustomPropertyAttribute() : string
+    {
+        return 'thread';
     }
 }


### PR DESCRIPTION
This PR adds support for Eloquent [model accessors](https://laravel.com/docs/6.x/eloquent-mutators#defining-an-accessor).