### PR TITLE
Improve collection stubs

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -70,8 +70,34 @@ class Collection implements \ArrayAccess, Enumerable
     public function map($callable) {}
 
     /**
-     * @param callable(static<TValue>): void $callable
-     * @return static<TValue>
+     * @param callable(TValue, TKey): array<mixed> $callback
+     * @return static<static<mixed>>
      */
-    public function tap($callable) {}
+    public function mapToGroups(callable $callback) {}
+
+    /**
+     * @param callable(TValue, TKey): mixed $callback
+     * @return static<mixed>
+     */
+    public function flatMap(callable $callback) {}
+
+    /**
+     * @param callable $callback
+     * @return static<int, mixed>
+     */
+    public function mapSpread(callable $callback) {}
+
+    /**
+     * @param int $number
+     * @param null|callable(int, int): mixed $callback
+     * @return static<mixed>
+     */
+    public static function times($number, callable $callback = null) {}
+
+    /**
+     * @param string|array<mixed> $value
+     * @param string|null $key
+     * @return static<mixed>
+     */
+    public function pluck($value, $key = null) {}
 }

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
- * @template TModel of Model
+ * @template TModel
  * @extends \Illuminate\Support\Collection<int, TModel>
  */
 class Collection extends \Illuminate\Support\Collection
@@ -21,4 +21,36 @@ class Collection extends \Illuminate\Support\Collection
      * @return static<TReturn>|\Illuminate\Support\Collection<int, TReturn>
      */
     public function map($callable) {}
+
+    /**
+     * @param callable(TValue, TKey): array<mixed> $callback
+     * @return \Illuminate\Support\Collection<mixed, static<mixed>>
+     */
+    public function mapToGroups(callable $callback) {}
+
+    /**
+     * @param callable(TValue, TKey): mixed $callback
+     * @return \Illuminate\Support\Collection<mixed, mixed>
+     */
+    public function flatMap(callable $callback) {}
+
+    /**
+     * @param callable $callback
+     * @return static<mixed>|\Illuminate\Support\Collection<int, mixed>
+     */
+    public function mapSpread(callable $callback) {}
+
+    /**
+     * @param int $number
+     * @param null|callable(int, int): mixed $callback
+     * @return mixed
+     */
+    public static function times($number, callable $callback = null) {}
+
+    /**
+     * @param string|array<mixed> $value
+     * @param string|null $key
+     * @return \Illuminate\Support\Collection<int, mixed>
+     */
+    public function pluck($value, $key = null) {}
 }

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -23,13 +23,13 @@ class Collection extends \Illuminate\Support\Collection
     public function map($callable) {}
 
     /**
-     * @param callable(TValue, TKey): array<mixed> $callback
+     * @param callable(TModel, int): array<mixed> $callback
      * @return \Illuminate\Support\Collection<mixed, static<mixed>>
      */
     public function mapToGroups(callable $callback) {}
 
     /**
-     * @param callable(TValue, TKey): mixed $callback
+     * @param callable(TModel, int): mixed $callback
      * @return \Illuminate\Support\Collection<mixed, mixed>
      */
     public function flatMap(callable $callback) {}

--- a/stubs/Enumerable.stub
+++ b/stubs/Enumerable.stub
@@ -8,4 +8,65 @@ namespace Illuminate\Support;
  *
  * @extends \IteratorAggregate<TKey, TValue>
  */
-interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable {}
+interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable
+{
+    /**
+     * @param string|callable(TValue, TKey): bool $key
+     * @param mixed $operator
+     * @param mixed $value
+     * @return static<static>
+     */
+    public function partition($key, $operator = null, $value = null);
+
+    /**
+     * @param array<mixed>|string|callable(TValue, TKey): mixed $groupBy
+     * @param bool $preserveKeys
+     * @return static<static<mixed>>
+     */
+    public function groupBy($groupBy, $preserveKeys = false);
+
+    /**
+     * @param string|callable(TValue, TKey): mixed $keyBy
+     * @return static<TValue>
+     */
+    public function keyBy($keyBy);
+
+    /**
+     * @param callable(TValue, TKey): array<mixed> $callback
+     * @return static<mixed>
+     */
+    public function mapWithKeys(callable $callback);
+
+    /**
+     * @param callable(TValue, TKey): array<mixed> $callback
+     * @return static<array<mixed>>
+     */
+    public function mapToDictionary(callable $callback);
+
+    /**
+     * @param string|callable(TValue, TKey): bool $key
+     * @param mixed $operator
+     * @param mixed $value
+     * @return bool
+     */
+    public function every($key, $operator = null, $value = null);
+
+    /**
+     * @template TClass
+     * @param class-string<TClass> $class
+     * @return static<TClass>
+     */
+    public function mapInto($class);
+
+    /**
+     * @param  int  $size
+     * @return static<static>
+     */
+    public function chunk($size);
+
+    /**
+     * @param callable(static): void $callable
+     * @return static
+     */
+    public function tap($callable);
+}

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -53,7 +53,9 @@ class BuilderExtension
     /** @return Collection<User> */
     public function testUsingCollectionMethodsAfterGet(): Collection
     {
-        return User::whereIn('id', [1, 2, 3])->get()->mapWithKeys('key');
+        return User::whereIn('id', [1, 2, 3])->get()->mapWithKeys(function ($user) {
+            return [$user->name => $user->email];
+        });
     }
 
     public function testCallingQueryBuilderMethodOnEloquentBuilderReturnsEloquentBuilder(Builder $builder): Builder

--- a/tests/Features/ReturnTypes/CollectionStub.php
+++ b/tests/Features/ReturnTypes/CollectionStub.php
@@ -155,7 +155,6 @@ class CollectionStub
         });
     }
 
-
     /**
      * @param EloquentCollection<User> $items
      * @return EloquentCollection<User>

--- a/tests/Features/ReturnTypes/CollectionStub.php
+++ b/tests/Features/ReturnTypes/CollectionStub.php
@@ -43,6 +43,120 @@ class CollectionStub
     }
 
     /**
+     * @param EloquentCollection<User> $collection
+     */
+    public function testMapPartition(EloquentCollection $collection): SupportCollection
+    {
+        return $collection->partition(function (User $user) {
+            return $user->accounts()->count() > 1;
+        })->map(function (EloquentCollection $users) {
+            return $users->count();
+        });
+    }
+
+    /**
+     * @param EloquentCollection<User> $collection
+     * @return int|null
+     */
+    public function testPluck(EloquentCollection $collection): ?int
+    {
+        return $collection->pluck('id')->first();
+    }
+
+    /**
+     * @param EloquentCollection<User> $collection
+     * @return SupportCollection<int>
+     */
+    public function testMapToGroups(EloquentCollection $collection)
+    {
+        return $collection->mapToGroups(function (User $user, int $key): array {
+            return [$user->name => $user->id];
+        })->map(function (EloquentCollection $items, string $name) {
+            return $items->first();
+        })->take(3);
+    }
+
+    /**
+     * @param EloquentCollection<User> $collection
+     * @return EloquentCollection<User>
+     */
+    public function testKeyBy(EloquentCollection $collection)
+    {
+        return $collection->keyBy(function (User $user, int $key): string {
+            return $user->email;
+        });
+    }
+
+    /**
+     * @return EloquentCollection<EloquentCollection<User>>
+     */
+    public function testGroupBy()
+    {
+        return User::all()->groupBy('id');
+    }
+
+    /**
+     * @return SupportCollection<User>
+     */
+    public function testMapInto()
+    {
+        return User::all()->map(function (User $user): array {
+            return $user->toArray();
+        })->mapInto(User::class);
+    }
+
+    /**
+     * @return EloquentCollection<int>
+     */
+    public function testTimes(): EloquentCollection
+    {
+        return EloquentCollection::times(4);
+    }
+
+    /**
+     * @return SupportCollection<int>
+     */
+    public function testTimesSupport(): SupportCollection
+    {
+        return SupportCollection::times(4);
+    }
+
+    /**
+     * @return SupportCollection<string>
+     */
+    public function testTimesCallback(): SupportCollection
+    {
+        return EloquentCollection::times(4, function (): string {
+            return 'a string';
+        });
+    }
+
+    /**
+     * @param SupportCollection<array<mixed>> $collection
+     * @return SupportCollection<string>
+     */
+    public function testMapSpread(SupportCollection $collection)
+    {
+        return $collection->mapSpread(function (string $x, int $y, float $z, array $t): string {
+            return $x;
+        });
+    }
+
+    /**
+     * @param EloquentCollection<mixed> $collection
+     * @return SupportCollection<User>
+     */
+    public function testFlatMap(EloquentCollection $collection)
+    {
+        return $collection->flatMap(function (User $user, int $id): array {
+            return [$user];
+        })->map(function (User $user, int $id): User {
+            return $user;
+        });
+    }
+
+
+    /**
      * @param EloquentCollection<User> $items
      * @return EloquentCollection<User>
      */

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -40,7 +40,7 @@ class FeaturesTest extends TestCase
         $result = $this->execLarastan($file);
 
         if (! $result || $result['totals']['errors'] > 0 || $result['totals']['file_errors'] > 0) {
-            $this->fail(json_encode(json_decode($result[0]), JSON_PRETTY_PRINT));
+            $this->fail(json_encode($result, JSON_PRETTY_PRINT));
         }
 
         return 0;


### PR DESCRIPTION
This MR ensures that an EloquentCollection can also contain non-model values.
Keys are still hardcoded as `int`s this should be changed in the future.

The more I looked into properly type-hinting the collection methods using stubs the more I realised what a can of worms I had opened. The return-types of the collection methods can be really counter-intuitive. Take for example:
```php
EloquentCollection::times(5); // Returns an EloquentCollection

EloquentCollection::times(5, function ($i) {
   return $i;
}); // Returns a SupportCollection

User::all()->mapToGroups(function (User $user) {
   return [$user->email => $user->name];
}) // Returns SupportCollection<string, EloquentCollection<string>>
```

Another problem with the EloquentCollection methods is that a lot of them use `map()` internally, and `map()` may return either a SupportCollection or an EloquentCollection. However, Laravel's PHPDoc states the return type as `static` which is technically incorrect and may result in false positives.


Further work remains to be done to completely support all the collection magic without any false positives.

Closes  https://github.com/nunomaduro/larastan/issues/550 