### PR TITLE
Add value helper extension

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -223,6 +223,11 @@ services:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\ValueExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\StorageDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/Helpers/ValueExtension.php
+++ b/src/ReturnTypes/Helpers/ValueExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use function count;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+
+/**
+ * @internal
+ */
+final class ValueExtension implements DynamicFunctionReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'value';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        if (count($functionCall->args) === 0) {
+            return new NeverType();
+        }
+
+        $arg = $functionCall->args[0]->value;
+        if ($arg instanceof Closure) {
+            $callbackType = $scope->getType($arg);
+            $callbackReturnType = ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $functionCall->args,
+                $callbackType->getCallableParametersAcceptors($scope)
+            )->getReturnType();
+
+            return $callbackReturnType;
+        }
+
+        return $scope->getType($arg);
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/ValueExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/ValueExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use App\User;
+
+class ValueExtension
+{
+    public function testClosure(): ?User
+    {
+        return value(function (): ?User {
+            return User::first();
+        });
+    }
+
+    public function testInt(): int
+    {
+        return value(5);
+    }
+}


### PR DESCRIPTION
Adds an extension for the value helper function such that the return type is correctly inferred.

The following will now be seen as invalid:

```php
public function returnInt(): int
{
    return value('string'); // string and int mismatch
}

public function returnClosureInt(): int
{
   return value(function (): string {
       return 'string'; // string and int mismatch
  });
}
```

