### PR TITLE
Add better collection stubs

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -55,4 +55,23 @@ class Collection implements \ArrayAccess, Enumerable
      * @return TValue|null
      */
     public function shift() {}
+
+    /**
+     * @param callable(TValue, TKey): (void|bool) $callable
+     * @return static<TValue>
+     */
+    public function each($callable) {}
+
+    /**
+     * @template TReturn
+     * @param callable(TValue, TKey): TReturn $callable
+     * @return static<TKey, TReturn>
+     */
+    public function map($callable) {}
+
+    /**
+     * @param callable(static<TValue>): void $callable
+     * @return static<TValue>
+     */
+    public function tap($callable) {}
 }

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -14,4 +14,11 @@ class Collection extends \Illuminate\Support\Collection
      * @phpstan-return TModel|null
      */
     public function find($key, $default = null) {}
+
+    /**
+     * @template TReturn
+     * @param callable(TModel, int): TReturn $callable
+     * @return static<TReturn>|\Illuminate\Support\Collection<int, TReturn>
+     */
+    public function map($callable) {}
 }

--- a/tests/Features/ReturnTypes/CollectionStub.php
+++ b/tests/Features/ReturnTypes/CollectionStub.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\Role;
+use App\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as SupportCollection;
+
+class CollectionStub
+{
+    /**
+     * @return EloquentCollection<User>
+     */
+    public function testEachUserParam(): EloquentCollection
+    {
+        return User::all()->each(function (User $user, int $key): void {
+            echo $user->id . $key;
+        });
+    }
+
+    /**
+     * @param SupportCollection<class-string, int> $items
+     * @return SupportCollection<class-string, int>
+     */
+    public function testEachWithoutParams(SupportCollection $items): SupportCollection
+    {
+        return $items->each(function (): bool {
+            return false;
+        });
+    }
+
+    /**
+     * @param SupportCollection<int> $items
+     * @return SupportCollection<string>
+     */
+    public function testMap(SupportCollection $items): SupportCollection
+    {
+        return $items->map(function (int $item): string {
+            return (string) $item;
+        });
+    }
+
+    /**
+     * @param EloquentCollection<User> $items
+     * @return EloquentCollection<User>
+     */
+    public function testTap(EloquentCollection $items): EloquentCollection
+    {
+        return $items->tap(function ($collection): void {
+            $first = $collection->first();
+            if (is_null($first)) {
+                echo 'Null';
+            } else {
+                echo $first->id;
+            }
+        });
+    }
+}

--- a/tests/Features/ReturnTypes/CollectionStub.php
+++ b/tests/Features/ReturnTypes/CollectionStub.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes;
 
-use App\Role;
 use App\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as SupportCollection;
@@ -17,7 +16,7 @@ class CollectionStub
     public function testEachUserParam(): EloquentCollection
     {
         return User::all()->each(function (User $user, int $key): void {
-            echo $user->id . $key;
+            echo $user->id.$key;
         });
     }
 


### PR DESCRIPTION
Adds better stubs for Collection methods such that Larastan understands them better.

Larastan will now understand that e.g. the following things are not valid:
```php
User::all()->each(function (int $user, User $key): void { // Expects User as first parameter and int as second

});

/**
  * @param EloquentCollection<User>
  * @return Collection<User>    // Collection<User> and Collection<string> mismatch
  */
public function getNames($items)
{
   return $items->map(function (User $user): string {
       return $user->name;
  });
}
```