### PR TITLE
Fixed incorrect minimum php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Larastan was created by [Nuno Maduro](https://github.com/nunomaduro), got artwor
 ## ✨ Getting Started in 3 Steps
 
 > **Requires:**
-- **[PHP 7.1.3+](https://php.net/releases/)**
+- **[PHP 7.2+](https://php.net/releases/)**
 - **[Laravel 6.0+](https://github.com/laravel/laravel)**
 
 **1**: First, you may use [Composer](https://getcomposer.org) to install Larastan as a development dependency into your Laravel project:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "composer/composer": "^1.0",
         "illuminate/console": "^6.0 || ^7.0",
         "illuminate/container": "^6.0 || ^7.0",


### PR DESCRIPTION
Because this package depends on the illuminate 6/7 components, it cannot be installed on PHP 7.1. The real minimum version is 7.2.0.