### PR TITLE
Fix incorrect boolean type cast

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -195,15 +195,16 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
                 $readableType = $writableType = $column->readableType.($column->nullable ? '|null' : '');
                 break;
 
+            case 'boolean':
             case 'bool':
                 switch ((string) config('database.default')) {
                     case 'sqlite':
                     case 'mysql':
-                        $writableType = '0|1|bool';
+                        $writableType = '0|1|boolean';
                         $readableType = '0|1';
                         break;
                     default:
-                        $readableType = $writableType = 'bool';
+                        $readableType = $writableType = 'boolean';
                         break;
                 }
                 break;


### PR DESCRIPTION
Boolean properties were cast to `boolean` here:
https://github.com/nunomaduro/larastan/blob/master/src/Properties/ModelPropertyExtension.php#L233
So we need to compare `$column->readableType` with `boolean` instead of `bool`