### PR TITLE
feat: return type support for get on relations

### DIFF
--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Group extends Model
+{
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -37,6 +38,11 @@ class User extends Authenticatable
     public function scopeActive(Builder $query): Builder
     {
         return $query->where('active', 1);
+    }
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
     }
 
     public function accounts(): HasMany

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Features\Models;
 
 use App\Account;
+use App\Group;
 use App\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
@@ -112,14 +113,32 @@ class Relations
     }
 
     /**
-     * @phpstan-return Collection<\App\Account>|null
+     * @phpstan-return Collection<Account>
      */
-    public function testGetModelScopesOnRelation(): ?Collection
+    public function testGetModelScopesOnRelation(): Collection
     {
         /** @var User $user */
         $user = new User;
 
         return $user->accounts()->active()->get();
+    }
+
+    /**
+     * @param User $user
+     *
+     * @return Collection<Account>
+     */
+    public function testGetOnRelationAndBuilder(User $user): Collection
+    {
+        /** @var Group $group */
+        $group = $user->group;
+
+        return $group->accounts()->where('active', 1)->get();
+    }
+
+    public function testMakeOnRelation(User $user): Account
+    {
+        return $user->accounts()->make();
     }
 
     private function getUser(): User


### PR DESCRIPTION
With the generics added for collections, now we can infer the types of relationship collections better. For example, now we know `$user->accounts()->where('active', 1)->get();` returns a collection of accounts.