### PR TITLE
Forward calls on Model when subclass is not known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Document common errors for users to ignore ([#564](https://github.com/nunomaduro/larastan/pull/564))
 
+### Fixed
+- Avoid false-positive when calling static builder methods such as `::find()` on Model classes where
+  the concrete subclass is not yet known ([#565](https://github.com/nunomaduro/larastan/pull/565))
+
 ### Changed
 - Do not overwrite PHPStan's default for `reportUnmatchedIgnoredErrors` ([#564](https://github.com/nunomaduro/larastan/pull/564))
 

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -30,7 +30,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if (! $classReflection->isSubclassOf(Model::class)) {
+        if ($classReflection->getName() !== Model::class && ! $classReflection->isSubclassOf(Model::class)) {
             return false;
         }
 

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -75,6 +75,19 @@ class ModelExtension
         return User::find(1);
     }
 
+    public function testFindOnGenericModel(Model $model): ?Model
+    {
+        return $model::find(1);
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    public function testFindOnModelClassString(string $modelClass): ?Model
+    {
+        return $modelClass::find(1);
+    }
+
     /**
      * @return Collection<\App\User>|null
      */


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Avoid false-positive when calling static builder methods such as `::find()` on Model classes where the concrete subclass is not yet known.

**Breaking changes**

No, allows more valid programs.
