### PR TITLE
feat: generic factory helper

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -21,6 +21,7 @@ parameters:
         - stubs/MorphToMany.stub
         - stubs/MorphMany.stub
         - stubs/Helpers.stub
+        - stubs/FactoryBuilder.stub
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
         - Illuminate\Http\Request
@@ -206,6 +207,11 @@ services:
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\TransExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\FactoryHelper
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
         class: NunoMaduro\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension

--- a/src/ReturnTypes/Helpers/FactoryHelper.php
+++ b/src/ReturnTypes/Helpers/FactoryHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use Illuminate\Database\Eloquent\FactoryBuilder;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\TypeCombinator;
+
+final class FactoryHelper implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return FactoryBuilder::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'create';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): \PHPStan\Type\Type {
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+        $typeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
+
+        $amountType = $typeMap->getType('TAmount');
+        $modelType = $typeMap->getType('TModel');
+
+        // $amountType and $modelType should not be null here. Maybe add a check
+
+        if ($amountType instanceof NullType) {
+            return $modelType;
+        }
+
+        if ($amountType instanceof IntegerType) {
+            return TypeCombinator::remove($returnType, $modelType);
+        }
+
+        return $returnType;
+    }
+}

--- a/stubs/FactoryBuilder.stub
+++ b/stubs/FactoryBuilder.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @template TModel
+ * @template TAmount
+ */
+class FactoryBuilder
+{
+    /**
+     * Create a collection of models and persist them to the database.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @phpstan-return Collection<TModel>|TModel
+     */
+    public function create(array $attributes = []){}
+}

--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -10,6 +10,13 @@
  *
  * @throws \Exception
  */
-function retry($times, callable $callback, $sleep = 0, $when = null)
-{
-}
+function retry($times, callable $callback, $sleep = 0, $when = null){}
+
+/**
+ * @template TModel
+ * @template TAmount
+ * @param  class-string<TModel>  $class
+ * @param  TAmount  $amount
+ * @return \Illuminate\Database\Eloquent\FactoryBuilder<TModel, TAmount>
+ */
+function factory($class, $amount = null){}

--- a/tests/Features/ReturnTypes/Helpers/FactoryHelper.php
+++ b/tests/Features/ReturnTypes/Helpers/FactoryHelper.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+
+class FactoryHelper
+{
+    /** @phpstan-return Collection<User> */
+    public function testItReturnsCollection() : Collection
+    {
+        return factory(User::class, 5)->create();
+    }
+
+    /** @phpstan-return Collection<User> */
+    public function testItReturnsCollectionWithZero() : Collection
+    {
+        return factory(User::class, 0)->create();
+    }
+
+    public function testItReturnsModel() : User
+    {
+        return factory(User::class)->create();
+    }
+
+    public function testItReturnsModelWithNull() : User
+    {
+        return factory(User::class, null)->create();
+    }
+}


### PR DESCRIPTION
This is a POC implementation of adding generics to the `factory` helper.

Currently we can understand `factory(User::class, 5)->create()` returns `Collection<User>` and `factory(User::class)->create()` returns `User`

It might be possible to add support for `times`.

@timacdonald Please take a look at this. And you can improve on it. Adding custom collection support, support for other `FactoryBuilder` methods like `state`, `times` etc.