### PR TITLE
Added missing branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
         "preferred-install": "dist"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "0.5-dev"
+        },
         "phpstan": {
             "includes": [
                 "extension.neon"


### PR DESCRIPTION
This allows developers to ask for `^0.5.9` even before it is tagged, and composer will know to download the wip code that will become the 0.5.9 release.