### PR TITLE
Transform ide-helper style builder docblock to generic docblocks

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -174,3 +174,8 @@ services:
         class: NunoMaduro\Larastan\Types\GenericEloquentCollectionTypeNodeResolverExtension
         tags:
             - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
+        class: NunoMaduro\Larastan\Types\GenericEloquentBuilderTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension

--- a/src/Types/GenericEloquentBuilderTypeNodeResolverExtension.php
+++ b/src/Types/GenericEloquentBuilderTypeNodeResolverExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use function count;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class GenericEloquentBuilderTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if (! $typeNode instanceof UnionTypeNode || count($typeNode->types) !== 2) {
+            return null;
+        }
+
+        $modelTypeNode = null;
+        $builderTypeNode = null;
+        foreach ($typeNode->types as $innerTypeNode) {
+            if ($innerTypeNode instanceof IdentifierTypeNode
+                && is_subclass_of($nameScope->resolveStringName($innerTypeNode->name), Model::class)
+            ) {
+                $modelTypeNode = $innerTypeNode;
+                continue;
+            }
+
+            if (
+                $innerTypeNode instanceof IdentifierTypeNode
+                && ($nameScope->resolveStringName($innerTypeNode->name) === Builder::class || is_subclass_of($nameScope->resolveStringName($innerTypeNode->name), Builder::class))
+            ) {
+                $builderTypeNode = $innerTypeNode;
+            }
+        }
+
+        if ($modelTypeNode === null || $builderTypeNode === null) {
+            return null;
+        }
+
+        $builderTypeName = $nameScope->resolveStringName($builderTypeNode->name);
+        $modelTypeName = $nameScope->resolveStringName($modelTypeNode->name);
+
+        return new GenericObjectType($builderTypeName, [
+            new ObjectType($modelTypeName),
+        ]);
+    }
+}

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -130,3 +130,56 @@ class CustomBuilder extends Builder
         return $this->whereIn('category', $categories);
     }
 }
+
+class CustomEloquentBuilderTest1
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection<\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks>
+     */
+    public function testGetModelFromModelWithCustomBuilderQuery()
+    {
+        return ModelWithCustomBuilderAndDocBlocks::query()->get();
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection<\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks>
+     */
+    public function testAllModelFromModelWithCustomBuilderQuery()
+    {
+        return ModelWithCustomBuilderAndDocBlocks::all();
+    }
+
+    /**
+     * @return CustomBuilder2<\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks>
+     */
+    public function testQueryModelFromModelWithCustomBuilderQuery()
+    {
+        return ModelWithCustomBuilderAndDocBlocks::query();
+    }
+}
+
+/**
+ * @method static \Tests\Features\ReturnTypes\CustomBuilder2|\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks newModelQuery()
+ * @method static \Tests\Features\ReturnTypes\CustomBuilder2|\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks newQuery()
+ * @method static \Tests\Features\ReturnTypes\CustomBuilder2|\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks query()
+ */
+class ModelWithCustomBuilderAndDocBlocks extends Model
+{
+    /**
+     * @param \Illuminate\Database\Query\Builder $query
+     *
+     * @return CustomBuilder2<\Tests\Features\ReturnTypes\ModelWithCustomBuilderAndDocBlocks>
+     */
+    public function newEloquentBuilder($query): CustomBuilder2
+    {
+        return new CustomBuilder2($query);
+    }
+}
+
+/**
+ * @template TModelClass
+ * @extends Builder<TModelClass>
+ */
+class CustomBuilder2 extends Builder
+{
+}


### PR DESCRIPTION
Fixes #461 

It is the same idea from #479 And it was discussed at #461

Basically, it converts `\Illuminate\Database\Eloquent\Builder|\App\User` into `\Illuminate\Database\Eloquent\Builder<\App\User>`