### PR TITLE
Fix false positive NoUnnecessaryCollectionCallRule

### DIFF
--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -74,6 +74,24 @@ class CorrectCollectionCalls
             return $user->id === 2;
         });
     }
+
+    public function testAggregateNoArgs(): int
+    {
+        return User::query()
+            ->select([DB::raw('COUNT(*) as temp')])
+            ->pluck('temp')
+            ->sum();
+    }
+
+    public function testRelationAggregate(User $user): int
+    {
+        return $user->group()
+            ->withCount(['accounts' => function ($query) {
+                $query->where('id', '<>', 1);
+            }])
+            ->pluck('accounts_count')
+            ->avg();
+    }
 }
 
 class Foo extends Model

--- a/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
@@ -89,4 +89,9 @@ class UnnecessaryCollectionCallsEloquent
     {
         return User::query()->get()->containsStrict('id', 1);
     }
+
+    public function testSum(): int
+    {
+        return User::pluck('id')->sum();
+    }
 }

--- a/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
@@ -14,11 +14,6 @@ class UnnecessaryCollectionCallsQuery
         return DB::table('users')->get()->max('id');
     }
 
-    public function queryAverageNoParam(): float
-    {
-        return DB::table('users')->pluck('id')->average();
-    }
-
     public function queryNotEmpty(): bool
     {
         return DB::table('users')->pluck('id')->isNotEmpty();

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -34,6 +34,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
             77 => 'Called \'diff\' on Laravel collection, but could have been retrieved as a query.',
             85 => 'Called \'modelKeys\' on Laravel collection, but could have been retrieved as a query.',
             90 => 'Called \'containsStrict\' on Laravel collection, but could have been retrieved as a query.',
+            95 => 'Called \'sum\' on Laravel collection, but could have been retrieved as a query.',
         ], $errors);
     }
 
@@ -41,7 +42,6 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
     {
         $this->assertSeeErrorsInOrder(__DIR__.'/Data/UnnecessaryCollectionCallsQuery.php', [
             'Called \'max\' on Laravel collection, but could have been retrieved as a query.',
-            'Called \'average\' on Laravel collection, but could have been retrieved as a query.',
             'Called \'isNotEmpty\' on Laravel collection, but could have been retrieved as a query.',
             'Called \'pluck\' on Laravel collection, but could have been retrieved as a query.',
         ]);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Resolves #578 
**Changes**

Ensures that if you call an aggregate function on a collection without any arguments (e.g. `$collection->sum()` ) does not result in a false positive.
