### PR TITLE
Add rule for detecting expensive calls on a Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you are getting the error `Allowed memory size exhausted`, then you can use t
 ./vendor/bin/phpstan analyse --memory-limit=2G
 ```
 
+## Rules
+A list of configurable rules specific to Laravel can be found [here](docs/rules.md).
 ## 👊🏻 Contributing
 
 Thank you for considering contributing to Larastan. All the contribution guidelines are mentioned [here](CONTRIBUTING.md).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -20,8 +20,8 @@ $user->roles()->pluck('name')->contains('a role name');
 
 Will result in the following errors:
 ```
-[NoUnnecessaryCollectionCallRule] Called 'count' on collection, but could have been retrieved as a query.
-[NoUnnecessaryCollectionCallRule] Called 'contains' on collection, but could have been retrieved as a query.
+Called 'count' on Laravel collection, but could have been retrieved as a query.
+Called 'contains' on Laravel collection, but could have been retrieved as a query.
 ```
 
 To fix the errors, the code in the previous example could be changed to:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,53 @@
+# Rules
+
+All rules that are specific to Laravel applications 
+are listed here with their configurable options.
+
+
+## NoUnnecessaryCollectionCall
+
+Checks for method calls on instances of `Illuminate\Support\Collection` and their 
+subclasses. If the same result could have been determined 
+directly with a query then this rule will produce an error.
+This rule exists to reduce unnecessarily heavy queries on the database 
+and to prevent unneeded loops over Collections.
+
+#### Examples
+```php
+User::all()->count();
+$user->roles()->pluck('name')->contains('a role name');
+```
+
+Will result in the following errors:
+```
+[NoUnnecessaryCollectionCallRule] Called 'count' on collection, but could have been retrieved as a query.
+[NoUnnecessaryCollectionCallRule] Called 'contains' on collection, but could have been retrieved as a query.
+```
+
+To fix the errors, the code in the previous example could be changed to:
+```php
+User::count();
+$user->roles()->where('name', 'a role name')->exists();
+```
+
+#### Configuration
+This rule is enabled by default. To disable it completely, add:
+```
+noUnnecessaryCollectionCall: false
+```
+to your `phpstan.neon` file.
+
+You can also configure the collection methods which this rule 
+checks for. By default, all collection methods are checked. 
+To only enable a specific set of methods, you could set the
+ `noUnnecessaryCollectionCallOnly` configuration key. For example:
+```
+noUnnecessaryCollectionCallOnly: ['count', 'first']
+```
+will only throw errors on the `count` and `first` methods.
+The inverse is also configurable, to not throw an exception
+on the `contains` method, one could set the following value:
+```
+noUnnecessaryCollectionCallExcept: ['contains']
+```
+

--- a/extension.neon
+++ b/extension.neon
@@ -190,6 +190,11 @@ services:
             - phpstan.phpDoc.typeNodeResolverExtension
 
     -
+        class: NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule
+        tags:
+            - phpstan.rules.rule
+
+    -
         class: NunoMaduro\Larastan\Types\GenericEloquentBuilderTypeNodeResolverExtension
         tags:
             - phpstan.phpDoc.typeNodeResolverExtension

--- a/extension.neon
+++ b/extension.neon
@@ -33,6 +33,18 @@ parameters:
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false
     checkGenericClassInNonGenericObjectType: false
+    noUnnecessaryCollectionCall: true
+    noUnnecessaryCollectionCallOnly: []
+    noUnnecessaryCollectionCallExcept: []
+
+parametersSchema:
+    noUnnecessaryCollectionCall: bool()
+    noUnnecessaryCollectionCallOnly: listOf(string())
+    noUnnecessaryCollectionCallExcept: listOf(string())
+
+conditionalTags:
+    NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
+    		phpstan.rules.rule: %noUnnecessaryCollectionCall%
 
 services:
     -
@@ -196,8 +208,9 @@ services:
 
     -
         class: NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule
-        tags:
-            - phpstan.rules.rule
+        arguments:
+            onlyMethods: %noUnnecessaryCollectionCallOnly%
+            excludeMethods: %noUnnecessaryCollectionCallExcept%
 
     -
         class: NunoMaduro\Larastan\Types\GenericEloquentBuilderTypeNodeResolverExtension

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -241,6 +241,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
 
             return $this->propertyExtension->hasProperty($modelReflection, $firstArg->value);
         }
+
         return false;
     }
 
@@ -261,6 +262,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
             $class = $call->class;
             if ($class instanceof Node\Name) {
                 $modelClassName = $class->toCodeString();
+
                 return is_subclass_of($modelClassName, Model::class);
             }
         }
@@ -309,6 +311,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
     protected function isNotCalledOnCollection(Node\Expr $expr, Scope $scope): bool
     {
         $calledOnType = $scope->getType($expr);
+
         return ! (new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->yes();
     }
 
@@ -319,6 +322,6 @@ class NoUnnecessaryCollectionCallRule implements Rule
      */
     protected function formatError(string $method_name): string
     {
-        return "Called '{$method_name}' on collection, but could have been retrieved as a query.";
+        return "[NoUnnecessaryCollectionCallRule] Called '{$method_name}' on collection, but could have been retrieved as a query.";
     }
 }

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -189,27 +189,6 @@ class NoUnnecessaryCollectionCallRule implements Rule
     }
 
     /**
-     * Returns whether the method call was called with a string as its only argument.
-     * @param MethodCall $node
-     * @return bool
-     */
-    protected function hasStringAsOnlyArgument(MethodCall $node): bool
-    {
-        /** @var \PhpParser\Node\Arg[] $args */
-        $args = $node->args;
-
-        if (count($args) !== 1) {
-            return false;
-        }
-
-        if (!($args[0]->value instanceof Node\Scalar\String_)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Returns whether the method call is a call on a builder instance.
      * @param Node\Expr $call
      * @param Scope $scope

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -326,6 +326,6 @@ class NoUnnecessaryCollectionCallRule implements Rule
      */
     protected function formatError(string $method_name): string
     {
-        return "[NoUnnecessaryCollectionCallRule] Called '{$method_name}' on collection, but could have been retrieved as a query.";
+        return "Called '{$method_name}' on Laravel collection, but could have been retrieved as a query.";
     }
 }

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -189,7 +189,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
             if ($this->firstArgIsDatabaseColumn($node, $scope)) {
                 return [$this->formatError($name->toString())];
             }
-        } elseif (in_array($name->toLowerString(),  ['contains', 'containsstrict'], true)) {
+        } elseif (in_array($name->toLowerString(), ['contains', 'containsstrict'], true)) {
             // 'contains' can also be called with Model instances or keys as its first argument
             /** @var \PhpParser\Node\Arg[] $args */
             $args = $node->args;

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -115,17 +115,18 @@ class NoUnnecessaryCollectionCallRule implements Rule
         );
 
         if (! empty($onlyMethods)) {
-            $this->shouldHandle = $onlyMethods;
+            $this->shouldHandle = array_map(function (string $methodName): string {
+                return Str::lower($methodName);
+            }, $onlyMethods);
         } else {
             $this->shouldHandle = $allMethods;
         }
 
         if (! empty($excludeMethods)) {
-            $this->shouldHandle = array_diff($this->shouldHandle, $excludeMethods);
+            $this->shouldHandle = array_diff($this->shouldHandle, array_map(function (string $methodName): string {
+                return Str::lower($methodName);
+            }, $excludeMethods));
         }
-        $this->shouldHandle = array_map(function (string $methodName): string {
-            return Str::lower($methodName);
-        }, $this->shouldHandle);
     }
 
     /**

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use NunoMaduro\Larastan\Properties\ModelPropertyExtension;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * This rule checks for unnecessary heavy operations on the Collection class
+ * that could have instead been performed on the Builder class.
+ *
+ * For example:
+ * User::all()->count()
+ * could be simplified to:
+ * User::count()
+ *
+ * In addition, this code:
+ * User::whereStatus('active')->get()->pluck('id')
+ * could be simplified to:
+ * User::whereStatus('active')->pluck('id')
+ */
+class NoUnnecessaryCollectionCallRule implements Rule
+{
+    /**
+     * The method names that can be applied on a Collection, but should be applied on a Builder.
+     * @var string[]
+     */
+    protected const RISKY_METHODS = [
+        'count',
+        'first',
+        'isempty',
+        'isnotempty',
+        'last',
+        'pop',
+        'skip',
+        'slice',
+        'take',
+        // Eloquent collection
+        'modelKeys',
+        'contains',
+        'find',
+        'findMany',
+        'only',
+    ];
+
+    /**
+     * The method names that can be applied on a Collection, but should in some cases be applied
+     * on a builder depending on what parameter is passed to the method.
+     * @var string[]
+     */
+    protected const RISKY_PARAM_METHODS = [
+        'average',
+        'avg',
+        'max',
+        'min',
+        'pluck',
+        'sum',
+    ];
+
+    /**
+     * @var \PHPStan\Reflection\ReflectionProvider
+     */
+    protected $reflectionProvider;
+
+    /**
+     * @var \NunoMaduro\Larastan\Properties\ModelPropertyExtension
+     */
+    protected $propertyExtension;
+
+    /**
+     * NoRedundantCollectionCallRule constructor.
+     * @param ReflectionProvider $reflectionProvider
+     * @param ModelPropertyExtension $propertyExtension
+     */
+    public function __construct(ReflectionProvider $reflectionProvider, ModelPropertyExtension $propertyExtension)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->propertyExtension = $propertyExtension;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param Node $node
+     * @param Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var \PhpParser\Node\Expr\MethodCall $node */
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        /** @var \PhpParser\Node\Identifier $name */
+        $name = $node->name;
+
+        if ($this->isNotCalledOnCollection($node->var, $scope)) {
+            // Method was called not called on a collection, so no errors.
+            return [];
+        }
+
+        $previousCall = $node->var;
+
+        if (!$this->callIsQuery($previousCall, $scope)) {
+            // Previous call wasn't on a Builder, so no errors.
+            return [];
+        }
+
+        /** @var Node\Expr\MethodCall|Node\Expr\StaticCall $previousCall */
+        if (!($previousCall->name instanceof Identifier)) {
+            // Previous call was made dynamically e.g. User::query()->{$method}()
+            // Can't really analyze it in this scenario so no errors.
+            return [];
+        }
+
+        if ($this->isRiskyMethod($name)) {
+            return [$this->formatError($name->toString())];
+        } elseif ($this->isRiskyParamMethod($name)) {
+            if (!$this->hasStringAsOnlyArgument($node)) {
+                return [];
+            }
+            /** @var \PhpParser\Node\Scalar\String_ $firstArg */
+            $firstArg = $node->args[0]->value;
+            $columnName = $firstArg->value;
+
+            /** @var \PHPStan\Type\ObjectType $iterableType */
+            $iterableType = $scope->getType($node->var)->getIterableValueType();
+            if ((new ObjectType(Model::class))->isSuperTypeOf($iterableType)->yes()) {
+                $modelReflection = $this->reflectionProvider->getClass($iterableType->getClassName());
+
+                if (!$this->propertyExtension->hasProperty($modelReflection, $columnName)) {
+                    // Not a database property so call couldn't have been improved with a DB query.
+                    return [];
+                }
+
+                return [$this->formatError($name->toString())];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns whether the method call was called with a string as its only argument.
+     * @param MethodCall $node
+     * @return bool
+     */
+    protected function hasStringAsOnlyArgument(MethodCall $node): bool
+    {
+        /** @var \PhpParser\Node\Arg[] $args */
+        $args = $node->args;
+
+        if (count($args) !== 1) {
+            return false;
+        }
+
+        if (!($args[0]->value instanceof Node\Scalar\String_)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether the method call is a call on a builder instance.
+     * @param Node\Expr $call
+     * @param Scope $scope
+     * @return bool
+     */
+    protected function callIsQuery(Node\Expr $call, Scope $scope): bool
+    {
+        if ($call instanceof MethodCall) {
+            $calledOn = $scope->getType($call->var);
+
+            return $this->isBuilder($calledOn);
+        } else if ($call instanceof Node\Expr\StaticCall) {
+            /** @var Node\Name $class */
+            $class = $call->class;
+            if ($class instanceof Node\Name) {
+                $modelClassName = $class->toCodeString();
+                return is_subclass_of($modelClassName, Model::class);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether the method is one of the risky methods.
+     * @param Identifier $name
+     * @return bool
+     */
+    protected function isRiskyMethod(Identifier $name): bool
+    {
+        return in_array($name->toLowerString(), self::RISKY_METHODS, true);
+    }
+
+    /**
+     * Returns whether the method might be a risky method depending on the parameters passed.
+     * @param Identifier $name
+     * @return bool
+     */
+    protected function isRiskyParamMethod(Identifier $name): bool
+    {
+        return in_array($name->toLowerString(), self::RISKY_PARAM_METHODS, true);
+    }
+
+    /**
+     * Returns whether its argument is some builder instance.
+     * @param Type $type
+     * @return bool
+     */
+    protected function isBuilder(Type $type): bool
+    {
+        return !(new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->no()
+            || !(new ObjectType(QueryBuilder::class))->isSuperTypeOf($type)->no()
+            || !(new ObjectType(Relation::class))->isSuperTypeOf($type)->no();
+    }
+
+    /**
+     * Returns whether the Expr was not called on a Collection instance.
+     * @param Node\Expr $expr
+     * @param Scope $scope
+     * @return bool
+     */
+    protected function isNotCalledOnCollection(Node\Expr $expr, Scope $scope): bool
+    {
+        $calledOnType = $scope->getType($expr);
+        return !(new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->yes();
+    }
+
+    /**
+     * Formats the error.
+     * @param string $method_name
+     * @return string
+     */
+    protected function formatError(string $method_name): string
+    {
+        return "Called '{$method_name}' on collection, but could have been retrieved as a query.";
+    }
+}

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Rules;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use NunoMaduro\Larastan\Properties\ModelPropertyExtension;
@@ -100,8 +100,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
         ModelPropertyExtension $propertyExtension,
         array $onlyMethods,
         array $excludeMethods
-    )
-    {
+    ) {
         $this->reflectionProvider = $reflectionProvider;
         $this->propertyExtension = $propertyExtension;
         $allMethods = array_merge(
@@ -257,7 +256,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
             $calledOn = $scope->getType($call->var);
 
             return $this->isBuilder($calledOn);
-        } else if ($call instanceof Node\Expr\StaticCall) {
+        } elseif ($call instanceof Node\Expr\StaticCall) {
             /** @var Node\Name $class */
             $class = $call->class;
             if ($class instanceof Node\Name) {

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -316,7 +316,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
     {
         $calledOnType = $scope->getType($expr);
 
-        return ! (new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->yes();
+        return (new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->no();
     }
 
     /**

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 use Tests\Application\HasManySyncable;
 
 /**
@@ -42,6 +43,11 @@ class User extends Authenticatable
     public function id(): int
     {
         return $this->id;
+    }
+
+    public function getAllCapsName(): string
+    {
+        return Str::upper($this->name);
     }
 
     public function scopeActive(Builder $query): Builder

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -21,11 +21,6 @@ class ModelExtension
         return User::all();
     }
 
-    public function testAllFirst(): ?User
-    {
-        return User::all()->first();
-    }
-
     public function testReturnThis(): Builder
     {
         $user = User::join('tickets.tickets', 'tickets.tickets.id', '=', 'tickets.sale_ticket.ticket_id')
@@ -237,7 +232,7 @@ class Thread extends Model
 
     public static function testFindOnStaticSelf(): ?Thread
     {
-        return self::query()->where('foo', 'bar')->get()->first();
+        return self::query()->where('foo', 'bar')->first();
     }
 
     public function getCustomPropertyAttribute(): string

--- a/tests/Features/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Features/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -30,4 +30,26 @@ class NoUnnecessaryCollectionCallRuleTest
 
         return User::where('id', '>', 1)->{$x}()->count();
     }
+
+    /**
+     * Can't analyze the closure as a parameter to contains, so should not throw any error.
+     * @return bool
+     */
+    public function testContainsClosure(): bool
+    {
+        return User::where('id', '>', 1)->get()->contains(function (User $user): bool {
+            return $user->id === 2;
+        });
+    }
+
+    /**
+     * Can't analyze the closure as a parameter to first, so should not throw any error.
+     * @return User|null
+     */
+    public function testFirstClosure(): ?User
+    {
+        return User::where('id', '>', 1)->get()->first(function (User $user): bool {
+            return $user->id === 2;
+        });
+    }
 }

--- a/tests/Features/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Features/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Rules;
+
+use App\User;
+use Illuminate\Support\Collection;
+
+class NoUnnecessaryCollectionCallRuleTest
+{
+    public function testPluckComputedProperty(): Collection
+    {
+        return User::all()->pluck('allCapsName');
+    }
+
+    public function testCallPluckCorrect(): Collection
+    {
+        return User::pluck('id');
+    }
+
+    public function testCallCountProperly(): int
+    {
+        return User::where('id', '>', 5)->count();
+    }
+
+    public function testNotAnalyzable(): int
+    {
+        $x = 'get';
+
+        return User::where('id', '>', 1)->{$x}()->count();
+    }
+}

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -26,6 +26,11 @@ class CorrectCollectionCalls
         return User::all()->pluck('allCapsName');
     }
 
+    public function pluckRelation(): Collection
+    {
+        return User::with(['accounts'])->get()->pluck('accounts');
+    }
+
     public function firstRelation(): ?Account
     {
         return User::firstOrFail()->accounts()->first();

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -2,33 +2,38 @@
 
 declare(strict_types=1);
 
-namespace Tests\Features\Rules;
+namespace Tests\Rules\Data;
 
+use App\Account;
 use App\User;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
-class NoUnnecessaryCollectionCallRuleTest
+class CorrectCollectionCalls
 {
-    public function testPluckComputedProperty(): Collection
+    public function staticCount(): int
+    {
+        return User::count();
+    }
+
+    public function pluckQuery(): Collection
+    {
+        return User::query()->pluck('id');
+    }
+
+    public function pluckComputed(): Collection
     {
         return User::all()->pluck('allCapsName');
     }
 
-    public function testCallPluckCorrect(): Collection
+    public function firstRelation(): ?Account
     {
-        return User::pluck('id');
+        return User::firstOrFail()->accounts()->first();
     }
 
-    public function testCallCountProperly(): int
+    public function maxQuery(): int
     {
-        return User::where('id', '>', 5)->count();
-    }
-
-    public function testNotAnalyzable(): int
-    {
-        $x = 'get';
-
-        return User::where('id', '>', 1)->{$x}()->count();
+        return DB::table('users')->max('id');
     }
 
     /**

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -36,6 +36,11 @@ class CorrectCollectionCalls
         return DB::table('users')->max('id');
     }
 
+    public function collectionCalls(): int
+    {
+        return collect([1, 2, 3])->flip()->reverse()->sum();
+    }
+
     /**
      * Can't analyze the closure as a parameter to contains, so should not throw any error.
      * @return bool

--- a/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use App\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class UnnecessaryCollectionCallsEloquent
+{
+    public function pluckId(): Collection
+    {
+        return User::all()->pluck('id');
+    }
+
+    public function testCallCountWrong(): int
+    {
+        return User::where('id', '>', 5)->get()->count();
+    }
+
+    public function testCallGetPluckWrong(): Collection
+    {
+        return User::query()->get()->pluck('id');
+    }
+
+    public function testCallCountWrongly(): int
+    {
+        return User::all()->count();
+    }
+
+    public function testCallFirstWrongly(): ?User
+    {
+        return User::all()->first();
+    }
+
+    public function testCallRelationTakeWrongly(): \Illuminate\Database\Eloquent\Collection
+    {
+        return User::firstOrFail()->accounts()->get()->take(2);
+    }
+
+    public function testDbQueryBuilder(): int
+    {
+        return DB::table('users')->get()->count();
+    }
+
+    public function testVarWrong(): bool
+    {
+        $query = User::query()->limit(3)->where('status', 'active');
+
+        return $query->get()->isEmpty();
+    }
+
+    public function testVarWrongFirst(): ?User
+    {
+        return User::where('id', 1)->get()->first();
+    }
+
+    public function testContainsWrong(): bool
+    {
+        return User::all()->contains(User::firstOrFail());
+    }
+
+    public function testPluckCountWrong(): int
+    {
+        return User::query()->pluck('id')->count();
+    }
+
+    public function testCallWhereWrong(): Collection
+    {
+        return User::all()->where('id', '<', 4);
+    }
+
+    public function testCallDiffWrong(): Collection
+    {
+        return User::all()->diff([1, 2, 3]);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function testCallModelKeysWrong(): array
+    {
+        return User::all()->modelKeys();
+    }
+
+    public function testContainsStrictWrong(): bool
+    {
+        return User::query()->get()->containsStrict('id', 1);
+    }
+}

--- a/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class UnnecessaryCollectionCallsQuery
+{
+    public function queryMax(): int
+    {
+        return DB::table('users')->get()->max('id');
+    }
+
+    public function queryAverageNoParam(): float
+    {
+        return DB::table('users')->pluck('id')->average();
+    }
+
+    public function queryNotEmpty(): bool
+    {
+        return DB::table('users')->pluck('id')->isNotEmpty();
+    }
+
+    public function queryPluck(): Collection
+    {
+        return DB::table('users')->get()->pluck('arbitraryName');
+    }
+}

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -19,31 +19,31 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
         $errors = $this->findErrorsByLine(__DIR__.'/Data/UnnecessaryCollectionCallsEloquent.php');
 
         $this->assertEquals([
-            15 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
-            20 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
-            25 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
-            30 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
-            35 => '[NoUnnecessaryCollectionCallRule] Called \'first\' on collection, but could have been retrieved as a query.',
-            40 => '[NoUnnecessaryCollectionCallRule] Called \'take\' on collection, but could have been retrieved as a query.',
-            45 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
-            52 => '[NoUnnecessaryCollectionCallRule] Called \'isEmpty\' on collection, but could have been retrieved as a query.',
-            57 => '[NoUnnecessaryCollectionCallRule] Called \'first\' on collection, but could have been retrieved as a query.',
-            62 => '[NoUnnecessaryCollectionCallRule] Called \'contains\' on collection, but could have been retrieved as a query.',
-            67 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
-            72 => '[NoUnnecessaryCollectionCallRule] Called \'where\' on collection, but could have been retrieved as a query.',
-            77 => '[NoUnnecessaryCollectionCallRule] Called \'diff\' on collection, but could have been retrieved as a query.',
-            85 => '[NoUnnecessaryCollectionCallRule] Called \'modelKeys\' on collection, but could have been retrieved as a query.',
-            90 => '[NoUnnecessaryCollectionCallRule] Called \'containsStrict\' on collection, but could have been retrieved as a query.',
+            15 => 'Called \'pluck\' on Laravel collection, but could have been retrieved as a query.',
+            20 => 'Called \'count\' on Laravel collection, but could have been retrieved as a query.',
+            25 => 'Called \'pluck\' on Laravel collection, but could have been retrieved as a query.',
+            30 => 'Called \'count\' on Laravel collection, but could have been retrieved as a query.',
+            35 => 'Called \'first\' on Laravel collection, but could have been retrieved as a query.',
+            40 => 'Called \'take\' on Laravel collection, but could have been retrieved as a query.',
+            45 => 'Called \'count\' on Laravel collection, but could have been retrieved as a query.',
+            52 => 'Called \'isEmpty\' on Laravel collection, but could have been retrieved as a query.',
+            57 => 'Called \'first\' on Laravel collection, but could have been retrieved as a query.',
+            62 => 'Called \'contains\' on Laravel collection, but could have been retrieved as a query.',
+            67 => 'Called \'count\' on Laravel collection, but could have been retrieved as a query.',
+            72 => 'Called \'where\' on Laravel collection, but could have been retrieved as a query.',
+            77 => 'Called \'diff\' on Laravel collection, but could have been retrieved as a query.',
+            85 => 'Called \'modelKeys\' on Laravel collection, but could have been retrieved as a query.',
+            90 => 'Called \'containsStrict\' on Laravel collection, but could have been retrieved as a query.',
         ], $errors);
     }
 
     public function testNoFalseNegativesQuery(): void
     {
         $this->assertSeeErrorsInOrder(__DIR__.'/Data/UnnecessaryCollectionCallsQuery.php', [
-            '[NoUnnecessaryCollectionCallRule] Called \'max\' on collection, but could have been retrieved as a query.',
-            '[NoUnnecessaryCollectionCallRule] Called \'average\' on collection, but could have been retrieved as a query.',
-            '[NoUnnecessaryCollectionCallRule] Called \'isNotEmpty\' on collection, but could have been retrieved as a query.',
-            '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
+            'Called \'max\' on Laravel collection, but could have been retrieved as a query.',
+            'Called \'average\' on Laravel collection, but could have been retrieved as a query.',
+            'Called \'isNotEmpty\' on Laravel collection, but could have been retrieved as a query.',
+            'Called \'pluck\' on Laravel collection, but could have been retrieved as a query.',
         ]);
     }
 }

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -19,31 +19,31 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
         $errors = $this->findErrorsByLine(__DIR__.'/Data/UnnecessaryCollectionCallsEloquent.php');
 
         $this->assertEquals($errors, [
-            15 => 'Called \'pluck\' on collection, but could have been retrieved as a query.',
-            20 => 'Called \'count\' on collection, but could have been retrieved as a query.',
-            25 => 'Called \'pluck\' on collection, but could have been retrieved as a query.',
-            30 => 'Called \'count\' on collection, but could have been retrieved as a query.',
-            35 => 'Called \'first\' on collection, but could have been retrieved as a query.',
-            40 => 'Called \'take\' on collection, but could have been retrieved as a query.',
-            45 => 'Called \'count\' on collection, but could have been retrieved as a query.',
-            52 => 'Called \'isEmpty\' on collection, but could have been retrieved as a query.',
-            57 => 'Called \'first\' on collection, but could have been retrieved as a query.',
-            62 => 'Called \'contains\' on collection, but could have been retrieved as a query.',
-            67 => 'Called \'count\' on collection, but could have been retrieved as a query.',
-            72 => 'Called \'where\' on collection, but could have been retrieved as a query.',
-            77 => 'Called \'diff\' on collection, but could have been retrieved as a query.',
-            85 => 'Called \'modelKeys\' on collection, but could have been retrieved as a query.',
-            90 => 'Called \'containsStrict\' on collection, but could have been retrieved as a query.',
+            15 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
+            20 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
+            25 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
+            30 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
+            35 => '[NoUnnecessaryCollectionCallRule] Called \'first\' on collection, but could have been retrieved as a query.',
+            40 => '[NoUnnecessaryCollectionCallRule] Called \'take\' on collection, but could have been retrieved as a query.',
+            45 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
+            52 => '[NoUnnecessaryCollectionCallRule] Called \'isEmpty\' on collection, but could have been retrieved as a query.',
+            57 => '[NoUnnecessaryCollectionCallRule] Called \'first\' on collection, but could have been retrieved as a query.',
+            62 => '[NoUnnecessaryCollectionCallRule] Called \'contains\' on collection, but could have been retrieved as a query.',
+            67 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
+            72 => '[NoUnnecessaryCollectionCallRule] Called \'where\' on collection, but could have been retrieved as a query.',
+            77 => '[NoUnnecessaryCollectionCallRule] Called \'diff\' on collection, but could have been retrieved as a query.',
+            85 => '[NoUnnecessaryCollectionCallRule] Called \'modelKeys\' on collection, but could have been retrieved as a query.',
+            90 => '[NoUnnecessaryCollectionCallRule] Called \'containsStrict\' on collection, but could have been retrieved as a query.',
         ]);
     }
 
     public function testNoFalseNegativesQuery(): void
     {
         $this->assertSeeErrorsInOrder(__DIR__.'/Data/UnnecessaryCollectionCallsQuery.php', [
-            'Called \'max\' on collection, but could have been retrieved as a query.',
-            'Called \'average\' on collection, but could have been retrieved as a query.',
-            'Called \'isNotEmpty\' on collection, but could have been retrieved as a query.',
-            'Called \'pluck\' on collection, but could have been retrieved as a query.',
+            '[NoUnnecessaryCollectionCallRule] Called \'max\' on collection, but could have been retrieved as a query.',
+            '[NoUnnecessaryCollectionCallRule] Called \'average\' on collection, but could have been retrieved as a query.',
+            '[NoUnnecessaryCollectionCallRule] Called \'isNotEmpty\' on collection, but could have been retrieved as a query.',
+            '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
         ]);
     }
 }

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Tests\RulesTest;
+
+class NoUnnecessaryCollectionCallRuleTest extends RulesTest
+{
+    public function testNoFalsePositives(): void
+    {
+        $errors = $this->findErrors(__DIR__ . '/Data/CorrectCollectionCalls.php');
+        $this->assertEquals([], $errors, 'The rule should not result in any errors for this data set.');
+    }
+
+    public function testNoFalseNegativesEloquent(): void
+    {
+        $errors = $this->findErrorsByLine(__DIR__ . '/Data/UnnecessaryCollectionCallsEloquent.php');
+
+        $this->assertEquals($errors, [
+            15 => 'Called \'pluck\' on collection, but could have been retrieved as a query.',
+            20 => 'Called \'count\' on collection, but could have been retrieved as a query.',
+            25 => 'Called \'pluck\' on collection, but could have been retrieved as a query.',
+            30 => 'Called \'count\' on collection, but could have been retrieved as a query.',
+            35 => 'Called \'first\' on collection, but could have been retrieved as a query.',
+            40 => 'Called \'take\' on collection, but could have been retrieved as a query.',
+            45 => 'Called \'count\' on collection, but could have been retrieved as a query.',
+            52 => 'Called \'isEmpty\' on collection, but could have been retrieved as a query.',
+            57 => 'Called \'first\' on collection, but could have been retrieved as a query.',
+            62 => 'Called \'contains\' on collection, but could have been retrieved as a query.',
+            67 => 'Called \'count\' on collection, but could have been retrieved as a query.',
+            72 => 'Called \'where\' on collection, but could have been retrieved as a query.',
+            77 => 'Called \'diff\' on collection, but could have been retrieved as a query.',
+            85 => 'Called \'modelKeys\' on collection, but could have been retrieved as a query.',
+            90 => 'Called \'containsStrict\' on collection, but could have been retrieved as a query.',
+        ]);
+    }
+
+    public function testNoFalseNegativesQuery(): void
+    {
+        $this->assertSeeErrorsInOrder(__DIR__ . '/Data/UnnecessaryCollectionCallsQuery.php', [
+            'Called \'max\' on collection, but could have been retrieved as a query.',
+            'Called \'average\' on collection, but could have been retrieved as a query.',
+            'Called \'isNotEmpty\' on collection, but could have been retrieved as a query.',
+            'Called \'pluck\' on collection, but could have been retrieved as a query.',
+        ]);
+    }
+}

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -10,13 +10,13 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
 {
     public function testNoFalsePositives(): void
     {
-        $errors = $this->findErrors(__DIR__ . '/Data/CorrectCollectionCalls.php');
+        $errors = $this->findErrors(__DIR__.'/Data/CorrectCollectionCalls.php');
         $this->assertEquals([], $errors, 'The rule should not result in any errors for this data set.');
     }
 
     public function testNoFalseNegativesEloquent(): void
     {
-        $errors = $this->findErrorsByLine(__DIR__ . '/Data/UnnecessaryCollectionCallsEloquent.php');
+        $errors = $this->findErrorsByLine(__DIR__.'/Data/UnnecessaryCollectionCallsEloquent.php');
 
         $this->assertEquals($errors, [
             15 => 'Called \'pluck\' on collection, but could have been retrieved as a query.',
@@ -39,7 +39,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
 
     public function testNoFalseNegativesQuery(): void
     {
-        $this->assertSeeErrorsInOrder(__DIR__ . '/Data/UnnecessaryCollectionCallsQuery.php', [
+        $this->assertSeeErrorsInOrder(__DIR__.'/Data/UnnecessaryCollectionCallsQuery.php', [
             'Called \'max\' on collection, but could have been retrieved as a query.',
             'Called \'average\' on collection, but could have been retrieved as a query.',
             'Called \'isNotEmpty\' on collection, but could have been retrieved as a query.',

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -18,7 +18,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
     {
         $errors = $this->findErrorsByLine(__DIR__.'/Data/UnnecessaryCollectionCallsEloquent.php');
 
-        $this->assertEquals($errors, [
+        $this->assertEquals([
             15 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
             20 => '[NoUnnecessaryCollectionCallRule] Called \'count\' on collection, but could have been retrieved as a query.',
             25 => '[NoUnnecessaryCollectionCallRule] Called \'pluck\' on collection, but could have been retrieved as a query.',
@@ -34,7 +34,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
             77 => '[NoUnnecessaryCollectionCallRule] Called \'diff\' on collection, but could have been retrieved as a query.',
             85 => '[NoUnnecessaryCollectionCallRule] Called \'modelKeys\' on collection, but could have been retrieved as a query.',
             90 => '[NoUnnecessaryCollectionCallRule] Called \'containsStrict\' on collection, but could have been retrieved as a query.',
-        ]);
+        ], $errors);
     }
 
     public function testNoFalseNegativesQuery(): void

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -26,6 +26,7 @@ abstract class RulesTest extends TestCase
     protected function findErrorsByLine(string $filename): array
     {
         $errors = $this->findErrors($filename);
+
         return collect($errors['messages'] ?? [])->mapWithKeys(function ($message) {
             return [$message['line'] => $message['message']];
         })->toArray();

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -26,7 +26,7 @@ abstract class RulesTest extends TestCase
     protected function findErrorsByLine(string $filename): array
     {
         $errors = $this->findErrors($filename);
-        return collect($errors['messages'])->mapWithKeys(function ($message) {
+        return collect($errors['messages'] ?? [])->mapWithKeys(function ($message) {
             return [$message['line'] => $message['message']];
         })->toArray();
     }

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+abstract class RulesTest extends TestCase
+{
+    /**
+     * Returns an array of errors that were found after analyzing $filename.
+     * @param string $filename
+     * @return array
+     */
+    protected function findErrors(string $filename): array
+    {
+        return $this->execLarastan($filename)['files'][$filename] ?? [];
+    }
+
+    /**
+     * Returns an associative Collection where each key represents the line
+     * number and the value represents the error found. Will return
+     * at most one error per line.
+     * @param string $filename
+     * @return array<int, string>
+     */
+    protected function findErrorsByLine(string $filename): array
+    {
+        $errors = $this->findErrors($filename);
+        return collect($errors['messages'])->mapWithKeys(function ($message) {
+            return [$message['line'] => $message['message']];
+        })->toArray();
+    }
+
+    /**
+     * Tests whether the expected errors were found in a particular order
+     * after analyzing $filename.
+     * @param string $filename
+     * @param array $expected
+     */
+    protected function assertSeeErrorsInOrder(string $filename, array $expected): void
+    {
+        $errors = array_values($this->findErrorsByLine($filename));
+        $this->assertEquals($expected, $errors);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\File;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    public function setUpFiles(): void
+    {
+        @File::makeDirectory(__DIR__ . '/../vendor/nunomaduro/larastan', 0755, true);
+        @File::makeDirectory(__DIR__ . '/../vendor/nunomaduro/larastan/config', 0755, true);
+        @File::copy(__DIR__.'/../bootstrap.php', __DIR__.'/../vendor/nunomaduro/larastan/bootstrap.php');
+        @File::copy(__DIR__.'/../config/mixins.php', __DIR__.'/../vendor/nunomaduro/larastan/config/mixins.php');
+        @File::copy(__DIR__.'/../config/statics.php', __DIR__.'/../vendor/nunomaduro/larastan/config/statics.php');
+        File::copyDirectory(__DIR__.'/Application/database/migrations', $this->getBasePath().'/database/migrations');
+    }
+
+    public function execLarastan(string $filename)
+    {
+        $configPath = __DIR__.'/../extension.neon';
+        $command = escapeshellcmd(__DIR__.'/../vendor/bin/phpstan');
+
+        exec(sprintf('%s %s analyse --no-progress  --level=max --configuration %s --autoload-file %s %s --error-format=%s',
+            escapeshellarg(PHP_BINARY), $command,
+            escapeshellarg($configPath),
+            escapeshellarg(__DIR__.'/../vendor/autoload.php'),
+            escapeshellarg($filename),
+            'json'),
+            $jsonResult);
+
+        return json_decode($jsonResult[0], true);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,10 +7,12 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    public function setUpFiles(): void
+    public function setUp(): void
     {
-        @File::makeDirectory(__DIR__ . '/../vendor/nunomaduro/larastan', 0755, true);
-        @File::makeDirectory(__DIR__ . '/../vendor/nunomaduro/larastan/config', 0755, true);
+        parent::setUp();
+
+        @File::makeDirectory(__DIR__.'/../vendor/nunomaduro/larastan', 0755, true);
+        @File::makeDirectory(__DIR__.'/../vendor/nunomaduro/larastan/config', 0755, true);
         @File::copy(__DIR__.'/../bootstrap.php', __DIR__.'/../vendor/nunomaduro/larastan/bootstrap.php');
         @File::copy(__DIR__.'/../config/mixins.php', __DIR__.'/../vendor/nunomaduro/larastan/config/mixins.php');
         @File::copy(__DIR__.'/../config/statics.php', __DIR__.'/../vendor/nunomaduro/larastan/config/statics.php');


### PR DESCRIPTION
# Description

This pull request serves as a proof of concept for a new rule I'd like to have added to Larastan in light of https://github.com/nunomaduro/larastan/issues/326. 

This rule would detect method calls such as `count()` on a collection that could have been called immediately on a query builder instance. Using the query builder to determine the result uses less memory and can be much faster.

#### Example 1
To determine the number of users, one could query all users into a Collection and then call `count()` on that Collection:
```php
$num_users = User::all()->count();
```
But it is much more efficient to just user the query builder to determine the count:
```php
$num_users = User::count();
```
#### Example 2
To determine if a certain `$user` has a role with a particular name, we could query all names of the roles that belong to that user and then loop over the collection to find if it contains that particular name:
```php
$user->roles()->pluck('name')->contains('a role name');
```
But again, we can also do this in a single query:
```php
$user->roles()->where('name', 'a role name')->exists();
```

#### More examples
There are plenty more scenario's where only a query could be used to more efficiently determine something. Below are some more examples. On the left side is the incorrect / inefficient form, on the right side is the more efficient form (only using a query).

<details>

```php

User::all()->first(); // User::first()
User::all()->find([1, 2]); // User::whereIn('id', [1, 2])->get()
User::all()->pluck('id'); // User::pluck('id')
User::whereActive()->get()->only([1, 2]); // User::whereActive()->whereIn('id' [1, 2])->get()
$user->roles()->whereSomething()->get()->isEmpty(); // $user->roles()->whereSomething()->doesntExist()
User::query()->get()->modelKeys(); // User::query()->pluck('id');
User::all()->max('age'); // User::max('age');
User::all()->take(3); // User::take(3)->get();
Post::pluck('num_likes')->sum(); // Post::sum('num_likes');
User::get()->last(); // <Flip the applied ordering> User::orderBy('id', 'desc')->first()
User::all()->slice(4, 2); // User::take(2)->skip(4)->get();
User::all()->where('name', 'Taylor'); // User::where('name', 'Taylor')->get()
User::all()->contains('id', '>', 5); // User::where('id', '>', 5)->exists()
DB::table('users')->where('age', '>', 90)->get()->isNotEmpty(); // DB::table('users')->where('age', '>', 90)->exists()
```
</details>

## Implementation
The implementation I provide checks all method calls on any object that is a subtype of `Illuminate\Support\Collection`. It then checks whether that collection was obtained by calling some method on a query builder instance. Depending on what method is called on the collection and what arguments are supplied to that method, the rule might produce an error. For example, if you call sum with a closure:
```php
User::all()->sum(function (User $user): int { return $user->age; });
```
the rule does not produce an error. But if you use the shorthand notation using a string:
```php
User::all()->sum('age');
```
It will throw an error. The rule actually checks whether the argument exists as a property on your model. The following, will not report an error:
```php
User::with(['roles'])->get()->pluck('roles');
```
## Considerations
### Overriding methods on Custom Collections
Since this implementation supports custom Collection classes, it is possible that a user has overridden some of the native collections methods with a nonintuitive implementation. The `max()` method might do something that is not possible with a regular query and Larastan will report a false positive. We could disable the rule for methods that are called on a custom collection and are also overridden, but I do not think it's worth it as this should be, as far as I know, an extremely rare scenario.

### Proper testing
As far as I could see, there isn't a proper way to test rules yet in this repository, is there? The current tests are not that useful as they can only check whether no error message is reported, but we should really be checking the inverse.

Here some tests that should produce an error message:

<details>

```php

<?php

declare(strict_types=1);

namespace Tests\Features\Rules;

use App\User;
use Illuminate\Support\Collection;

class NoUnnecessaryCollectionCallRuleTest
{
    public function testCallCountWrong(): int
    {
        return User::where('id', '>', 5)->get()->count();
    }

    public function testCallGetPluckWrong(): Collection
    {
        return User::query()->get()->pluck('id');
    }

    public function testCallCountWrongly(): int
    {
        return User::all()->count();
    }

    public function testCallFirstWrongly(): ?User
    {
        return User::all()->first();
    }

    public function testCallRelationTakeWrongly(): \Illuminate\Database\Eloquent\Collection
    {
        return User::firstOrFail()->accounts()->get()->take(2);
    }

    public function testDbQueryBuilder(): int
    {
        return DB::table('users')->get()->count();
    }

    public function testVarWrong(): bool
    {
        $query = User::query()->limit(3)->where('status', 'active');

        return $query->get()->isEmpty();
    }

    public function testVarWrongFirst(): ?User
    {
        return User::where('id', 1)->get()->first();
    }

    public function testContainsWrong(): bool
    {
        return User::all()->contains(User::firstOrFail());
    }

    public function testPluckCountWrong(): int
    {
        return User::query()->pluck('id')->count();
    }

    public function testCallWhereWrong(): Collection
    {
        return User::all()->where('id', '<', 4);
    }

    public function testCallDiffWrong(): Collection
    {
        return User::all()->diff([1, 2, 3]);
    }

    /**
     * @return int[]
     */
    public function testCallModelKeysWrong(): array
    {
        return User::all()->modelKeys();
    }

    public function testContainsStrictWrong(): bool
    {
        return User::query()->get()->containsStrict('id', 1);
    }

    public function testMaxWrong(): int
    {
        return User::query()->get()->max('id');
    }
}

```
</details>

#### Disclaimer
I have no previous experience with Larastan, PHPStan or PHP-parser. My implementation might be really shitty. This pull request serves more as a proof of concept. You are free to throw this implementation away. As long as something like this gets added to Larastan, I'd be really happy. If you have any suggests for improvements, I'd be happy to implement them.
