### PR TITLE
Fix NoUnnecessaryCollectionCallRule when query result is mixed

### DIFF
--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -151,7 +151,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
         /** @var \PhpParser\Node\Identifier $name */
         $name = $node->name;
 
-        if ($this->isNotCalledOnCollection($node->var, $scope)) {
+        if (! $this->isCalledOnCollection($node->var, $scope)) {
             // Method was not called on a collection, so no errors.
             return [];
         }
@@ -312,11 +312,11 @@ class NoUnnecessaryCollectionCallRule implements Rule
      * @param Scope $scope
      * @return bool
      */
-    protected function isNotCalledOnCollection(Node\Expr $expr, Scope $scope): bool
+    protected function isCalledOnCollection(Node\Expr $expr, Scope $scope): bool
     {
         $calledOnType = $scope->getType($expr);
 
-        return (new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->no();
+        return (new ObjectType(Collection::class))->isSuperTypeOf($calledOnType)->yes();
     }
 
     /**

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -6,6 +6,8 @@ namespace Tests\Rules\Data;
 
 use App\Account;
 use App\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -46,6 +48,11 @@ class CorrectCollectionCalls
         return collect([1, 2, 3])->flip()->reverse()->sum();
     }
 
+    public function mixedReturn(): ?Foo
+    {
+        return Foo::query()->returnMixed()->first();
+    }
+
     /**
      * Can't analyze the closure as a parameter to contains, so should not throw any error.
      * @return bool
@@ -66,5 +73,32 @@ class CorrectCollectionCalls
         return User::where('id', '>', 1)->get()->first(function (User $user): bool {
             return $user->id === 2;
         });
+    }
+}
+
+class Foo extends Model
+{
+    /**
+     * @param \Illuminate\Database\Query\Builder $query
+     * @return FooBuilder
+     */
+    public function newEloquentBuilder($query): FooBuilder
+    {
+        return new FooBuilder($query);
+    }
+}
+
+/**
+ * @extends Builder<Foo>
+ */
+class FooBuilder extends Builder
+{
+    /**
+     * @return mixed
+     */
+    public function returnMixed()
+    {
+        /** @var mixed */
+        return $this;
     }
 }


### PR DESCRIPTION
Ensures the rule is only applied when we are certain that we have a collection.

Fixes false positives when the result of a query is inferred as `mixed` instead of `Builder`.