### PR TITLE
fix: also search for global Schema class while parsing migrations

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -51,7 +51,7 @@ final class SchemaAggregator
                 && $stmt->expr instanceof PhpParser\Node\Expr\StaticCall
                 && ($stmt->expr->class instanceof PhpParser\Node\Name)
                 && $stmt->expr->name instanceof PhpParser\Node\Identifier
-                && $stmt->expr->class->toCodeString() === '\\Illuminate\Support\Facades\Schema'
+                && ($stmt->expr->class->toCodeString() === '\\Illuminate\Support\Facades\Schema' || $stmt->expr->class->toCodeString() === '\Schema')
             ) {
                 switch ($stmt->expr->name->name) {
                     case 'create':

--- a/tests/Application/database/migrations/2020_03_20_000000_create_accounts_table.php
+++ b/tests/Application/database/migrations/2020_03_20_000000_create_accounts_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateAccountsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('accounts', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('active', 1);
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\Properties;
 
+use App\Account;
 use App\User;
 use Carbon\Carbon as BaseCarbon;
 use Illuminate\Support\Carbon;
@@ -12,6 +13,9 @@ class ModelPropertyExtension
 {
     /** @var User */
     private $user;
+
+    /** @var Account */
+    private $account;
 
     public function testPropertyReturnType(): int
     {
@@ -46,5 +50,10 @@ class ModelPropertyExtension
         $this->user->unknown_column = 'foo';
 
         return $this->user->unknown_column;
+    }
+
+    public function testMigrationWithoutSchemaFacadeImport(): string
+    {
+        return $this->account->active;
     }
 }


### PR DESCRIPTION
From the discussions in #491 

This PR also checks for the global Schema facade. As pointed out by  @azurinspire [here](https://github.com/nunomaduro/larastan/issues/491#issuecomment-601704140).