### PR TITLE
Add abort to list of early terminating calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -24,6 +24,8 @@ parameters:
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
         - Illuminate\Http\Request
+    earlyTerminatingFunctionCalls:
+        - abort
     excludes_analyse:
         - *.blade.php
     ignoreErrors:

--- a/tests/Features/Types/Abort.php
+++ b/tests/Features/Types/Abort.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Types;
+
+class Abort
+{
+    /**
+     * Tests whether we can detect that abort terminates the application.
+     * @param int $value
+     * @return string
+     */
+    public function testAbort(int $value): string
+    {
+        if ($value > 0) {
+            $operator = '+';
+        } elseif ($value < 0) {
+            $operator = '-';
+        } else {
+            abort(422);
+        }
+
+        // Should not complain about $operator possibly not being defined
+        return $operator;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds abort to the list of early terminating function calls. See https://phpstan.org/writing-php-code/solving-undefined-variables.

<!-- Detail the changes in behaviour this PR introduces. -->


