### PR TITLE
Ignore `Undefined variable: $factory` in factories

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -31,8 +31,8 @@ parameters:
         - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
         - '#Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response#'
         - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
-        - path: %rootDir%/../../../database/factories/*
-          message: '#Undefined variable: \$factory#'
+#        - path: %rootDir%/../../../database/factories/*
+#          message: '#Undefined variable: \$factory#'
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false
     checkGenericClassInNonGenericObjectType: false

--- a/extension.neon
+++ b/extension.neon
@@ -31,8 +31,8 @@ parameters:
         - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
         - '#Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response#'
         - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
-#        - path: %rootDir%/../../../database/factories/*
-#          message: '#Undefined variable: \$factory#'
+        - path: %rootDir%/../../../database/factories/*
+          message: '#Undefined variable: \$factory#'
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false
     checkGenericClassInNonGenericObjectType: false

--- a/extension.neon
+++ b/extension.neon
@@ -31,7 +31,7 @@ parameters:
         - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
         - '#Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response#'
         - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
-        - path: %rootDir%/../../database/factories/*
+        - path: %rootDir%/../../../database/factories/*
           message: '#Undefined variable: \$factory#'
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false

--- a/extension.neon
+++ b/extension.neon
@@ -31,6 +31,8 @@ parameters:
         - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
         - '#Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response#'
         - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
+        - path: %rootDir%/../../database/factories/*
+          message: '#Undefined variable: \$factory#'
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
     reportUnmatchedIgnoredErrors: false
     checkGenericClassInNonGenericObjectType: false

--- a/tests/Application/database/factories/UserFactory.php
+++ b/tests/Application/database/factories/UserFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\User;
+use Faker\Generator as Faker;
+use Illuminate\Support\Str;
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| This directory should contain each of the model factory definitions for
+| your application. Factories provide a convenient way to generate new
+| model instances for testing / seeding your application's database.
+|
+*/
+
+$factory->define(User::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->unique()->safeEmail,
+        'email_verified_at' => now(),
+        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+        'remember_token' => Str::random(10),
+    ];
+});


### PR DESCRIPTION
This comes up when adding `- database/factories` to the list of analysed paths.

## Before

```
$ vendor/bin/phpstan analyse
Note: Using configuration file /home/spawnia/Projects/lighthouse-example/phpstan.neon.
 14/14 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------ 
  Line   database/factories/UserFactory.php  
 ------ ------------------------------------ 
  20     Undefined variable: $factory        
 ------ ------------------------------------

[ERROR] Found 1 error
```

## After

```
$ vendor/bin/phpstan analyse
Note: Using configuration file /home/spawnia/Projects/lighthouse-example/phpstan.neon.
 14/14 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

[OK] No errors
```