### PR TITLE
fix: model scopes returns builder if scope return type is void

### DIFF
--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -27,6 +27,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 
 final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
@@ -97,7 +98,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             }
         }
 
-        if ($modelType instanceof ObjectType && in_array($methodReflection->getName(), array_merge(ModelForwardsCallsExtension::MODEL_CREATION_METHODS, ModelForwardsCallsExtension::MODEL_RETRIEVAL_METHODS), true)) {
+        if (($modelType instanceof ObjectType || $modelType instanceof ThisType) && in_array($methodReflection->getName(), array_merge(ModelForwardsCallsExtension::MODEL_CREATION_METHODS, ModelForwardsCallsExtension::MODEL_RETRIEVAL_METHODS), true)) {
             return ModelTypeHelper::replaceStaticTypeWithModel($methodReflection->getVariants()[0]->getReturnType(), $modelType->getClassName());
         }
 

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -43,4 +43,19 @@ class Scopes extends Model
 
         return $this->user->where('foo', 'bar')->active()->first();
     }
+
+    public function testVoidScopeStillReturnsBuilder(): Builder
+    {
+        return $this->withVoidReturn();
+    }
+
+    public function testVoidScopeStillHasGenericBuilder(): ?Scopes
+    {
+        return $this->withVoidReturn()->first();
+    }
+
+    public function scopeWithVoidReturn(Builder $query): void
+    {
+        $query->where('whyuse', 'void');
+    }
 }


### PR DESCRIPTION
Fixes #448 

If the return type of a local model scope is `void`, Larasan will return the builder.