### PR TITLE
No invalid route action rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -51,3 +51,37 @@ on the `contains` method, one could set the following value:
 noUnnecessaryCollectionCallExcept: ['contains']
 ```
 
+## NoInvalidRouteAction
+
+Checks if the class and method that a route uses exist when registering a route using 
+the Route facade.
+
+#### Examples
+
+```php
+Route::get('/hello', [UserController::class, 'nonExistingMethod']);
+
+Route::match(['put', 'patch'], '/endpoint', 'App\Http\Controllers\UserTypoController@index');
+
+Route::post('/post', [
+    'uses' => 'App\Http\Controllers\UserController@typo',
+]);
+```
+
+results in the following errors:
+```
+Detected non-existing method 'nonExistingMethod' on class 'App\\Http\\Controllers\\UserController during route registration.
+Detected non-existing class 'App\Http\Controllers\UserTypoController' during route registration.
+Detected non-existing method 'typo' on class 'App\\Http\\Controllers\\UserController during route registration.
+```
+
+This rule assumes that no [namespace is set on your route groups](https://laravel.com/docs/7.x/routing#route-group-namespaces).
+Since Laravel has a namespace set by default in the `RouteServiceProvider`, this rule is also disabled by default.
+
+To enable this rule, set:
+```
+parameters:
+    noInvalidRouteAction: true
+```
+
+in your `phpstan.neon` config file.

--- a/extension.neon
+++ b/extension.neon
@@ -37,15 +37,19 @@ parameters:
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
+    noInvalidRouteAction: false
 
 parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
+    noInvalidRouteAction: bool()
 
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
-    		phpstan.rules.rule: %noUnnecessaryCollectionCall%
+         phpstan.rules.rule: %noUnnecessaryCollectionCall%
+    NunoMaduro\Larastan\Rules\NoInvalidRouteActionRule:
+             phpstan.rules.rule: %noInvalidRouteAction%
 
 services:
     -
@@ -249,6 +253,9 @@ services:
         arguments:
             onlyMethods: %noUnnecessaryCollectionCallOnly%
             excludeMethods: %noUnnecessaryCollectionCallExcept%
+
+    -
+        class: NunoMaduro\Larastan\Rules\NoInvalidRouteActionRule
 
     -
         class: NunoMaduro\Larastan\Types\GenericEloquentBuilderTypeNodeResolverExtension

--- a/extension.neon
+++ b/extension.neon
@@ -49,7 +49,7 @@ conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
          phpstan.rules.rule: %noUnnecessaryCollectionCall%
     NunoMaduro\Larastan\Rules\NoInvalidRouteActionRule:
-             phpstan.rules.rule: %noInvalidRouteAction%
+         phpstan.rules.rule: %noInvalidRouteAction%
 
 services:
     -

--- a/src/Rules/NoInvalidRouteActionRule.php
+++ b/src/Rules/NoInvalidRouteActionRule.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * This rule checks if the action of a route points to a valid Controller
+ * method.
+ */
+class NoInvalidRouteActionRule implements Rule
+{
+    /**
+     * The method names that can register a route.
+     * @var string[]
+     */
+    protected const REGISTERING_METHODS = [
+        'any',
+        'delete',
+        'get',
+        'match',
+        'options',
+        'patch',
+        'post',
+        'put',
+    ];
+    /**
+     * @var \PHPStan\Reflection\ReflectionProvider
+     */
+    protected $reflectionProvider;
+
+    /**
+     * NoInvalidRouteActionRule constructor.
+     * @param ReflectionProvider $reflectionProvider
+     */
+    public function __construct(
+        ReflectionProvider $reflectionProvider
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return Node\Expr\StaticCall::class;
+    }
+
+    /**
+     * @param Node $node
+     * @param Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var \PhpParser\Node\Expr\StaticCall $node */
+        if (! $this->isRegisteringRoute($node)) {
+            return [];
+        }
+
+        $method_name = $node->name->toLowerString();
+
+        if (! $this->canAnalyzeArguments($node->args, $method_name)) {
+            return [];
+        }
+
+        $parsed = $this->parseArgument($node->args[$method_name === 'match' ? 2 : 1]);
+
+        if ($parsed === null) {
+            return [];
+        }
+
+        [$controller, $method] = $parsed;
+
+        if (! class_exists($controller)) {
+            return ["Detected non-existing class '{$controller}' during route registration."];
+        }
+
+        if (is_string($method) && ! method_exists($controller, $method)) {
+            return ["Detected non-existing method '{$method}' on class '{$controller}' during route registration."];
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns whether this static call is registering a new endpoint.
+     * @param Node $node
+     * @return bool
+     */
+    protected function isRegisteringRoute(Node $node): bool
+    {
+        if ($node->class->toString() !== Route::class) {
+            return false;
+        }
+        return in_array($node->name->toLowerString(), self::REGISTERING_METHODS, true);
+    }
+
+    /**
+     * Returns whether we can properly analyze the argument that was passed
+     * to the static method call.
+     * @param array $arguments
+     * @param string $method_name
+     * @return bool
+     */
+    protected function canAnalyzeArguments(array $arguments, string $method_name): bool
+    {
+        $required_arguments = $method_name === 'match' ? 3 : 2;
+        if (count($arguments) < $required_arguments) {
+            return false;
+        }
+
+        $second_arg = $arguments[$required_arguments - 1];
+        return $second_arg->value instanceof Node\Expr\Array_
+            || $second_arg->value instanceof Node\Scalar\String_;
+    }
+
+    /**
+     * Attempts to parse the argument and return both the controller class and method name.
+     * Returns null if it was unable to parse the argument.
+     * @param Node\Arg $arg
+     * @return string[]|null - Null when the arguments could not reliably be parsed.
+     */
+    protected function parseArgument(Node\Arg $arg): ?array
+    {
+        $value = $arg->value;
+        if ($value instanceof Node\Expr\Array_) {
+            if ($this->hasCallableArrayNotation($value)) {
+                return [
+                    $this->getControllerClass($value),
+                    $value->items[1]->value->value
+                ];
+            }
+
+            if (($value = $this->getUsesParam($value)) === null) {
+                return null;
+            }
+        }
+
+        if ($value instanceof Node\Scalar\String_) {
+            return $this->getControllerAndMethodFromString($value->value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the value of the 'uses' key in the array, or null if it does not exist.
+     * @param Node\Expr\Array_ $value
+     * @return Node\Expr|null
+     */
+    protected function getUsesParam(Node\Expr\Array_ $value): ?Node\Expr
+    {
+        $uses = Arr::first($value->items, function (Node\Expr\ArrayItem $item): bool {
+            return $item->key->value === 'uses';
+        });
+
+        return $uses ? $uses->value : null;
+    }
+
+    /**
+     * Gets the controller class as a string from the Node.
+     * @param Node\Expr\Array_ $value
+     * @return string
+     * @throws ShouldNotHappenException
+     */
+    protected function getControllerClass(Node\Expr\Array_ $value): string
+    {
+        $first_arg = $value->items[0]->value;
+        if ($first_arg instanceof Node\Expr\ClassConstFetch) {
+            return $first_arg->class->toCodeString();
+        }
+
+        if ($first_arg instanceof Node\Scalar\String_) {
+            return $first_arg->value;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+
+    /**
+     * Given a string ith a value of 'App\SomeController@index',
+     * will return ['App\SomeController', 'index']. In the case of an invokable controller:
+     * 'App\SomeOtherController', it will return ['App\SomeController', '__invoke'].
+     * @param string $action
+     * @return string[]
+     */
+    protected function getControllerAndMethodFromString(string $action): array
+    {
+        if (Str::contains($action, '@')) {
+            return [
+                Str::before($action, '@'),
+                Str::after($action, '@'),
+            ];
+        }
+
+        return [$action, '__invoke'];
+    }
+
+    /**
+     * Returns whether the route is being registered using the [Controller::class, 'index'] method.
+     * @param Node\Expr\Array_ $array
+     * @return bool
+     */
+    protected function hasCallableArrayNotation(Node\Expr\Array_ $array): bool
+    {
+        if (count($array->items) !== 2) {
+            return false;
+        }
+
+        if (! ($array->items[1]->value instanceof Node\Scalar\String_)) {
+            return false;
+        }
+
+        if ($array->items[1]->key->value !== null) {
+            // Ensure we don't have an associative array
+            return false;
+        }
+
+        return $array->items[0]->value instanceof Node\Scalar\String_
+            || $array->items[0]->value instanceof Node\Expr\ClassConstFetch;
+    }
+}

--- a/src/Rules/NoInvalidRouteActionRule.php
+++ b/src/Rules/NoInvalidRouteActionRule.php
@@ -136,6 +136,7 @@ class NoInvalidRouteActionRule implements Rule
         }
 
         $second_arg = $arguments[$required_arguments - 1];
+
         return $second_arg->value instanceof Node\Expr\Array_
             || $second_arg->value instanceof Node\Scalar\String_;
     }
@@ -154,6 +155,7 @@ class NoInvalidRouteActionRule implements Rule
                 $controller_class = $this->getControllerClass($value);
                 /** @var Node\Scalar\String_ $method */
                 $method = $value->items[1]->value;
+
                 return $controller_class !== null ? [
                     $controller_class,
                     $method->value,

--- a/src/Rules/NoInvalidRouteActionRule.php
+++ b/src/Rules/NoInvalidRouteActionRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Rules;
 
+use Illuminate\Routing\Controller;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
@@ -11,7 +12,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * This rule checks if the action of a route points to a valid Controller
@@ -90,8 +90,11 @@ class NoInvalidRouteActionRule implements Rule
             return ["Detected non-existing class '{$controller}' during route registration."];
         }
 
-        if (is_string($method) && ! method_exists($controller, $method)) {
-            return ["Detected non-existing method '{$method}' on class '{$controller}' during route registration."];
+        if (is_string($method)) {
+            $classReflection = $this->reflectionProvider->getClass($controller);
+            if (! $classReflection->hasMethod($method)) {
+                return ["Detected non-existing method '{$method}' on class '{$controller}' during route registration."];
+            }
         }
 
         return [];

--- a/tests/Application/app/Http/Controllers/UserController.php
+++ b/tests/Application/app/Http/Controllers/UserController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+    }
+}

--- a/tests/Rules/Data/InvalidRouteActions.php
+++ b/tests/Rules/Data/InvalidRouteActions.php
@@ -15,6 +15,8 @@ class InvalidRouteActions
             ->name('hello');
 
         Route::post('/bye', [UserController::class, 'notAMethod']);
+
+        Route::options('/magical', [FooController::class, 'magic']);
     }
 
     public function testString(): void
@@ -41,5 +43,16 @@ class InvalidRouteActions
         Route::group(['middleware' => 'can:destroy cookies'], function (): void {
             Route::delete('/cookie/{cookie}', [UserController::class, 'typo']);
         });
+    }
+}
+
+class FooController
+{
+    /**
+     * @param string $name
+     * @param array<mixed> $arguments
+     */
+    public function __call($name, $arguments): void
+    {
     }
 }

--- a/tests/Rules/Data/InvalidRouteActions.php
+++ b/tests/Rules/Data/InvalidRouteActions.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use App\Http\Controllers\UserController;
+use Illuminate\Support\Facades\Route;
+
+class InvalidRouteActions
+{
+    public function testArray(): void
+    {
+        Route::get('/hello', ['\Not\A\Controller', 'index'])
+            ->name('hello');
+
+        Route::post('/bye', [UserController::class, 'notAMethod']);
+    }
+
+    public function testString(): void
+    {
+        Route::patch('/some/route', 'non_existing_class@non_existing_method');
+
+        Route::match(['put', 'patch'], '/hello', '\App\Http\Controllers\UserController@non_existing_method');
+    }
+
+    public function testUses(): void
+    {
+        Route::patch('/patch-something', [
+            'uses' => '',
+            'name' => 'uses-empty-string',
+        ]);
+
+        Route::any('/any', [
+            'uses' => '\App\Http\Controllers\UserController@nonExisting',
+        ]);
+    }
+
+    public function testGroup(): void
+    {
+        Route::group(['middleware' => 'can:destroy cookies'], function (): void {
+            Route::delete('/cookie/{cookie}', [UserController::class, 'typo']);
+        });
+    }
+}

--- a/tests/Rules/Data/ValidRouteActions.php
+++ b/tests/Rules/Data/ValidRouteActions.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use App\Http\Controllers\UserController;
+use Illuminate\Support\Facades\Route;
+
+class ValidRouteActions
+{
+    public function testArray(): void
+    {
+        Route::get('/hello', [UserController::class, 'index'])
+            ->name('hello');
+
+        Route::post('/bye', ['Tests\Rules\Data\FruitController', 'getPears'])
+            ->name('bye')
+            ->middleware('can:say bye');
+    }
+
+    public function testString(): void
+    {
+        Route::patch('/some/route', 'Tests\Rules\Data\FruitController@getPears');
+
+        Route::match(['put', 'patch'], '/hello', FruitController::class . '@non_existing_method');
+
+        $controller = UserController::class;
+        Route::get('/users', $controller . '@index');
+    }
+
+    public function testUses(): void
+    {
+        Route::patch('/patch-something', [
+            'uses' => FruitController::class . '@getPears',
+            'name' => 'some-name',
+        ]);
+
+        Route::any('/any', [
+            'uses' => 'Tests\Rules\Data\FruitController@getApples',
+        ]);
+    }
+
+    public function testGroup(): void
+    {
+        Route::group(['middleware' => 'can:get fruit'], function (): void {
+            foreach (['getApples', 'getPears'] as $method) {
+                Route::get('/fruit/' . $method, [FruitController::class, $method]);
+            }
+        });
+    }
+}
+
+class FruitController {
+    public function getApples(): void
+    {
+    }
+
+    public function getPears(): void
+    {
+    }
+}

--- a/tests/Rules/Data/ValidRouteActions.php
+++ b/tests/Rules/Data/ValidRouteActions.php
@@ -24,16 +24,16 @@ class ValidRouteActions
     {
         Route::patch('/some/route', 'Tests\Rules\Data\FruitController@getBananas');
 
-        Route::match(['put', 'patch'], '/hello', FruitController::class . '@non_existing_method');
+        Route::match(['put', 'patch'], '/hello', FruitController::class.'@non_existing_method');
 
         $controller = UserController::class;
-        Route::get('/users', $controller . '@index');
+        Route::get('/users', $controller.'@index');
     }
 
     public function testUses(): void
     {
         Route::patch('/patch-something', [
-            'uses' => MagicalController::class . '@index',
+            'uses' => MagicalController::class.'@index',
             'name' => 'some-name',
         ]);
 
@@ -46,7 +46,7 @@ class ValidRouteActions
     {
         Route::group(['middleware' => 'can:get fruit'], function (): void {
             foreach (['getApples', 'getPears'] as $method) {
-                Route::get('/fruit/' . $method, [FruitController::class, $method]);
+                Route::get('/fruit/'.$method, [FruitController::class, $method]);
             }
         });
     }

--- a/tests/Rules/Data/ValidRouteActions.php
+++ b/tests/Rules/Data/ValidRouteActions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Rules\Data;
 
 use App\Http\Controllers\UserController;
+use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Route;
 
 class ValidRouteActions
@@ -21,7 +22,7 @@ class ValidRouteActions
 
     public function testString(): void
     {
-        Route::patch('/some/route', 'Tests\Rules\Data\FruitController@getPears');
+        Route::patch('/some/route', 'Tests\Rules\Data\FruitController@getBananas');
 
         Route::match(['put', 'patch'], '/hello', FruitController::class . '@non_existing_method');
 
@@ -32,7 +33,7 @@ class ValidRouteActions
     public function testUses(): void
     {
         Route::patch('/patch-something', [
-            'uses' => FruitController::class . '@getPears',
+            'uses' => MagicalController::class . '@index',
             'name' => 'some-name',
         ]);
 
@@ -51,12 +52,33 @@ class ValidRouteActions
     }
 }
 
-class FruitController {
+/**
+ * @method int getBananas()
+ */
+class FruitController
+{
     public function getApples(): void
     {
     }
 
     public function getPears(): void
     {
+    }
+}
+
+class MagicalController extends Controller
+{
+    public function index(): void
+    {
+    }
+
+    /**
+     * @param string $method
+     * @param array<mixed> $parameters
+     * @return int
+     */
+    public function __call($method, $parameters)
+    {
+        return $method === 'magic' ? 1 : 2;
     }
 }

--- a/tests/Rules/NoInvalidRouteActionTest.php
+++ b/tests/Rules/NoInvalidRouteActionTest.php
@@ -11,7 +11,7 @@ class NoInvalidRouteActionTest extends RulesTest
     public function testNoFalsePositives(): void
     {
         $errors = $this->findErrors(__DIR__.'/Data/ValidRouteActions.php', [
-            'config' => __DIR__.'/configs/valid-route-actions.neon'
+            'config' => __DIR__.'/configs/valid-route-actions.neon',
         ]);
         $this->assertEquals([], $errors, 'The rule should not result in any errors for this data set.');
     }
@@ -19,7 +19,7 @@ class NoInvalidRouteActionTest extends RulesTest
     public function testNoFalseNegatives(): void
     {
         $errors = $this->findErrorsByLine(__DIR__.'/Data/InvalidRouteActions.php', [
-            'config' => __DIR__.'/configs/valid-route-actions.neon'
+            'config' => __DIR__.'/configs/valid-route-actions.neon',
         ]);
 
         $this->assertEquals([

--- a/tests/Rules/NoInvalidRouteActionTest.php
+++ b/tests/Rules/NoInvalidRouteActionTest.php
@@ -10,22 +10,27 @@ class NoInvalidRouteActionTest extends RulesTest
 {
     public function testNoFalsePositives(): void
     {
-        $errors = $this->findErrors(__DIR__.'/Data/ValidRouteActions.php');
+        $errors = $this->findErrors(__DIR__.'/Data/ValidRouteActions.php', [
+            'config' => __DIR__.'/configs/valid-route-actions.neon'
+        ]);
         $this->assertEquals([], $errors, 'The rule should not result in any errors for this data set.');
     }
 
     public function testNoFalseNegatives(): void
     {
-        $errors = $this->findErrorsByLine(__DIR__.'/Data/InvalidRouteActions.php');
+        $errors = $this->findErrorsByLine(__DIR__.'/Data/InvalidRouteActions.php', [
+            'config' => __DIR__.'/configs/valid-route-actions.neon'
+        ]);
 
         $this->assertEquals([
             14 => 'Detected non-existing class \'\\Not\A\Controller\' during route registration.',
             17 => 'Detected non-existing method \'notAMethod\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
-            22 => 'Detected non-existing class \'non_existing_class\' during route registration.',
-            24 => 'Detected non-existing method \'non_existing_method\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
-            29 => 'Detected non-existing class \'\' during route registration.',
-            34 => 'Detected non-existing method \'nonExisting\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
-            42 => 'Detected non-existing method \'typo\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            19 => 'Detected non-existing method \'magic\' on class \'\\Tests\\Rules\\Data\\FooController\' during route registration.',
+            24 => 'Detected non-existing class \'non_existing_class\' during route registration.',
+            26 => 'Detected non-existing method \'non_existing_method\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            31 => 'Detected non-existing class \'\' during route registration.',
+            36 => 'Detected non-existing method \'nonExisting\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            44 => 'Detected non-existing method \'typo\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
         ], $errors);
     }
 }

--- a/tests/Rules/NoInvalidRouteActionTest.php
+++ b/tests/Rules/NoInvalidRouteActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Tests\RulesTest;
+
+class NoInvalidRouteActionTest extends RulesTest
+{
+    public function testNoFalsePositives(): void
+    {
+        $errors = $this->findErrors(__DIR__.'/Data/ValidRouteActions.php');
+        $this->assertEquals([], $errors, 'The rule should not result in any errors for this data set.');
+    }
+
+    public function testNoFalseNegatives(): void
+    {
+        $errors = $this->findErrorsByLine(__DIR__.'/Data/InvalidRouteActions.php');
+
+        $this->assertEquals([
+            14 => 'Detected non-existing class \'\\Not\A\Controller\' during route registration.',
+            17 => 'Detected non-existing method \'notAMethod\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            22 => 'Detected non-existing class \'non_existing_class\' during route registration.',
+            24 => 'Detected non-existing method \'non_existing_method\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            29 => 'Detected non-existing class \'\' during route registration.',
+            34 => 'Detected non-existing method \'nonExisting\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+            42 => 'Detected non-existing method \'typo\' on class \'\\App\\Http\\Controllers\\UserController\' during route registration.',
+        ], $errors);
+    }
+}

--- a/tests/Rules/configs/valid-route-actions.neon
+++ b/tests/Rules/configs/valid-route-actions.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../extension.neon
+    - ../../../extension.neon
 
 parameters:
     noInvalidRouteAction: true

--- a/tests/Rules/rules.neon
+++ b/tests/Rules/rules.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    noInvalidRouteAction: true

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -6,6 +6,12 @@ namespace Tests;
 
 abstract class RulesTest extends TestCase
 {
+    public function execLarastan(string $filename, array $options = [])
+    {
+        $options['config'] = __DIR__.'/Rules/rules.neon';
+        return parent::execLarastan($filename, $options);
+    }
+
     /**
      * Returns an array of errors that were found after analyzing $filename.
      * @param string $filename

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -6,20 +6,15 @@ namespace Tests;
 
 abstract class RulesTest extends TestCase
 {
-    public function execLarastan(string $filename, array $options = [])
-    {
-        $options['config'] = __DIR__.'/Rules/rules.neon';
-        return parent::execLarastan($filename, $options);
-    }
-
     /**
      * Returns an array of errors that were found after analyzing $filename.
      * @param string $filename
+     * @param array $options
      * @return array
      */
-    protected function findErrors(string $filename): array
+    protected function findErrors(string $filename, array $options = []): array
     {
-        return $this->execLarastan($filename)['files'][$filename] ?? [];
+        return $this->execLarastan($filename, $options)['files'][$filename] ?? [];
     }
 
     /**
@@ -27,11 +22,12 @@ abstract class RulesTest extends TestCase
      * number and the value represents the error found. Will return
      * at most one error per line.
      * @param string $filename
+     * @param array $options
      * @return array<int, string>
      */
-    protected function findErrorsByLine(string $filename): array
+    protected function findErrorsByLine(string $filename, array $options = []): array
     {
-        $errors = $this->findErrors($filename);
+        $errors = $this->findErrors($filename, $options);
 
         return collect($errors['messages'] ?? [])->mapWithKeys(function ($message) {
             return [$message['line'] => $message['message']];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,9 +19,9 @@ class TestCase extends BaseTestCase
         File::copyDirectory(__DIR__.'/Application/database/migrations', $this->getBasePath().'/database/migrations');
     }
 
-    public function execLarastan(string $filename)
+    public function execLarastan(string $filename, array $options = [])
     {
-        $configPath = __DIR__.'/../extension.neon';
+        $configPath = $options['config'] ?? (__DIR__.'/../extension.neon');
         $command = escapeshellcmd(__DIR__.'/../vendor/bin/phpstan');
 
         exec(sprintf('%s %s analyse --no-progress  --level=max --configuration %s --autoload-file %s %s --error-format=%s',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,7 +24,7 @@ class TestCase extends BaseTestCase
         $configPath = $options['config'] ?? (__DIR__.'/../extension.neon');
         $command = escapeshellcmd(__DIR__.'/../vendor/bin/phpstan');
 
-        exec(sprintf('%s %s analyse --no-progress  --level=max --configuration %s --autoload-file %s %s --error-format=%s',
+        exec(sprintf('%s %s analyse --no-progress --level=max --configuration %s --autoload-file %s %s --error-format=%s',
             escapeshellarg(PHP_BINARY), $command,
             escapeshellarg($configPath),
             escapeshellarg(__DIR__.'/../vendor/autoload.php'),


### PR DESCRIPTION
Closes https://github.com/nunomaduro/larastan/issues/129
Related to https://github.com/nunomaduro/larastan/issues/326

# Introduction

If you do not use [invokable controllers](https://laravel.com/docs/7.x/controllers#single-action-controllers), then you could have registered routes that point to a non-existing method, because the existence of a controller method action is only checked if you use invokable controllers.

This PR adds a new rule that checks if the methods used by your routes actually exist. If they do not exist, this rule will produce an error.

### Example

```php
Route::get('/users', [UserController::index, 'typo']);
```
will result in the following error:
```
Detected non-existing method 'typo' on class '\App\Http\Controllers\UserController' during route registration.
```

The following three methods of route registration are supported:
- Array with class and method as elements: 
```php
Route::get('/', [UserController::class, 'index'])
```
- Array with 'uses' parameter and string: 
```php
Route::get('/', ['uses' => '\App\Http\Controller\UserController@index'])
```

- String: 
```php
Route::get('/', '\App\Http\Controller\UserController@index')
```

### Considerations

Since this rule does not work with [route namespaces ](https://laravel.com/docs/7.x/routing#route-group-namespaces), I decided to disable it by default. 

Magic methods on controllers have to be annotated using the `@method` PHPDoc annotations on the controller (or one of its parents).

Currently, only route registration by using the imported Route facade is supported. I want to add support for a non-imported Route facade as well, but I'm not sure what the best way to do that is.

Simple expressions like:
```php
Route::get('/', UserController::class . '@index')
```
will not work. I'm not sure if there's an easy way to evaluate them.


Maybe we can add another parameter that allows a developer to specify a single global route namespace as is being done in the [default RouteServiceProvider](https://github.com/laravel/laravel/blob/master/app/Providers/RouteServiceProvider.php#L17). 