### PR TITLE
find* method calls chained after a relationship call

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -144,6 +144,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\RelationModelFindExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\Properties\JsonResourceExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension

--- a/src/ReturnTypes/RelationModelFindExtension.php
+++ b/src/ReturnTypes/RelationModelFindExtension.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Str;
+use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Methods\ModelTypeHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * @internal
+ */
+final class RelationModelFindExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+{
+    use Concerns\HasBroker;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Relation::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $methodName = $methodReflection->getName();
+
+        if (! Str::startsWith($methodName, 'find')) {
+            return false;
+        }
+
+        if (! $this->getBroker()->getClass(Builder::class)->hasNativeMethod($methodName) &&
+            ! $this->getBroker()->getClass(QueryBuilder::class)->hasNativeMethod($methodName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var ObjectType $model */
+        $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TRelatedModel');
+        $returnType = $methodReflection->getVariants()[0]->getReturnType();
+        $argType = $scope->getType($methodCall->args[0]->value);
+
+        $returnType = ModelTypeHelper::replaceStaticTypeWithModel($returnType, $model->getClassName());
+
+        if ($argType->isIterable()->yes()) {
+            if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+                $genericCollectionReturnType = new GenericObjectType(Collection::class, [$model]);
+
+                if ($returnType->accepts(new NullType(), true)->yes()) {
+                    return TypeCombinator::addNull($genericCollectionReturnType);
+                }
+
+                return $genericCollectionReturnType;
+            }
+
+            return TypeCombinator::remove($returnType, $model);
+        }
+
+        if ($argType instanceof MixedType) {
+            return $returnType;
+        }
+
+        return TypeCombinator::remove(
+            TypeCombinator::remove(
+                $returnType,
+                new ArrayType(new MixedType(), $model)
+            ),
+            new ObjectType(Collection::class)
+        );
+    }
+}

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -216,6 +216,16 @@ class ModelExtension
     {
         return $user->accounts()->firstOrCreate([]);
     }
+
+    public function testFindOrFailWithIntWithRelation(User $user): Account
+    {
+        return $user->accounts()->findOrFail(1);
+    }
+
+    public function testFindOrFailWithArrayWithRelation(User $user): Collection
+    {
+        return $user->accounts()->findOrFail([1, 2, 3]);
+    }
 }
 
 function foo(): string

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -40,7 +40,7 @@ class FeaturesTest extends TestCase
         $result = $this->execLarastan($file);
 
         if (! $result || $result['totals']['errors'] > 0 || $result['totals']['file_errors'] > 0) {
-            $this->fail(json_encode(json_decode($result[0]), JSON_PRETTY_PRINT));
+            $this->fail(json_encode($result, JSON_PRETTY_PRINT));
         }
 
         return 0;


### PR DESCRIPTION
Chaining a call to find methods after a relationship call fails. 
i.e.
```$user->roles()->findOrFail(1)```

This is more or less identical to the [BuilderModelFindExtension](https://github.com/nunomaduro/larastan/blob/12af69f657b88182fa5608e137b7c47fba386b7e/src/ReturnTypes/BuilderModelFindExtension.php) other than instead of calls being made on the builder class calls are made on a relation class. 
