### PR TITLE
fix: eloquent builders returns generic builder

### DIFF
--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -74,6 +74,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
     {
         $builderHelper = new BuilderHelper($this->getBroker());
         $customBuilderName = $builderHelper->determineBuilderType($originalModelReflection->getName());
+
         $returnMethodReflection = $builderHelper->getMethodReflectionFromBuilder(
             $originalModelReflection,
             $methodName,

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -231,18 +231,7 @@ class Thread extends Model
 
     public static function testFindOnStaticSelf(): ?Thread
     {
-        return self::valid()->first();
-    }
-
-    public static function testFindOnStatic(): ?Thread
-    {
-        return static::valid()->first();
-    }
-
-    /** @return iterable<Thread>&Collection */
-    public static function findAllFooBarThreads()
-    {
-        return self::query()->where('foo', 'bar')->get();
+        return self::query()->where('foo', 'bar')->get()->first();
     }
 
     public function getCustomPropertyAttribute(): string

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -11,19 +11,19 @@ use Illuminate\Database\Eloquent\Model;
 
 class BuilderExtension
 {
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testCallingGetOnModelWithStaticQueryBuilder(): Collection
     {
         return User::where('id', 1)->get();
     }
 
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testCallingGetOnModelWithVariableQueryBuilder(): Collection
     {
         return (new User)->where('id', 1)->get();
     }
 
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testCallingLongGetChainOnModelWithStaticQueryBuilder(): Collection
     {
         return User::where('id', 1)
@@ -33,7 +33,7 @@ class BuilderExtension
             ->get();
     }
 
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testCallingLongGetChainOnModelWithVariableQueryBuilder(): Collection
     {
         return (new User)->whereNotNull('active')
@@ -42,7 +42,7 @@ class BuilderExtension
             ->get();
     }
 
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testCallingGetOnModelWithVariableQueryBuilder2(): Collection
     {
         $user = new User;
@@ -50,7 +50,7 @@ class BuilderExtension
         return $user->where('test', 1)->get();
     }
 
-    /** @return Collection|User[] */
+    /** @return Collection<User> */
     public function testUsingCollectionMethodsAfterGet(): Collection
     {
         return User::whereIn('id', [1, 2, 3])->get()->mapWithKeys('key');
@@ -73,6 +73,24 @@ class BuilderExtension
         $user = new User;
 
         return $user->where('test', 1)->exists();
+    }
+
+    /**
+     * @phpstan-return Builder<User>
+     */
+    public function testWith(): Builder
+    {
+        return User::with('foo')->whereNull('bar');
+    }
+
+    /**
+     * @phpstan-return Builder<User>
+     */
+    public function testWithWithBuilderMethods(): Builder
+    {
+        return User::with('foo')
+            ->where('foo', 'bar')
+            ->orWhere('bar', 'baz');
     }
 }
 

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -10,6 +10,16 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CustomEloquentBuilderTest
 {
+    public function testModelWithCustomBuilderReturnsCorrectModelAfterBuilderMethod(): ?ModelWithCustomBuilder
+    {
+        return ModelWithCustomBuilder::where('foo', 'bar')->first();
+    }
+
+    public function testEloquentBuilderMethodReturnsCustomBuilder(): CustomBuilder
+    {
+        return ModelWithCustomBuilder::with('foo')->where('foo', 'bar');
+    }
+
     public function testModelScopeReturnsCustomBuilder(): CustomBuilder
     {
         return ModelWithCustomBuilder::foo('foo')->foo('bar');
@@ -40,6 +50,13 @@ class CustomEloquentBuilderTest
     public function testFindAfterCustomBuilderMethodAfterDynamicWhere(): ?ModelWithCustomBuilder
     {
         return ModelWithCustomBuilder::whereFoo(['bar'])->type('foo')->first();
+    }
+
+    public function testFindAfterCustomBuilderMethodAfterDynamicWhereOnExistingVariable(): ?ModelWithCustomBuilder
+    {
+        $query = ModelWithCustomBuilder::whereFoo(['bar'])->type('foo');
+
+        return $query->first();
     }
 }
 


### PR DESCRIPTION
Fixes #455 and #456

This PR makes sure that any builder method called on Eloquent Builder returns the generic builder.