### PR TITLE
Fix compatibility with PHPStan 0.12.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/pipeline": "^6.0 || ^7.0",
         "illuminate/support": "^6.0 || ^7.0",
         "mockery/mockery": "^0.9 || ^1.0",
-        "phpstan/phpstan": "^0.12.24",
+        "phpstan/phpstan": "^0.12.26",
         "symfony/process": "^4.3 || ^5.0",
         "ext-json": "*"
     },

--- a/extension.neon
+++ b/extension.neon
@@ -31,7 +31,8 @@ parameters:
         - *.blade.php
     mixinExcludeClasses:
         - Eloquent
-    bootstrap: %rootDir%/../../nunomaduro/larastan/bootstrap.php
+    bootstrapFiles:
+        - %rootDir%/../../nunomaduro/larastan/bootstrap.php
     checkGenericClassInNonGenericObjectType: false
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []

--- a/src/Types/RelationParserHelper.php
+++ b/src/Types/RelationParserHelper.php
@@ -77,6 +77,7 @@ class RelationParserHelper
         $scope = $this->scopeFactory->create(
             ScopeContext::create($fileName),
             false,
+            [],
             $methodReflection
         );
 


### PR DESCRIPTION
PHPStan 0.12.26 makes user's lives easier by a mile. See [the release notes](https://github.com/phpstan/phpstan/releases/tag/0.12.26) and [the accompanying article](https://phpstan.org/blog/zero-config-analysis-with-static-reflection).

I had to make one small compatibility fix to Larastan to make it work with the latest version. Please release it as soon as you're able to. Thank you.