### PR TITLE
Fixes handler method return type for Lumen

### DIFF
--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -30,6 +30,10 @@ echo "Add package from source"
 sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan" } ],|' -i composer.json
 travis_retry composer require --dev "nunomaduro/larastan:*"
 
+echo 'Fix Handler::render return type'
+sed -e 's/@return \\Illuminate\\Http\\Response|\\Illuminate\\Http\\JsonResponse$/@return \\Symfony\\Component\\HttpFoundation\\Response/' \
+    -i app/Exceptions/Handler.php
+
 echo "Add Larastan to Lumen"
 cat <<"EOF" | patch -p 0
 --- bootstrap/app.php     2019-02-15 12:31:48.469773495 +0000

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -30,7 +30,7 @@ echo "Add package from source"
 sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan" } ],|' -i composer.json
 travis_retry composer require --dev "nunomaduro/larastan:*"
 
-echo 'Fix Handler::render return type'
+echo "Fix Handler::render return type"
 sed -e 's/@return \\Illuminate\\Http\\Response|\\Illuminate\\Http\\JsonResponse$/@return \\Symfony\\Component\\HttpFoundation\\Response/' \
     -i app/Exceptions/Handler.php
 


### PR DESCRIPTION
The PR I made got rejected: https://github.com/laravel/lumen/pull/146 Even though the same docblock is changed in `laravel/laravel` [repo](https://github.com/laravel/laravel/blob/master/app/Exceptions/Handler.php#L47) with [this](https://github.com/laravel/laravel/pull/5187) PR  :man_shrugging: 

So I'm adding another change to the test script, just like the one [we have](https://github.com/nunomaduro/larastan/blob/master/tests/laravel-test.sh#L14) before.