### PR TITLE
Fix service provider detection

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -39,10 +39,10 @@ final class ApplicationResolver
 
         if (file_exists($composerFile)) {
             $namespace = (string) key(json_decode((string) file_get_contents($composerFile), true)['autoload']['psr-4']);
-            /* @var class-string $class */
             $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace), function (string $class) use (
                 $namespace
             ) {
+                /** @var class-string $class */
                 return substr($class, 0, strlen($namespace)) === $namespace && self::isServiceProvider($class);
             }));
 

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -39,7 +39,7 @@ final class ApplicationResolver
 
         if (file_exists($composerFile)) {
             $namespace = (string) key(json_decode((string) file_get_contents($composerFile), true)['autoload']['psr-4']);
-
+            /* @var class-string $class */
             $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace), function (string $class) use (
                 $namespace
             ) {

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -66,10 +66,12 @@ final class ApplicationResolver
      * @param  string $class
      *
      * @return bool
+     * @throws \ReflectionException
      */
     private static function isServiceProvider($class): bool
     {
-        return in_array(\Illuminate\Support\ServiceProvider::class, class_parents($class), true);
+        return in_array(\Illuminate\Support\ServiceProvider::class, class_parents($class), true) &&
+               !((new \ReflectionClass($class))->isAbstract());
     }
 
     /**

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -63,12 +63,12 @@ final class ApplicationResolver
     }
 
     /**
-     * @param  string $class
+     * @phpstan-param class-string $class
      *
      * @return bool
      * @throws \ReflectionException
      */
-    private static function isServiceProvider($class): bool
+    private static function isServiceProvider(string $class): bool
     {
         return in_array(\Illuminate\Support\ServiceProvider::class, class_parents($class), true) &&
                ! ((new \ReflectionClass($class))->isAbstract());

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -71,7 +71,7 @@ final class ApplicationResolver
     private static function isServiceProvider($class): bool
     {
         return in_array(\Illuminate\Support\ServiceProvider::class, class_parents($class), true) &&
-               !((new \ReflectionClass($class))->isAbstract());
+               ! ((new \ReflectionClass($class))->isAbstract());
     }
 
     /**

--- a/tests/Application/app/Providers/AbstractProvider.php
+++ b/tests/Application/app/Providers/AbstractProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+abstract class AbstractProvider extends ServiceProvider
+{
+
+}

--- a/tests/Application/app/Providers/AbstractProvider.php
+++ b/tests/Application/app/Providers/AbstractProvider.php
@@ -8,5 +8,4 @@ use Illuminate\Support\ServiceProvider;
 
 abstract class AbstractProvider extends ServiceProvider
 {
-
 }

--- a/tests/Application/app/Providers/ConcreteProvider.php
+++ b/tests/Application/app/Providers/ConcreteProvider.php
@@ -6,5 +6,4 @@ namespace App\Providers;
 
 class ConcreteProvider extends AbstractProvider
 {
-
 }

--- a/tests/Application/app/Providers/ConcreteProvider.php
+++ b/tests/Application/app/Providers/ConcreteProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+class ConcreteProvider extends AbstractProvider
+{
+
+}


### PR DESCRIPTION
Back in Oct 2019, my original changes (#318 )  to introduce service provider detection implicitly assumed all such providers were concrete.

My own work since has falsified that assumption, so I'm tightening the requirements here.