### PR TITLE
Load default auth model from config

### DIFF
--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -43,9 +43,9 @@ final class Auths implements PipeContract
         if (in_array($classReflectionName, $this->classes, true)) {
             $config = $this->resolve('config');
 
-            $authModel = $this->getAuthModel($config);
+            $authModel = $this->getDefaultAuthModel($config);
 
-            if ($authModel) {
+            if ($authModel !== null) {
                 $found = $passable->sendToPipeline($authModel);
             }
         } elseif ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
@@ -59,19 +59,14 @@ final class Auths implements PipeContract
         }
     }
 
-    /**
-     * Returns the default auth model from config.
-     *
-     * @return string
-     */
-    private function getAuthModel(ConfigRepository $config)
+    private function getDefaultAuthModel(ConfigRepository $config): ?string
     {
         if (
             ! ($guard = $config->get('auth.defaults.guard')) ||
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return '';
+            return null;
         }
 
         return $authModel;

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -62,7 +62,7 @@ final class Auths implements PipeContract
     /**
      * Returns the default auth model from config.
      *
-     * @return string|void
+     * @return string
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -71,7 +71,7 @@ final class Auths implements PipeContract
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return;
+            return '';
         }
 
         return $authModel;

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -66,18 +66,14 @@ final class Auths implements PipeContract
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                } else {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        } else {
+        if (
+            ! ($guard = $config->get('auth.defaults.guard')) ||
+            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
+            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
             return null;
         }
+
+        return $authModel;
     }
 }

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -62,7 +62,7 @@ final class Auths implements PipeContract
     /**
      * Returns the default auth model from config.
      *
-     * @return string|null
+     * @return string|void
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -71,7 +71,7 @@ final class Auths implements PipeContract
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return null;
+            return;
         }
 
         return $authModel;

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -60,20 +60,20 @@ final class Auths implements PipeContract
     }
 
     /**
-    * Returns the default auth model from config.
-    *
-    * @return string|null
-    */
+     * Returns the default auth model from config.
+     *
+     * @return string|null
+     */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                }
-            }
+        if (
+            ($guard = $config->get('auth.defaults.guard')) &&
+            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
+            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
+            return $authModel;
+        } else {
+            return null;
         }
-
-        return null;
     }
 }

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -66,12 +66,16 @@ final class Auths implements PipeContract
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if (
-            ($guard = $config->get('auth.defaults.guard')) &&
-            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
-            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return $authModel;
+        if ($guard = $config->get('auth.defaults.guard')) {
+            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
+                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
+                    return $authModel;
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
         } else {
             return null;
         }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -60,7 +60,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
     /**
      * Returns the default auth model from config.
      *
-     * @return string|null
+     * @return string|void
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -69,7 +69,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return null;
+            return;
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -50,26 +50,23 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        if ($authModel = $this->getAuthModel($config)) {
+        $authModel = $this->getDefaultAuthModel($config);
+
+        if ($authModel !== null) {
             return TypeCombinator::addNull(new ObjectType($authModel));
         }
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
     }
 
-    /**
-     * Returns the default auth model from config.
-     *
-     * @return string
-     */
-    private function getAuthModel(ConfigRepository $config)
+    private function getDefaultAuthModel(ConfigRepository $config): ?string
     {
         if (
             ! ($guard = $config->get('auth.defaults.guard')) ||
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return '';
+            return null;
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -58,20 +58,20 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
     }
 
     /**
-    * Returns the default auth model from config.
-    *
-    * @return string|null
-    */
+     * Returns the default auth model from config.
+     *
+     * @return string|null
+     */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                }
-            }
+        if (
+            ($guard = $config->get('auth.defaults.guard')) &&
+            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
+            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
+            return $authModel;
+        } else {
+            return null;
         }
-
-        return null;
     }
 }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -64,18 +64,14 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                } else {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        } else {
+        if (
+            ! ($guard = $config->get('auth.defaults.guard')) ||
+            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
+            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
             return null;
         }
+
+        return $authModel;
     }
 }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -60,7 +60,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
     /**
      * Returns the default auth model from config.
      *
-     * @return string|void
+     * @return string
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -69,7 +69,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return;
+            return '';
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -64,12 +64,16 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if (
-            ($guard = $config->get('auth.defaults.guard')) &&
-            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
-            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return $authModel;
+        if ($guard = $config->get('auth.defaults.guard')) {
+            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
+                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
+                    return $authModel;
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
         } else {
             return null;
         }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -41,26 +41,23 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        if ($authModel = $this->getAuthModel($config)) {
+        $authModel = $this->getDefaultAuthModel($config);
+
+        if ($authModel !== null) {
             return TypeCombinator::addNull(new ObjectType($authModel));
         }
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
     }
 
-    /**
-     * Returns the default auth model from config.
-     *
-     * @return string
-     */
-    private function getAuthModel(ConfigRepository $config)
+    private function getDefaultAuthModel(ConfigRepository $config): ?string
     {
         if (
             ! ($guard = $config->get('auth.defaults.guard')) ||
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return '';
+            return null;
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -51,7 +51,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
     /**
      * Returns the default auth model from config.
      *
-     * @return string|null
+     * @return string|void
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -60,7 +60,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return null;
+            return;
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Auth\AuthManager;
+use Illuminate\Config\Repository as ConfigRepository;
 use NunoMaduro\Larastan\Concerns;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -40,10 +41,28 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        if ($userModel = $config->get('auth.providers.users.model')) {
-            return TypeCombinator::addNull(new ObjectType($userModel));
+        if ($authModel = $this->getAuthModel($config)) {
+            return TypeCombinator::addNull(new ObjectType($authModel));
         }
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+    }
+
+    /**
+    * Returns the default auth model from config.
+    *
+    * @return string|null
+    */
+    private function getAuthModel(ConfigRepository $config)
+    {
+        if ($guard = $config->get('auth.defaults.guard')) {
+            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
+                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
+                    return $authModel;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -49,20 +49,20 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
     }
 
     /**
-    * Returns the default auth model from config.
-    *
-    * @return string|null
-    */
+     * Returns the default auth model from config.
+     *
+     * @return string|null
+     */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                }
-            }
+        if (
+            ($guard = $config->get('auth.defaults.guard')) &&
+            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
+            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
+            return $authModel;
+        } else {
+            return null;
         }
-
-        return null;
     }
 }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -55,12 +55,16 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if (
-            ($guard = $config->get('auth.defaults.guard')) &&
-            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
-            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return $authModel;
+        if ($guard = $config->get('auth.defaults.guard')) {
+            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
+                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
+                    return $authModel;
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
         } else {
             return null;
         }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -51,7 +51,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
     /**
      * Returns the default auth model from config.
      *
-     * @return string|void
+     * @return string
      */
     private function getAuthModel(ConfigRepository $config)
     {
@@ -60,7 +60,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return;
+            return '';
         }
 
         return $authModel;

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -55,18 +55,14 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
      */
     private function getAuthModel(ConfigRepository $config)
     {
-        if ($guard = $config->get('auth.defaults.guard')) {
-            if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
-                if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
-                    return $authModel;
-                } else {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        } else {
+        if (
+            ! ($guard = $config->get('auth.defaults.guard')) ||
+            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
+            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
             return null;
         }
+
+        return $authModel;
     }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
This PR adds support for dynamic auth model load from config.

Replaces

```php
$userModel = $config->get('auth.providers.users.model');
``` 

with

```php
if ($guard = $config->get('auth.defaults.guard')) {
    if ($provider = $config->get('auth.guards.'.$guard.'.provider')) {
        if ($authModel = $config->get('auth.providers.'.$provider.'.model')) {
            return $authModel;
        }
    }
}
```

_(In the future maybe it can be extended with dynamic guard handling.)_
