### PR TITLE
Allow Larastan to work from PHPStan Docker image

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -13,7 +13,7 @@ parameters:
         - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
         # Ignore error from issue #244
         - '#Cannot call method viaRequest\(\) on Illuminate\\Auth\\AuthManager\|null\.#'
-    bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
+    bootstrap: %currentWorkingDirectory%/vendor/nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false
 
 services:


### PR DESCRIPTION
While trying to run Larastan from a Docker image (https://github.com/nunomaduro/larastan/issues/285), I was getting the error 

```
docker run --rm -v $(pwd):/app phpstan/phpstan analyse
Note: Using configuration file /app/phpstan.neon.
Bootstrap file /app/../../nunomaduro/larastan/bootstrap.php does not exist.
```

The reason for this is because the Docker image provided by phpstan has phpstan installed globally. When trying to navigate the folder structure, we end up looking for the bootstrap file in the global composer folder instead of the local one. By changing it to `currentWorkingDirectory`, I managed to successfully run Larastan from the PHPStan Docker. I also managed to run it from within the project itself as a test case and it seems to be working fine as well.