### PR TITLE
feature:generic resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Support for eloquent resources. Thanks @mr-feek ([#470](https://github.com/nunomaduro/larastan/pull/470))
+
 ## [0.5.2] - 2020-02-10
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,20 @@
 # Upgrade Guide
 
+## Next
+
+#### Eloquent Resources
+In order to perform proper analysis on your eloquent resources, you must typehint the underlying eloquent model class.
+This will inform phpstan that only objects of type `User` will be accepted in this resource.
+
+```bash
+/**
+ * @extends JsonResource<User>
+ */
+class UserResource extends JsonResource
+...
+
+```
+
 ## Upgrading To 0.5.1 From 0.5.0
 
 #### Eloquent Model property types

--- a/extension.neon
+++ b/extension.neon
@@ -5,9 +5,9 @@ parameters:
         - stubs/Collection.stub
         - stubs/EloquentCollection.stub
         - stubs/Model.stub
+        - stubs/JsonResource.stub
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
-        - Illuminate\Http\Resources\Json\JsonResource
         - Illuminate\Http\Request
     excludes_analyse:
         - *.blade.php
@@ -115,6 +115,14 @@ services:
         class: NunoMaduro\Larastan\ReturnTypes\EloquentBuilderExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: NunoMaduro\Larastan\Properties\JsonResourceExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+    -
+        class: NunoMaduro\Larastan\Properties\JsonResourceExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\ReturnTypes\TestCaseExtension

--- a/src/Properties/JsonResourceExtension.php
+++ b/src/Properties/JsonResourceExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace NunoMaduro\Larastan\Properties;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
+use PHPStan\Reflection\Dummy\DummyPropertyReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Type\ObjectType;
+
+class JsonResourceExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension
+{
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (! $classReflection->isSubclassOf(JsonResource::class)) {
+            return false;
+        }
+
+        $modelClassReflection = $this->getModelClassReflection($classReflection);
+
+        if (! $modelClassReflection) {
+            return false;
+        }
+
+        return $modelClassReflection->hasMethod($methodName);
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): \PHPStan\Reflection\MethodReflection
+    {
+        $modelClassReflection = $this->getModelClassReflection($classReflection);
+
+        if (! $modelClassReflection) {
+            return new DummyMethodReflection($methodName);
+        }
+
+        return $modelClassReflection->getMethod($methodName, new OutOfClassScope());
+    }
+
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (! $classReflection->isSubclassOf(JsonResource::class)) {
+            return false;
+        }
+
+        $modelClassReflection = $this->getModelClassReflection($classReflection);
+
+        if (! $modelClassReflection) {
+            return false;
+        }
+
+        return $modelClassReflection->hasProperty($propertyName);
+    }
+
+    public function getProperty(ClassReflection $classReflection, string $propertyName): \PHPStan\Reflection\PropertyReflection
+    {
+        $modelClassReflection = $this->getModelClassReflection($classReflection);
+
+        if (! $modelClassReflection) {
+            return new DummyPropertyReflection();
+        }
+
+        return $modelClassReflection->getProperty($propertyName, new OutOfClassScope());
+    }
+
+    private function getModelClassReflection(ClassReflection $classReflection): ?ClassReflection
+    {
+        $templateTypeMap = $classReflection->getParents()[0]->getActiveTemplateTypeMap();
+
+        $modelType = $templateTypeMap->getType('TModelClass');
+
+        if (! $modelType || ! $modelType instanceof ObjectType || ! $modelType->getClassReflection()) {
+            return null;
+        }
+
+        return $modelType->getClassReflection();
+    }
+}

--- a/stubs/JsonResource.stub
+++ b/stubs/JsonResource.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Http\Resources\Json;
+
+/**
+ * @template TModelClass
+ * @implements \ArrayAccess<string, mixed>
+ */
+class JsonResource implements \ArrayAccess
+{
+    /**
+     * @var TModelClass
+     */
+    public $resource;
+
+    /**
+     * @param TModelClass $resource
+     */
+    public function __construct($resource)
+    {
+    }
+}

--- a/tests/Application/app/UserResource.php
+++ b/tests/Application/app/UserResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @extends JsonResource<User>
+ */
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'meta'  => json_decode($this->meta),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'has_verified_email' => $this->hasVerifiedEmail(),
+        ];
+    }
+}

--- a/tests/Features/Properties/JsonResourceExtension.php
+++ b/tests/Features/Properties/JsonResourceExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Features\Properties;
+
+use App\User;
+use App\UserResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class JsonResourceExtension
+{
+    /**
+     * @test
+     * @return JsonResource<User>
+     */
+    public function resources_proxy_to_underlying_model_type(): JsonResource
+    {
+        $user = new User();
+        $resource = new UserResource($user);
+        $array = $resource->toArray(new Request());
+        $id = $resource->id;
+        $hasVerifiedEmail = $resource->hasVerifiedEmail();
+
+        return $resource;
+    }
+
+    /** @test */
+    public function resource_property_types_are_correct(): int
+    {
+        $user = new User();
+        $resource = new UserResource($user);
+
+        return $resource->id;
+    }
+}

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -64,7 +64,7 @@ class FeaturesTest extends TestCase
 
         $result = json_decode($jsonResult[0], true);
 
-        if ($result['totals']['errors'] > 0 || $result['totals']['file_errors'] > 0) {
+        if (! $result || $result['totals']['errors'] > 0 || $result['totals']['file_errors'] > 0) {
             $this->fail($jsonResult[0]);
         }
 


### PR DESCRIPTION
resolves #437 

I'm opening this up now to get feedback on if I am implementing correctly. I would appreciate some guidance as this is my first time working with generics and understanding what phpstan does behind the scenes.

### Open Questions
- [x] How do I implement `getMethod` and `getProperty`. Off the top of my head, I would think `return $modelType->getMethod($methodName);` however this requires a `\PHPStan\Reflection\ClassMemberAccessAnswerer` parameter, and I'm not sure what that is or how to resolve it.
- [ ] How do I test my extension correctly catches failing statements? IE I want to ensure `$resource->foo()` is caught as an error. 

### Improvements
- [x] **NOT POSSIBLE:**  Is there a way we can infer the type passed to a `Resource` without having to declare 
```
/**
 * @extends JsonResource<User>
 */
```
At the top of resources? This is not ideal, and can hopefully be circumvented. I'm not sure how. 
- [ ] Along with the above,  ideally I would think `$templateTypeMap = $classReflection->getActiveTemplateTypeMap();`  would resolve the model type, rather than having to fetch it via the first parent...