### PR TITLE
Support custom eloquent collections

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -111,6 +111,16 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\RelationFindExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\RelationExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\ModelFindExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -28,7 +28,7 @@ class BuilderHelper
     public const MODEL_RETRIEVAL_METHODS = ['first', 'find', 'findMany', 'findOrFail', 'firstOrFail'];
 
     /** @var string[] */
-    public const MODEL_CREATION_METHODS = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate', 'fromQuery', 'firstOrCreate'];
+    public const MODEL_CREATION_METHODS = ['make', 'create', 'forceCreate', 'findOrNew', 'firstOrNew', 'updateOrCreate', 'firstOrCreate'];
 
     /**
      * @var Broker
@@ -192,5 +192,18 @@ class BuilderHelper
         }
 
         return $this->dynamicWhere($methodName, $customReturnType);
+    }
+
+    public function determineCollectionClassName(string $modelClassName): string
+    {
+        $newCollectionMethod = $this->broker->getClass($modelClassName)->getNativeMethod('newCollection');
+
+        $returnType = ParametersAcceptorSelector::selectSingle($newCollectionMethod->getVariants())->getReturnType();
+
+        if ($returnType instanceof ObjectType) {
+            return $returnType->getClassName();
+        }
+
+        return $returnType->describe(VerbosityLevel::value());
     }
 }

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -90,9 +90,12 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             );
         }
 
-        // 'get' method return type
-        if ($methodReflection->getName() === 'get') {
-            return new GenericObjectType(Collection::class, [$modelType]);
+        if ($modelType instanceof ObjectType && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            $builderHelper = new BuilderHelper($this->getBroker());
+
+            $collectionClassName = $builderHelper->determineCollectionClassName($modelType->getClassName());
+
+            return new GenericObjectType($collectionClassName, [$modelType]);
         }
 
         return $returnType;

--- a/src/ReturnTypes/RelationExtension.php
+++ b/src/ReturnTypes/RelationExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Str;
+use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Methods\BuilderHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @internal
+ */
+final class RelationExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Relation::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        if (Str::startsWith($methodReflection->getName(), 'find')) {
+            return false;
+        }
+
+        $modelType = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TRelatedModel');
+
+        if (! $modelType instanceof ObjectType) {
+            return false;
+        }
+
+        return $methodReflection->getDeclaringClass()->hasNativeMethod($methodReflection->getName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var ObjectType $modelType */
+        $modelType = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TRelatedModel');
+
+        $returnType = $methodReflection->getVariants()[0]->getReturnType();
+
+        if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            $builderHelper = new BuilderHelper($this->getBroker());
+
+            $collectionClassName = $builderHelper->determineCollectionClassName($modelType->getClassname());
+
+            return new GenericObjectType($collectionClassName, [$modelType]);
+        }
+
+        return $returnType;
+    }
+}

--- a/src/ReturnTypes/RelationFindExtension.php
+++ b/src/ReturnTypes/RelationFindExtension.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Str;
+use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Methods\BuilderHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * @internal
+ */
+final class RelationFindExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Relation::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        if (! Str::startsWith($methodReflection->getName(), 'find')) {
+            return false;
+        }
+
+        $modelType = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TRelatedModel');
+
+        if (! $modelType instanceof ObjectType) {
+            return false;
+        }
+
+        return $methodReflection->getDeclaringClass()->hasNativeMethod($methodReflection->getName()) ||
+            $this->getBroker()->getClass(Builder::class)->hasNativeMethod($methodReflection->getName()) ||
+            $this->getBroker()->getClass(QueryBuilder::class)->hasNativeMethod($methodReflection->getName());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var ObjectType $modelType */
+        $modelType = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TRelatedModel');
+
+        $argType = $scope->getType($methodCall->args[0]->value);
+
+        $returnType = $methodReflection->getVariants()[0]->getReturnType();
+
+        if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            if ($argType->isIterable()->yes()) {
+                $builderHelper = new BuilderHelper($this->getBroker());
+
+                $collectionClassName = $builderHelper->determineCollectionClassName($modelType->getClassname());
+
+                return new GenericObjectType($collectionClassName, [$modelType]);
+            }
+
+            $returnType = TypeCombinator::remove($returnType, new ObjectType(Collection::class));
+
+            return TypeCombinator::remove($returnType, new ArrayType(new MixedType(), $modelType));
+        }
+
+        return $returnType;
+    }
+}

--- a/tests/Application/app/Account.php
+++ b/tests/Application/app/Account.php
@@ -16,4 +16,19 @@ class Account extends Model
     {
         return $query->where('active', 1);
     }
+
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
+    /**
+     * @param array<int, Account> $models
+     *
+     * @return AccountCollection<Account>
+     */
+    public function newCollection(array $models = []): AccountCollection
+    {
+        return new AccountCollection($models);
+    }
 }

--- a/tests/Application/app/AccountCollection.php
+++ b/tests/Application/app/AccountCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * @template TModel
+ * @extends Collection<TModel>
+ */
+class AccountCollection extends Collection
+{
+    //
+}

--- a/tests/Application/app/Role.php
+++ b/tests/Application/app/Role.php
@@ -5,8 +5,24 @@ declare(strict_types=1);
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Role extends Model
 {
     protected $keyType = 'uuid';
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    /**
+     * @param array<int, Role> $models
+     *
+     * @return RoleCollection<Role>
+     */
+    public function newCollection(array $models = []): RoleCollection
+    {
+        return new RoleCollection($models);
+    }
 }

--- a/tests/Application/app/RoleCollection.php
+++ b/tests/Application/app/RoleCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * @template TModel
+ * @extends Collection<TModel>
+ */
+class RoleCollection extends Collection
+{
+    //
+}

--- a/tests/Application/app/Transaction.php
+++ b/tests/Application/app/Transaction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Transaction extends Model
+{
+    /**
+     * @param array<int, Transaction> $models
+     *
+     * @return TransactionCollection<Transaction>
+     */
+    public function newCollection(array $models = []): TransactionCollection
+    {
+        return new TransactionCollection($models);
+    }
+}

--- a/tests/Application/app/TransactionCollection.php
+++ b/tests/Application/app/TransactionCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * @template TModel
+ * @extends Collection<TModel>
+ */
+class TransactionCollection extends Collection
+{
+    //
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -7,13 +7,14 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Tests\Application\HasManySyncable;
 
 /**
- * @property-read \Illuminate\Database\Eloquent\Collection|\App\Account[] $accounts
+ * @property-read \App\AccountCollection $accounts
  */
 class User extends Authenticatable
 {
@@ -59,6 +60,11 @@ class User extends Authenticatable
     public function accounts(): HasMany
     {
         return $this->hasMany(Account::class);
+    }
+
+    public function transactions(): HasManyThrough
+    {
+        return $this->hasManyThrough(Transaction::class, Account::class);
     }
 
     public function syncableRelation(): HasManySyncable

--- a/tests/Features/ReturnTypes/CustomEloquentCollectionTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentCollectionTest.php
@@ -1,0 +1,529 @@
+<?php
+
+namespace Tests\Features\ReturnTypes;
+
+use App\Account;
+use App\AccountCollection;
+use App\Group;
+use App\Role;
+use App\RoleCollection;
+use App\Transaction;
+use App\TransactionCollection;
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomEloquentCollectionTest
+{
+    // Query builder...
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFromQueryViaQueryReturnsCustomCollection(): AccountCollection
+    {
+        return Account::query()->fromQuery('select * from accounts');
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFromQueryViaQueryReturnsEloquentCollection(): Collection
+    {
+        return User::query()->fromQuery('select * from accounts');
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFromQueryViaStaticCallOnModelReturnsCustomCollection(): AccountCollection
+    {
+        return Account::fromQuery('select * from accounts');
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFromQueryViaStaticCallOnModelReturnsEloquentCollection(): Collection
+    {
+        return User::fromQuery('select * from accounts');
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderHydrateViaQueryReturnsCustomCollection(): AccountCollection
+    {
+        return Account::query()->hydrate([
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderHydrateViaQueryReturnsEloquentCollection(): Collection
+    {
+        return User::query()->hydrate([
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderHydrateViaStaticCallOnModelReturnsCustomCollection(): AccountCollection
+    {
+        return Account::hydrate([
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderHydrateViaStaticCallOnModelReturnsEloquentCollection(): Collection
+    {
+        return User::hydrate([
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindViaQueryReturnsCustomCollection(): AccountCollection
+    {
+        return Account::query()->find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindViaQueryReturnsEloquentCollection(): Collection
+    {
+        return User::query()->find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindViaStaticCallOnModelReturnsCustomCollection(): AccountCollection
+    {
+        return Account::find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindViaStaticCallOnModelReturnsEloquentCollection(): Collection
+    {
+        return User::find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindManyViaQueryRetunsCustomCollection(): AccountCollection
+    {
+        return Account::query()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindManyViaQueryRetunsEloquentCollection(): Collection
+    {
+        return User::query()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindManyViaStaticCallOnModelReturnsCustomCollection(): AccountCollection
+    {
+        return Account::findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindManyViaStaticCallOnModelReturnsEloquentCollection(): Collection
+    {
+        return User::findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindOrFailViaQueryReturnsCustomCollection(): AccountCollection
+    {
+        return Account::query()->findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindOrFailViaQueryReturnsEloquentCollection(): Collection
+    {
+        return User::query()->findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderFindOrFailViaStaticCallOnModelCallReturnsCustomCollection(): AccountCollection
+    {
+        return Account::findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderFindOrFailViaStaticCallOnModelCallReturnsEloquentCollection(): Collection
+    {
+        return User::findOrFail([1, 2]);
+    }
+
+    public function testQueryBuilderFindOrFailExpectingSingleModelViaQueryDoesntReturnCollection(): Account
+    {
+        return Account::query()->findOrFail(1);
+    }
+
+    public function testQueryBuilderFindOrFailExpectingSingleModelViaStaticCallOnModelDoesntReturnCollection(): Account
+    {
+        return Account::findOrFail(1);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderGetViaQueryReturnsCustomCollection(): AccountCollection
+    {
+        return Account::query()->get();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderGetViaQueryReturnsEloquentCollection(): Collection
+    {
+        return User::query()->get();
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testQueryBuilderGetViaStaticOnModelCallReturnsCustomCollection(): AccountCollection
+    {
+        return Account::get();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testQueryBuilderGetViaStaticOnModelCallReturnsEloquentCollection(): Collection
+    {
+        return User::get();
+    }
+
+    // Model...
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testModelAllReturnsCustomCollection(): AccountCollection
+    {
+        return Account::all();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testModelAllReturnsEloquentCollection(): Collection
+    {
+        return User::all();
+    }
+
+    // Relation...
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationGetReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts()->get();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationGetReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->get();
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationGetEagerReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts()->getEager();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationGetEagerReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->getEager();
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationCreateManyReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts()->createMany([
+            //
+        ]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationCreateManyReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->createMany([
+            //
+        ]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationQueryWithWhereReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts()->active()->get();
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationQueryWithWhereReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->active()->get();
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationAttributeReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts;
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationAttributeReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children;
+    }
+
+    /**
+     * @phpstan-return RoleCollection<Role>
+     */
+    public function testRelationBelongsToManyFindReturnsCustomCollection(): RoleCollection
+    {
+        return (new User)->roles()->find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationBelongsToManyFindReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->find([1, 2]);
+    }
+
+    public function testRelationBelongsToManyFindExpectingSingleModelDoesntReturnACustomCollection(): ?Role
+    {
+        return (new User)->roles()->find(1);
+    }
+
+    /**
+     * @phpstan-return RoleCollection<Role>
+     */
+    public function testRelationBelongsToManyFindOrFailReturnsCustomCollection(): RoleCollection
+    {
+        return (new User)->roles()->findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationBelongsToManyFindOrFailReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->findOrFail([1, 2]);
+    }
+
+    public function testRelationBelongsToManyFindOrFailExpectingSingleModelDoesntReturnACustomCollection(): Role
+    {
+        return (new User)->roles()->findOrFail(1);
+    }
+
+    /**
+     * @phpstan-return RoleCollection<Role>
+     */
+    public function testRelationBelongsToManyFindManyReturnsCustomCollection(): RoleCollection
+    {
+        return (new User)->roles()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationBelongsToManyFindManyReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return TransactionCollection<Transaction>
+     */
+    public function testRelationHasManyThroughManyFindReturnsCustomCollection(): TransactionCollection
+    {
+        return (new User)->transactions()->find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyThroughManyFindReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->find([1, 2]);
+    }
+
+    public function testRelationHasManyThroughManyFindExpectingSingleModelDoesntReturnACustomCollection(): ?Model
+    {
+        return (new User)->transactions()->find(1);
+    }
+
+    /**
+     * @phpstan-return TransactionCollection<Transaction>
+     */
+    public function testRelationHasManyThroughManyFindOrFailReturnsCustomCollection(): TransactionCollection
+    {
+        return (new User)->transactions()->findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyThroughManyFindOrFailReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->findOrFail([1, 2]);
+    }
+
+    public function testRelationHasManyThroughManyFindOrFailExpectingSingleModelDoesntReturnACustomCollection(): Model
+    {
+        return (new User)->transactions()->findOrFail(1);
+    }
+
+    /**
+     * @phpstan-return TransactionCollection<Transaction>
+     */
+    public function testRelationHasManyThroughManyFindManyReturnsCustomCollection(): TransactionCollection
+    {
+        return (new User)->transactions()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyThroughManyFindManyReturnsEloquentCollection(): Collection
+    {
+        return (new Role)->users()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationHasManyFindReturnsCustomCollection(): AccountCollection
+    {
+        return (new Group)->accounts()->find([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyFindReturnsElquentCollection(): Collection
+    {
+        return (new User)->children()->find([1, 2]);
+    }
+
+    public function testRelationHasManyFindExpectingSingleModelDoesntReturnACustomCollection(): ?Model
+    {
+        return (new Group)->accounts()->find(1);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationHasManyFindOrFailReturnsCustomCollection(): AccountCollection
+    {
+        return (new Group)->accounts()->findOrFail([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyFindOrFailReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->findOrFail([1, 2]);
+    }
+
+    public function testRelationHasManyFindOrFailExpectingSingleModelDoesntReturnACustomCollection(): Model
+    {
+        return (new Group)->accounts()->findOrFail(1);
+    }
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testRelationHasManyFindManyReturnsCustomCollection(): AccountCollection
+    {
+        return (new Group)->accounts()->findMany([1, 2]);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testRelationHasManyFindManyReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children()->findMany([1, 2]);
+    }
+
+    // Collection...
+
+    /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testCustomCollectionWhereReturnsCustomCollection(): AccountCollection
+    {
+        return (new User)->accounts->where('active', true);
+    }
+
+    /**
+     * @phpstan-return Collection<User>
+     */
+    public function testEloquentCollectionWhereReturnsEloquentCollection(): Collection
+    {
+        return (new User)->children->where('active', true);
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/nunomaduro/larastan/issues/436

This PR brings support for [custom eloquent collections](https://laravel.com/docs/7.x/eloquent-collections#custom-collections).

## BuilderHelper::determineCollectionType

Now that this PR is done, I'm not entirely sure `determineCollectionType` should be on the builder helper. It was suggested this could be its home, however maybe it should be extracted to a Collection helper as it isn't really just about the builder? Maybe it doesn't matter.

[See method](https://github.com/nunomaduro/larastan/pull/537/files#diff-7feea80f9bc562bad5bf39fba90c9582R198-R213)

## Fixed find...() null return type

If any `find...()` methods receive an iterable, they will never return `null`. They always proxy to `findMany` which in all cases returns a collection.

See [here](https://github.com/nunomaduro/larastan/pull/537/files#diff-dc0c9bf2638b255d8cf20a1067ed6782L85-L87) and [here](https://github.com/nunomaduro/larastan/pull/537/files#diff-ffcea4aec97c2745f3004fe1464993bdL76-L78)

## Fixed fromQuery return type

`Builder::fromQuery` was included in some existing type checks, but as that method always returns a collection I removed it.

[See removal](https://github.com/nunomaduro/larastan/pull/537/files#diff-7feea80f9bc562bad5bf39fba90c9582L31)

## Doesn't handle factory helper

Due to the dynamic nature of the factory helper method and the builder, I was unable to get the correct return type for factory calls. Not sure if this needs to be included in this PR or if we can follow up with another PR to add this functionality. Here is some examples of what we'd have to handle...

```php
// should return custom class collection...
factory(Account::class, 1)->create();
factory(Account::class, 'name', 1)->create();
factory(Account::class)->times(1)->create();
factory(Account::class)->times(null)->times(1)->create();


// should return a single instance...
factory(Account::class)->create();
factory(Account::class, 'name')->create();
factory(Account::class)->times(null)->create();
factory(Account::class)->times(1)->times(null)->create();
```

[See factory helper](https://github.com/laravel/framework/blob/4e9f584689a185b2d10a543bf20fbca5e4e2989c/src/Illuminate/Foundation/helpers.php#L481-L497)

## Doesn't handle MorphTo::getResultsByType

This method accepts a string that could be either a class or a morph map key. Without booting the framework and retrieving the class from the Morph Map there is not way (that I'm aware) to determine the class, and therefore the collection type.

It is a protected method, and I'd guess this method isn't really used outside the framework anyway, however I've got no data to back that up.

```php

Relation::morphMap([
    'videos' => 'App\Video',
]);

$morphTo->getResultsByType('videos');
```

## Doesn't handle instance proxying by design

All methods that are accessible via static calls on the model are also available via instance calls. Looks like Larastan doesn't currently support that for other methods, so I didn't add support for this feature, but I could if needed.

```php
$instance->find($id);
$instance->hydrate($records);
```

[See method](https://github.com/laravel/framework/blob/efdd2781b9cf7924bef73c047a25caba907903de/src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L107-L131)