### PR TITLE
Return correct collection instance when calling all

### DIFF
--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -110,8 +110,7 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
             $returnType = new GenericObjectType(EloquentBuilder::class, [new ObjectType($scope->resolveName($methodCall->class))]);
         }
 
-        if ((count(in_array(Collection::class, $returnType->getReferencedClasses())) > 0)
-            && $methodCall->name->name === 'all'
+        if (in_array(Collection::class, $returnType->getReferencedClasses()) && $methodCall->name->name === 'all'
         ) {
             $returnType = new IntersectionType([new ObjectType(\Illuminate\Support\Collection::class), $returnType->getTypes()[1]]);
         }

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -18,6 +18,7 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionClass;
@@ -107,6 +108,12 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
             && $methodCall->class instanceof \PhpParser\Node\Name
         ) {
             $returnType = new GenericObjectType(EloquentBuilder::class, [new ObjectType($scope->resolveName($methodCall->class))]);
+        }
+
+        if ((count(in_array(Collection::class, $returnType->getReferencedClasses())) > 0)
+            && $methodCall->name->name === 'all'
+        ) {
+            $returnType = new IntersectionType([new ObjectType(\Illuminate\Support\Collection::class), $returnType->getTypes()[1]]);
         }
 
         return $returnType;

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -18,7 +18,6 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionClass;

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -110,7 +110,7 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
             $returnType = new GenericObjectType(EloquentBuilder::class, [new ObjectType($scope->resolveName($methodCall->class))]);
         }
 
-        if (in_array(Collection::class, $returnType->getReferencedClasses()) && $methodCall->name->name === 'all') {
+        if (in_array(Collection::class, $returnType->getReferencedClasses(), true) && $methodCall->name->name === 'all') {
             $returnType = new IntersectionType([new ObjectType(\Illuminate\Support\Collection::class), $returnType->getTypes()[1]]);
         }
 

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -110,8 +110,8 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
             $returnType = new GenericObjectType(EloquentBuilder::class, [new ObjectType($scope->resolveName($methodCall->class))]);
         }
 
-        if (in_array(Collection::class, $returnType->getReferencedClasses(), true) && $methodCall->name->name === 'all') {
-            $returnType = new IntersectionType([new ObjectType(\Illuminate\Support\Collection::class), $returnType->getTypes()[1]]);
+        if ($methodReflection->getName() === 'all' && in_array(Collection::class, $returnType->getReferencedClasses(), true) && $methodCall->class instanceof \PhpParser\Node\Name) {
+            $returnType = new GenericObjectType(Collection::class, [new ObjectType($scope->resolveName($methodCall->class))]);
         }
 
         return $returnType;

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -110,8 +110,7 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
             $returnType = new GenericObjectType(EloquentBuilder::class, [new ObjectType($scope->resolveName($methodCall->class))]);
         }
 
-        if (in_array(Collection::class, $returnType->getReferencedClasses()) && $methodCall->name->name === 'all'
-        ) {
+        if (in_array(Collection::class, $returnType->getReferencedClasses()) && $methodCall->name->name === 'all') {
             $returnType = new IntersectionType([new ObjectType(\Illuminate\Support\Collection::class), $returnType->getTypes()[1]]);
         }
 

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -13,11 +13,16 @@ use Illuminate\Foundation\Http\FormRequest;
 class ModelExtension
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Collection<User>
+     * @return \Illuminate\Support\Collection<User>
      */
     public function testAll()
     {
         return User::all();
+    }
+
+    public function testAllFirst(): ?User
+    {
+        return User::all()->first();
     }
 
     public function testReturnThis(): Builder

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Http\FormRequest;
 class ModelExtension
 {
     /**
-     * @return \Illuminate\Support\Collection<User>
+     * @return \Illuminate\Database\Eloquent\Collection<User>
      */
     public function testAll()
     {


### PR DESCRIPTION
Fixes #452 

Calling `User::all();` returned a `Eloquent/Collection`. This PR makes sure a `Support/Collection` is returned so that `User::all()->first()` returns a `User|null`.
