### PR TITLE
feat: support for changing used date class

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -156,6 +156,11 @@ services:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\NowAndTodayExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.functionTypeSpecifyingExtension

--- a/src/ReturnTypes/Helpers/NowAndTodayExtension.php
+++ b/src/ReturnTypes/Helpers/NowAndTodayExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Larastan.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @internal
+ */
+final class NowAndTodayExtension implements DynamicFunctionReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'now' || $functionReflection->getName() === 'today';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        return new ObjectType(get_class(now()));
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/NowAndTodayExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/NowAndTodayExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+
+class NowAndTodayExtension
+{
+    public function testNowReturnsSupportCarbonByDefault(): Carbon
+    {
+        return now();
+    }
+
+    public function testTodayReturnsSupportCarbonByDefault(): Carbon
+    {
+        return today();
+    }
+
+    public function testNowCanReturnImmutableCarbon(): CarbonImmutable
+    {
+        Date::use(CarbonImmutable::class);
+
+        return now();
+    }
+
+    public function testTodayReturnImmutableCarbon(): CarbonImmutable
+    {
+        Date::use(CarbonImmutable::class);
+
+        return today();
+    }
+}


### PR DESCRIPTION
Fixes #421 

I did not find an easy way to test this. I tested it in a separate Laravel project and it works. I tried putting the `Data::use(...)` inside the `getEnvironmentSetup` in `FeaturesTest` But that didn't work.

One idea is to create a new test case just for this, and a service provider. Put `Data::use(...)` in the service provider. And register the service provider in the test with `getPackageProviders` But that seemed a really long shot :stuck_out_tongue: 

I'm open to any ideas.