### PR TITLE
Fix ParserException

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -197,16 +197,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
 
             case 'boolean':
             case 'bool':
-                switch ((string) config('database.default')) {
-                    case 'sqlite':
-                    case 'mysql':
-                        $writableType = '0|1|boolean';
-                        $readableType = '0|1';
-                        break;
-                    default:
-                        $readableType = $writableType = 'boolean';
-                        break;
-                }
+                $readableType = $writableType = 'boolean';
                 break;
             case 'enum':
                 if (! $column->options) {

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -27,7 +27,7 @@ class User extends Authenticatable
     ];
 
     /** @var array<string, string> */
-    protected $casts = ['meta' => 'array'];
+    protected $casts = ['meta' => 'array', 'blocked' => 'boolean'];
 
     /**
      * The attributes that should be hidden for arrays.

--- a/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
@@ -20,6 +20,7 @@ class CreateUsersTable extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->json('meta');
+            $table->boolean('blocked');
             $table->unknownColumnType('unknown_column');
             $table->rememberToken();
             $table->timestamps();

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -30,6 +30,11 @@ class ModelPropertyExtension
         return $this->user->id;
     }
 
+    public function testBooleanProperty(): bool
+    {
+        return $this->user->blocked;
+    }
+
     /**
      * @return Carbon|BaseCarbon|null
      */


### PR DESCRIPTION
`$this->stringResolver->resolve($column->readableType)` will throw a `PHPStan\PhpDocParser\Parser\ParserException` if `$column->readableType` is `0|1`

```
>    PHPStan\PhpDocParser\Parser\ParserException  : Unexpected token "0", expected type at offset 0
> 
>   at phar:///Users/xxxxxxx/vendor/phpstan/phpstan/phpstan/vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:132
>     128|      * @throws \PHPStan\PhpDocParser\Parser\ParserException
>     129|      */
>     130|     private function throwError(int $expectedTokenType) : void
>     131|     {
>   ->132|         throw new \PHPStan\PhpDocParser\Parser\ParserException($this->currentTokenValue(), $this->currentTokenType(), $this->currentTokenOffset(), $expectedTokenType);
>     133|     }
>     134| }
>     135|
> 
>   Exception trace:
> 
>   1   PHPStan\PhpDocParser\Parser\TokenIterator::throwError()
>       phar:///Users/xxxxxxx/vendor/phpstan/phpstan/phpstan/vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:59
> 
>   2   PHPStan\PhpDocParser\Parser\TokenIterator::consumeTokenType()
>       phar:///Users/xxxxxxx/vendor/phpstan/phpstan/phpstan/vendor/phpstan/phpdoc-parser/src/Parser/TypeParser.php:39
```