### PR TITLE
Document errors to ignore instead of forcing it upon users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Document common errors for users to ignore ([#564](https://github.com/nunomaduro/larastan/pull/564))
+
+### Changed
+- Do not overwrite PHPStan's default for `reportUnmatchedIgnoredErrors` ([#564](https://github.com/nunomaduro/larastan/pull/564))
+
+### Removed
+- Stop ignoring errors ([#564](https://github.com/nunomaduro/larastan/pull/564))
+
 ## [0.5.8] - 2020-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Larastan was created by [Nuno Maduro](https://github.com/nunomaduro), got artwor
 - Supports most of [Laravel](https://laravel.com)'s **beautiful magic**
 - Discovers bugs in your code without running it
 
-## ✨ Getting Started in 3 Steps
+## ✨ Getting Started In 3 Steps
 
 > **Requires:**
 - **[PHP 7.2+](https://php.net/releases/)**
@@ -72,14 +72,21 @@ If you are getting the error `Allowed memory size exhausted`, then you can use t
 ```
 
 ## Rules
+
 A list of configurable rules specific to Laravel can be found [here](docs/rules.md).
+
+## Errors To Ignore
+
+Some parts of Laravel are currently too magical for Larastan/PHPStan to understand.
+We listed common [errors to ignore](docs/errors-to-ignore.md), add them as needed.
+
 ## 👊🏻 Contributing
 
 Thank you for considering contributing to Larastan. All the contribution guidelines are mentioned [here](CONTRIBUTING.md).
 
 You can have a look at the [CHANGELOG](CHANGELOG.md) for constant updates & detailed information about the changes. You can also follow the Twitter account for the latest announcements or just come say hi!: [@enunomaduro](https://twitter.com/enunomaduro).
 
-## ❤️ Support the development
+## ❤️ Support The Development
 
 **Do you like this project? Support it by donating**
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,45 @@
 # Upgrade Guide
 
+## Upgrading to 0.6
+
+Larastan no longer ignores errors on your behalf. Here is how you can fix them yourself:
+
+### Result of function abort \(void\) is used
+
+Stop `return`-ing abort.
+
+```diff
+-return abort(401);
++abort(401);
+```
+
+### Call to an undefined method Illuminate\\Support\\HigherOrder
+
+Larastan still does not understand this particular magic, you can
+[ignore it yourself](docs/errors-to-ignore.md#higher-order-messages) for now.
+
+### Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response
+
+Fix the docblock.
+
+```diff
+-    * @return Illuminate\Http\Response|Symfony\Component\HttpFoundation\Response
++    * @return Symfony\Component\HttpFoundation\Response
+     */
+    public function render($request, Exception $exception)
+```
+
+### Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int
+
+Fix the docblock. 
+
+```diff
+-    * @var string
++    * @var int
+     */
+    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+```
+
 ## Upgrading to 0.5.8
 
 ### Custom collections

--- a/docs/errors-to-ignore.md
+++ b/docs/errors-to-ignore.md
@@ -1,0 +1,31 @@
+## Errors To Ignore
+
+Some parts of Laravel are currently too magical for Larastan/PHPStan to understand.
+
+If you hit those errors in your project, you can add them to your `phpstan.neon` as needed.
+For example:
+
+```neon
+ignoreErrors:
+- '#Result of function abort \(void\) is used#'
+```
+
+> Tip: If you set `reportUnmatchedIgnoredErrors: true`, you will be notified once Larastan
+> properly recognizes what's going on, and you no longer have to ignore the error.
+
+### Higher Order Messages
+
+This comes up when using [higher order messages](https://laravel.com/docs/collections#higher-order-messages). 
+
+```neon
+- '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
+```
+
+### Factories
+
+This comes up when you add `database/factories` to your analysed paths.
+
+```neon
+- path: database/factories/*
+  message: '#Undefined variable: \$factory#'
+```

--- a/docs/errors-to-ignore.md
+++ b/docs/errors-to-ignore.md
@@ -3,15 +3,7 @@
 Some parts of Laravel are currently too magical for Larastan/PHPStan to understand.
 
 If you hit those errors in your project, you can add them to your `phpstan.neon` as needed.
-For example:
-
-```neon
-ignoreErrors:
-- '#Result of function abort \(void\) is used#'
-```
-
-> Tip: If you set `reportUnmatchedIgnoredErrors: true`, you will be notified once Larastan
-> properly recognizes what's going on, and you no longer have to ignore the error.
+[Learn more about ignoring errors in PHPStan.](https://phpstan.org/user-guide/ignoring-errors)
 
 ### Higher Order Messages
 

--- a/extension.neon
+++ b/extension.neon
@@ -26,13 +26,7 @@ parameters:
         - Illuminate\Http\Request
     excludes_analyse:
         - *.blade.php
-    ignoreErrors:
-        - '#Result of function abort \(void\) is used#'
-        - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'
-        - '#Method App\\Exceptions\\Handler::render\(\) should return Illuminate\\Http\\Response but returns Symfony\\Component\\HttpFoundation\\Response#'
-        - '#Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int#'
     bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
-    reportUnmatchedIgnoredErrors: false
     checkGenericClassInNonGenericObjectType: false
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []


### PR DESCRIPTION
- [ ] ~Added or updated tests~
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Relates to the discussion in https://github.com/nunomaduro/larastan/pull/557

**Changes**

- Document common errors for users to ignore

**Breaking changes**

- Do not overwrite PHPStan's default for `reportUnmatchedIgnoredErrors`
- Stop ignoring errors
