### PR TITLE
fix: checks if generic model type in builder is object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed an issue with generics in BuilderModelFindExtension. ([#505](https://github.com/nunomaduro/larastan/pull/505))
+
 ## [0.5.4] - 2020-03-22
 
 ### Added

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -49,7 +49,9 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
             return false;
         }
 
-        if ($methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass') === null) {
+        $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass');
+
+        if ($model === null || ! $model instanceof ObjectType) {
             return false;
         }
 


### PR DESCRIPTION
In some cases, the generic builder may not have the correct model as a template type. So we should add a check if the type is an instance of `ObjectType`