### PR TITLE
Add return type extension for find* methods on builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [0.5.3] 2020-03-21
+## [0.5.4] - 2020-03-22
+
+### Added
+- Support for return type inference of `find*` methods on Builder class depending on passed arguments. ([#503](https://github.com/nunomaduro/larastan/pull/503))
+
+## [0.5.3] - 2020-03-21
 
 ### Added
 - Support for Eloquent resources. Thanks @mr-feek ([#470](https://github.com/nunomaduro/larastan/pull/470))
@@ -291,7 +296,8 @@ Upgrade guide: [UPGRADE.md](https://github.com/nunomaduro/larastan/blob/master/U
 ### Added
 - Adds first alpha version
 
-[Unreleased]: https://github.com/nunomaduro/larastan/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/nunomaduro/larastan/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/nunomaduro/larastan/compare/v0.5.3...HEAD
 [0.5.3]: https://github.com/nunomaduro/larastan/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/nunomaduro/larastan/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/nunomaduro/larastan/compare/v0.5.0...v0.5.1

--- a/extension.neon
+++ b/extension.neon
@@ -83,11 +83,6 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
-        class: NunoMaduro\Larastan\ReturnTypes\ModelFindExtension
-        tags:
-            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
-
-    -
         class: NunoMaduro\Larastan\ReturnTypes\AuthExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
@@ -106,6 +101,17 @@ services:
         class: NunoMaduro\Larastan\ReturnTypes\EloquentBuilderExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ModelFindExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\BuilderModelFindExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
     -
         class: NunoMaduro\Larastan\Properties\JsonResourceExtension
         tags:

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Str;
+use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Methods\ModelTypeHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * @internal
+ */
+final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Builder::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $methodName = $methodReflection->getName();
+
+        if (! Str::startsWith($methodName, 'find')) {
+            return false;
+        }
+
+        if ($methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass') === null) {
+            return false;
+        }
+
+        if (! $this->getBroker()->getClass(Builder::class)->hasNativeMethod($methodName) &&
+            ! $this->getBroker()->getClass(QueryBuilder::class)->hasNativeMethod($methodName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var ObjectType $model */
+        $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass');
+        $returnType = $methodReflection->getVariants()[0]->getReturnType();
+        $argType = $scope->getType($methodCall->args[0]->value);
+
+        $returnType = ModelTypeHelper::replaceStaticTypeWithModel($returnType, $model->getClassName());
+
+        if ($argType->isIterable()->yes()) {
+            if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+                $genericCollectionReturnType = new GenericObjectType(Collection::class, [$model]);
+
+                if ($returnType->accepts(new NullType(), true)->yes()) {
+                    return TypeCombinator::addNull($genericCollectionReturnType);
+                }
+
+                return $genericCollectionReturnType;
+            }
+
+            return TypeCombinator::remove($returnType, $model);
+        }
+
+        if ($argType instanceof MixedType) {
+            return $returnType;
+        }
+
+        return TypeCombinator::remove(
+            TypeCombinator::remove(
+                $returnType,
+                new ArrayType(new MixedType(), $model)
+            ),
+            new ObjectType(Collection::class)
+        );
+    }
+}

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -42,6 +42,12 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             return false;
         }
 
+        if (Str::startsWith($methodReflection->getName(), 'find') &&
+            $builderReflection->hasNativeMethod($methodReflection->getName())
+        ) {
+            return false;
+        }
+
         $templateTypeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
 
         if (! $templateTypeMap->getType('TModelClass') instanceof ObjectType) {

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -92,6 +92,45 @@ class BuilderExtension
             ->where('foo', 'bar')
             ->orWhere('bar', 'baz');
     }
+
+    public function testFindWithInteger(): ?User
+    {
+        return User::with(['foo'])->find(1);
+    }
+
+    /**
+     * @return Collection<User>|null
+     */
+    public function testFindWithArray()
+    {
+        return User::with(['foo'])->find([1, 2, 3]);
+    }
+
+    public function testFindOrFailWithInteger(): User
+    {
+        return User::with(['foo'])->findOrFail(1);
+    }
+
+    /**
+     * @return Collection<User>
+     */
+    public function testFindOrFailWithArray()
+    {
+        return User::with(['foo'])->findOrFail([1, 2, 3]);
+    }
+
+    public function testFindOrNewWithInteger(): User
+    {
+        return User::with(['foo'])->findOrNew(1);
+    }
+
+    /**
+     * @return Collection<User>
+     */
+    public function testFindOrNewWithArray()
+    {
+        return User::with(['foo'])->findOrNew([1, 2, 3]);
+    }
 }
 
 class TestModel extends Model


### PR DESCRIPTION
This is a similar extension to [`ModelFindExtension`](https://github.com/nunomaduro/larastan/blob/master/src/ReturnTypes/ModelFindExtension.php) but works on Eloquent Builder.

`User::with('foo')->find([1, 2, 3])` will return array of users or null. Whereas `User::with('foo')->find(1)` will return a single user or null.