### PR TITLE
fix: dont assume primary key is id

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -59,12 +59,13 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
             $this->initializeTables();
         }
 
-        if ($propertyName === 'id') {
+        /** @var Model $modelInstance */
+        $modelInstance = $classReflection->getNativeReflection()->newInstance();
+
+        if ($propertyName === $modelInstance->getKeyName()) {
             return true;
         }
 
-        /** @var Model $modelInstance */
-        $modelInstance = $classReflection->getNativeReflection()->newInstance();
         $tableName = $modelInstance->getTable();
 
         if (! array_key_exists($tableName, $this->tables)) {
@@ -101,7 +102,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
             (! array_key_exists($tableName, $this->tables)
                 || ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
             )
-            && $propertyName === 'id'
+            && $propertyName === $modelInstance->getKeyName()
         ) {
             return new ModelProperty(
                 $classReflection,

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -9,6 +9,7 @@ use App\Group;
 use App\Role;
 use App\User;
 use Carbon\Carbon as BaseCarbon;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
 class ModelPropertyExtension
@@ -95,4 +96,16 @@ class ModelPropertyExtension
 
         return $group->save();
     }
+
+    /** @test */
+    public function it_knows_name_of_primary_key_column(): void
+    {
+        $model = new CustomPrimaryKeyColumn();
+        $primaryKey = $model->custom_primary_key_name;
+    }
+}
+
+class CustomPrimaryKeyColumn extends Model
+{
+    protected $primaryKey = 'custom_primary_key_name';
 }


### PR DESCRIPTION
> Eloquent will also assume that each table has a primary key column named id. You may define a protected $primaryKey property to override this convention:

I have lots of models with custom ids