### PR TITLE
feat: add generics for Collection

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,10 @@
 parameters:
     stubFiles:
+        - stubs/Enumerable.stub
         - stubs/EloquentBuilder.stub
+        - stubs/Collection.stub
+        - stubs/EloquentCollection.stub
+        - stubs/Model.stub
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
         - Illuminate\Http\Resources\Json\JsonResource

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -24,8 +24,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\IterableType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
@@ -67,10 +66,9 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         if (Str::contains($relationClass, 'Many')) {
             return new ModelProperty(
                 $classReflection,
-                new IntersectionType([
-                    new ObjectType(Collection::class),
-                    new IterableType(new MixedType(), new ObjectType($relatedModel)),
-                ]), new NeverType(), false);
+                new GenericObjectType(Collection::class, [new ObjectType($relatedModel)]),
+                new NeverType(), false
+            );
         }
 
         if (Str::endsWith($relationClass, 'MorphTo')) {

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @template TKey
+ * @template TValue
+ * @implements \ArrayAccess<TKey, TValue>
+ * @implements Enumerable<TKey, TValue>
+ */
+class Collection implements \ArrayAccess, Enumerable
+{
+    /**
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return TValue|null
+     */
+    public function first(callable $callback = null, $default = null){}
+
+    /**
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return TValue|null
+     */
+    public function last(callable $callback = null, $default = null){}
+
+
+    /**
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return TValue|null
+     */
+    public function get($key, $default = null) {}
+
+    /**
+     * @return TValue|null
+     */
+    public function pop() {}
+
+    /**
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return TValue|null
+     */
+    public function pull($key, $default = null) {}
+
+    /**
+     * @param mixed $value
+     * @param bool  $strict
+     * @return TKey|false
+     */
+    public function search($value, $strict = false) {}
+
+    /**
+     * @return TValue|null
+     */
+    public function shift() {}
+}

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @template TModel of Model
+ * @extends \Illuminate\Support\Collection<int, TModel>
+ */
+class Collection extends \Illuminate\Support\Collection
+{
+    /**
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @phpstan-return TModel|null
+     */
+    public function find($key, $default = null) {}
+}

--- a/stubs/Enumerable.stub
+++ b/stubs/Enumerable.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @template TKey
+ * @template TValue
+ *
+ * @extends \IteratorAggregate<TKey, TValue>
+ */
+interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable {}

--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @implements \ArrayAccess<string, mixed>
+ */
+abstract class Model implements \JsonSerializable, \ArrayAccess {}

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -13,8 +13,7 @@ use Illuminate\Foundation\Http\FormRequest;
 class ModelExtension
 {
     /**
-     * @phpstan-return iterable<User>|\Illuminate\Database\Eloquent\Collection<User>
-     * @return iterable<User>|\Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<User>
      */
     public function testAll()
     {
@@ -83,13 +82,13 @@ class ModelExtension
         return User::find([1, 2, 3]);
     }
 
-    /** @return iterable<User>|null */
+    /** @return Collection<User>|null */
     public function testFindCanReturnCollectionWithAnnotation()
     {
         return User::find([1, 2, 3]);
     }
 
-    /** @return iterable<User> */
+    /** @return Collection<User>|null */
     public function testFindMany()
     {
         return User::findMany([1, 2, 3]);
@@ -163,11 +162,16 @@ class ModelExtension
     }
 
     /**
-     * @return Collection<\App\User>
+     * @return Collection<User>
      */
     public function testChainingCollectionMethodsOnModel(): Collection
     {
         return User::findOrFail([1, 2, 3])->makeHidden('foo');
+    }
+
+    public function testCollectionMethodWillReturnUser(): ?User
+    {
+        return User::findOrFail([1, 2, 3])->makeHidden('foo')->first();
     }
 
     public function testFirstOrFailWithChain(): User

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Tests\Features\Properties;
 
 use App\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Collection;
 
 class ModelRelationsExtension
 {
-    /** @return iterable<OtherDummyModel>&Collection */
+    /** @return Collection<OtherDummyModel> */
     public function testHasMany()
     {
         /** @var DummyModel $dummyModel */
@@ -37,7 +37,7 @@ class ModelRelationsExtension
         return new OtherDummyModel;
     }
 
-    /** @return iterable<OtherDummyModel>&Collection */
+    /** @return Collection<OtherDummyModel> */
     public function testHasManyThroughRelation()
     {
         /** @var DummyModel $dummyModel */
@@ -78,6 +78,33 @@ class ModelRelationsExtension
         $otherDummyModel = OtherDummyModel::firstOrFail();
 
         return $otherDummyModel->belongsToRelationWithoutNull;
+    }
+
+    public function testCollectionMethodFirstOnRelation(): ?OtherDummyModel
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        return $dummyModel->hasManyRelation->first();
+    }
+
+    public function testCollectionMethodFindOnRelation(): ?OtherDummyModel
+    {
+        /** @var DummyModel $dummyModel */
+        $dummyModel = DummyModel::firstOrFail();
+
+        return $dummyModel->hasManyRelation->find(1);
+    }
+
+    public function testModelRelationForeach(DummyModel $dummyModel): ?OtherDummyModel
+    {
+        foreach ($dummyModel->hasManyRelation as $item) {
+            if (random_int(0, 1)) {
+                return $item;
+            }
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
This PR adds stubs for the Laravel `Collection`.This will allow us to infer types in the collections for example returned by relationship. Like, `$user->accounts->first()` would return `Account`

Combined with the #435 this can be really good.

This should be merged after #435, and I want to do more testing.