### PR TITLE
Add extension for app return type, including test cases.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -163,3 +163,8 @@ services:
         class: NunoMaduro\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.functionTypeSpecifyingExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\AppExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -15,6 +15,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Throwable;
@@ -58,6 +59,6 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
             return new ObjectType($expr->class->toString());
         }
 
-        return new ErrorType();
+        return new NeverType();
     }
 }

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -15,8 +15,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Throwable;
@@ -47,7 +45,7 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
                 $resolved = $this->resolve($expr->value);
 
                 if (is_null($resolved)) {
-                    return new NullType();
+                    return new ErrorType();
                 }
 
                 return new ObjectType(get_class($resolved));
@@ -60,6 +58,6 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
             return new ObjectType($expr->class->toString());
         }
 
-        return new MixedType();
+        return new ErrorType();
     }
 }

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -26,7 +26,7 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
-        return $functionReflection->getName() === 'app';
+        return $functionReflection->getName() === 'app' || $functionReflection->getName() === 'resolve';
     }
 
     public function getTypeFromFunctionCall(

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class AppExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'app';
+    }
+
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        $className = $this->getClassName($functionCall);
+
+        if ($className && class_exists($className)) {
+            return new ObjectType($className);
+        }
+
+        return new MixedType();
+    }
+
+    /**
+     * Returns a fully qualified path to a class, or null if it is not a class.
+     */
+    private function getClassName(FuncCall $functionCall): ?string
+    {
+        if (count($functionCall->args) === 0) {
+            return null;
+        }
+
+        /** @var ClassConstFetch $value */
+        $value = $functionCall->args[0]->value;
+
+        if (! $value->class instanceof FullyQualified) {
+            return null;
+        }
+
+        return $value->class->toString();
+    }
+}

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Throwable;
@@ -43,7 +44,13 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
 
         if ($expr instanceof String_) {
             try {
-                return new ObjectType(get_class($this->resolve($expr->value)));
+                $resolved = $this->resolve($expr->value);
+
+                if (is_null($resolved)) {
+                    return new NullType();
+                }
+
+                return new ObjectType(get_class($resolved));
             } catch (Throwable $exception) {
                 return new ErrorType();
             }

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
 namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
 
 use Illuminate\Foundation\Application;

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
 
+use Illuminate\Foundation\Application;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
@@ -41,7 +42,7 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
     private function getClassName(FuncCall $functionCall): ?string
     {
         if (count($functionCall->args) === 0) {
-            return null;
+            return Application::class;;
         }
 
         /** @var ClassConstFetch $value */

--- a/tests/Features/ReturnTypes/Helpers/AppExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AppExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes\Helpers;
 
+use Illuminate\Auth\AuthManager;
 use Illuminate\Foundation\Application;
 use NunoMaduro\Larastan\ApplicationResolver;
 
@@ -25,5 +26,10 @@ class AppExtension
     public function testMixedTypeFor()
     {
         return app('sentry');
+    }
+
+    public function testAuthString(): AuthManager
+    {
+        return app('auth');
     }
 }

--- a/tests/Features/ReturnTypes/Helpers/AppExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AppExtension.php
@@ -10,26 +10,44 @@ use NunoMaduro\Larastan\ApplicationResolver;
 
 class AppExtension
 {
-    public function testObjectType(): ApplicationResolver
-    {
-        return app(ApplicationResolver::class);
-    }
-
-    public function testMixedTypeNoArgument(): Application
+    public function testAppNoArgument(): Application
     {
         return app();
+    }
+
+    public function testAppObjectType(): ApplicationResolver
+    {
+        return app(ApplicationResolver::class);
     }
 
     /**
      * @return mixed
      */
-    public function testMixedTypeFor()
+    public function testAppMixedType()
     {
         return app('sentry');
     }
 
-    public function testAuthString(): AuthManager
+    public function testAppAuthString(): AuthManager
     {
         return app('auth');
+    }
+
+    public function testResolveObjectType(): ApplicationResolver
+    {
+        return resolve(ApplicationResolver::class);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testResolveMixedType()
+    {
+        return resolve('sentry');
+    }
+
+    public function testResolveAuthString(): AuthManager
+    {
+        return resolve('auth');
     }
 }

--- a/tests/Features/ReturnTypes/Helpers/AppExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AppExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes\Helpers;
 
+use Illuminate\Foundation\Application;
 use NunoMaduro\Larastan\ApplicationResolver;
 
 class AppExtension
@@ -13,10 +14,7 @@ class AppExtension
         return app(ApplicationResolver::class);
     }
 
-    /**
-     * @return mixed
-     */
-    public function testMixedTypeNoArgument()
+    public function testMixedTypeNoArgument(): Application
     {
         return app();
     }

--- a/tests/Features/ReturnTypes/Helpers/AppExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AppExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use NunoMaduro\Larastan\ApplicationResolver;
+
+class AppExtension
+{
+    public function testObjectType(): ApplicationResolver
+    {
+        return app(ApplicationResolver::class);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testMixedTypeNoArgument()
+    {
+        return app();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testMixedTypeFor()
+    {
+        return app('sentry');
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/AppExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AppExtension.php
@@ -33,6 +33,17 @@ class AppExtension
         return app('auth');
     }
 
+    /**
+     * @return null
+     */
+    public function testAppNull()
+    {
+        app()->bind('null', function () {
+        });
+
+        return app('null');
+    }
+
     public function testResolveObjectType(): ApplicationResolver
     {
         return resolve(ApplicationResolver::class);
@@ -49,5 +60,16 @@ class AppExtension
     public function testResolveAuthString(): AuthManager
     {
         return resolve('auth');
+    }
+
+    /**
+     * @return null
+     */
+    public function testResolveNull()
+    {
+        app()->bind('null', function () {
+        });
+
+        return resolve('null');
     }
 }


### PR DESCRIPTION
I have added a simple return type extension for the `app()` helper.
Fully qualified classes will be resolved to the class itself. Unknown types, e.g. 'sentry' or 'db', will be resolved to `MixedType`.

This will allow checking for method calls directly on app(), so that e.g.

```php
/** @var Handler $handler */
$handler = app(Handler::class);
$handler->capture($exception);
```

can be simplified to

```php
app(Handler::class)->capture($exception);
```
and still be verified by larastan.