### PR TITLE
Fix symfony 5 compatibility by allowing composer 1.10.0-RC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "composer/composer": "^1.0",
+        "composer/composer": "^1.0 || 1.10.0-RC",
         "illuminate/console": "^6.0 || ^7.0",
         "illuminate/container": "^6.0 || ^7.0",
         "illuminate/contracts": "^6.0 || ^7.0",


### PR DESCRIPTION
Laravel 7 has a hard requirement for Symfony 5, which is only supported in this RC version of composer.