### PR TITLE
Fatal error when migrations folder does not exist

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -100,6 +100,10 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
 
     private function initializeTables(): void
     {
+        if (! is_dir(database_path().'/migrations')) {
+            return;
+        }
+        
         $schemaAggregator = new SchemaAggregator();
         $files = $this->getMigrationFiles(database_path().'/migrations');
         $filesArray = iterator_to_array($files);

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -103,7 +103,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
         if (! is_dir(database_path().'/migrations')) {
             return;
         }
-        
+
         $schemaAggregator = new SchemaAggregator();
         $files = $this->getMigrationFiles(database_path().'/migrations');
         $filesArray = iterator_to_array($files);


### PR DESCRIPTION
With the recent update I'm getting a fatal error when the `migrations` folder doesn't exist:

```
Internal error: RecursiveDirectoryIterator::__construct(/var/task/database/migrations): failed to open dir: No such file or directory
```

This is an attempt to patch that up.