### PR TITLE
fix: dynamic wheres can have a mixed parameter

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -14,7 +14,9 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -53,11 +55,17 @@ class BuilderHelper
         /** @var FunctionVariantWithPhpDocs $originalDynamicWhereVariant */
         $originalDynamicWhereVariant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
 
+        /** @var \PHPStan\Reflection\ParameterReflectionWithPhpDocs $originalParameter */
+        $originalParameter = $originalDynamicWhereVariant->getParameters()[1];
+
+        $actualParameter = new DummyParameter($originalParameter->getName(), new MixedType(), $originalParameter->isOptional(), $originalParameter->passedByReference(), $originalParameter->isVariadic(), $originalParameter->getDefaultValue());
+
         return new EloquentBuilderMethodReflection(
             $methodName,
             $classReflection,
-            [$originalDynamicWhereVariant->getParameters()[1]],
-            $returnObject
+            [$actualParameter],
+            $returnObject,
+            true
         );
     }
 

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -13,4 +13,19 @@ class Builder
     {
         return User::query()->groupBy('foo', 'bar');
     }
+
+    public function testDynamicWhereAsString(): ?User
+    {
+        return (new User())->whereFoo('bar')->first();
+    }
+
+    public function testDynamicWhereMultiple(): ?User
+    {
+        return User::whereIdAndEmail(1, 'foo@example.com')->first();
+    }
+
+    public function testDynamicWhereAsInt(): ?User
+    {
+        return (new User())->whereFoo(1)->first();
+    }
 }


### PR DESCRIPTION
fixes https://github.com/nunomaduro/larastan/issues/475

I'm not sure if I've implemented this properly, but the test passes.

Basically the parameter should be a mixed type, instead of just `array` when `dynamicWhere` is invoked via the  `ForwardsCalls` trait on the model