### PR TITLE
Fix tap $this bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix false positive when calling `tap($this)` ([#601](https://github.com/nunomaduro/larastan/pull/601))
+
 ## [0.6.0] - 2020-06-10
 
 ### Added

--- a/src/Methods/HigherOrderTapProxyExtension.php
+++ b/src/Methods/HigherOrderTapProxyExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 
 final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtension
 {
@@ -24,7 +25,7 @@ final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtens
 
         $templateType = $templateTypeMap->getType('TClass');
 
-        if (! $templateType instanceof ObjectType) {
+        if (! $templateType instanceof ObjectType && ! $templateType instanceof ThisType) {
             return false;
         }
 
@@ -35,8 +36,12 @@ final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtens
         ClassReflection $classReflection,
         string $methodName
     ): MethodReflection {
-        /** @var ObjectType $templateType */
+        /** @var ObjectType|ThisType $templateType */
         $templateType = $classReflection->getActiveTemplateTypeMap()->getType('TClass');
+
+        if ($templateType instanceof ThisType) {
+            $templateType = $templateType->getStaticObjectType();
+        }
 
         $reflection = $templateType->getClassReflection();
 

--- a/src/Methods/HigherOrderTapProxyExtension.php
+++ b/src/Methods/HigherOrderTapProxyExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\ThisType;
 
 final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtension
 {

--- a/src/Methods/HigherOrderTapProxyExtension.php
+++ b/src/Methods/HigherOrderTapProxyExtension.php
@@ -25,7 +25,7 @@ final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtens
 
         $templateType = $templateTypeMap->getType('TClass');
 
-        if (! $templateType instanceof ObjectType && ! $templateType instanceof ThisType) {
+        if (! $templateType instanceof ObjectType) {
             return false;
         }
 
@@ -36,12 +36,8 @@ final class HigherOrderTapProxyExtension implements MethodsClassReflectionExtens
         ClassReflection $classReflection,
         string $methodName
     ): MethodReflection {
-        /** @var ObjectType|ThisType $templateType */
+        /** @var ObjectType $templateType */
         $templateType = $classReflection->getActiveTemplateTypeMap()->getType('TClass');
-
-        if ($templateType instanceof ThisType) {
-            $templateType = $templateType->getStaticObjectType();
-        }
 
         $reflection = $templateType->getClassReflection();
 

--- a/src/ReturnTypes/Helpers/TapExtension.php
+++ b/src/ReturnTypes/Helpers/TapExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 
 class TapExtension implements DynamicFunctionReturnTypeExtension
@@ -32,8 +33,10 @@ class TapExtension implements DynamicFunctionReturnTypeExtension
         Scope $scope
     ): Type {
         if (count($functionCall->args) === 1) {
+            $type = $scope->getType($functionCall->args[0]->value);
+
             return new GenericObjectType(HigherOrderTapProxy::class, [
-                $scope->getType($functionCall->args[0]->value),
+                $type instanceof ThisType ? $type->getStaticObjectType() : $type,
             ]);
         }
 

--- a/tests/Features/ReturnTypes/Helpers/TapExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/TapExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Features\ReturnTypes\Helpers;
 
 use App\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HigherOrderTapProxy;
 
 class TapExtension
@@ -28,5 +29,27 @@ class TapExtension
     public function testTapProxy(): User
     {
         return tap(new User)->update(['name' => 'Taylor Otwell']);
+    }
+}
+
+/**
+ * @property string $name
+ */
+class TestModel extends Model
+{
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return tap($this)->save();
+    }
+
+    public function setName2(string $value): self
+    {
+        $this->name = $value;
+
+        return tap($this, function (self $user): void {
+            $user->save();
+        });
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Updates the HigherOrderTapProxyExtension such that statements using `$this`  are now properly understood as well. See https://github.com/nunomaduro/larastan/pull/575#issuecomment-642527659

<!-- Detail the changes in behaviour this PR introduces. -->


