### PR TITLE
feat: auth guard with multiple dynamic auth models

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -134,6 +134,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\GuardExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\RequestExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -8,10 +8,10 @@ use Illuminate\Config\Repository as ConfigRepository;
 
 trait LoadsAuthModel
 {
-    private function getDefaultAuthModel(ConfigRepository $config): ?string
+    private function getAuthModel(ConfigRepository $config, ?string $guard = null): ?string
     {
         if (
-            ! ($guard = $config->get('auth.defaults.guard')) ||
+            ($guard === null && ! ($guard = $config->get('auth.defaults.guard'))) ||
             ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
             ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
@@ -19,5 +19,20 @@ trait LoadsAuthModel
         }
 
         return $authModel;
+    }
+
+    private function getGuardFromNodeKey(?string $key): ?string
+    {
+        if ($key === null) {
+            return null;
+        }
+
+        $pattern = '/(?:guard|auth)\(\'(.*?)\'\)/';
+
+        if (! preg_match($pattern, $key, $matches)) {
+            return null;
+        }
+
+        return $matches[1];
     }
 }

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -20,19 +20,4 @@ trait LoadsAuthModel
 
         return $authModel;
     }
-
-    private function getGuardFromNodeKey(?string $key): ?string
-    {
-        if ($key === null) {
-            return null;
-        }
-
-        $pattern = '/(?:guard|auth)\(\'(.*?)\'\)/';
-
-        if (! preg_match($pattern, $key, $matches)) {
-            return null;
-        }
-
-        return $matches[1];
-    }
 }

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Concerns;
+
+use Illuminate\Config\Repository as ConfigRepository;
+
+trait LoadsAuthModel
+{
+    private function getDefaultAuthModel(ConfigRepository $config): ?string
+    {
+        if (
+            ! ($guard = $config->get('auth.defaults.guard')) ||
+            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
+            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+        ) {
+            return null;
+        }
+
+        return $authModel;
+    }
+}

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Closure;
-use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword;
@@ -20,6 +19,7 @@ use NunoMaduro\Larastan\Contracts\Methods\Pipes\PipeContract;
 final class Auths implements PipeContract
 {
     use Concerns\HasContainer;
+    use Concerns\LoadsAuthModel;
 
     /**
      * @var string[]
@@ -57,18 +57,5 @@ final class Auths implements PipeContract
         if (! $found) {
             $next($passable);
         }
-    }
-
-    private function getDefaultAuthModel(ConfigRepository $config): ?string
-    {
-        if (
-            ! ($guard = $config->get('auth.defaults.guard')) ||
-            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
-            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return null;
-        }
-
-        return $authModel;
     }
 }

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -43,7 +43,7 @@ final class Auths implements PipeContract
         $config = $this->resolve('config');
 
         if ($config !== null && in_array($classReflectionName, $this->classes, true)) {
-            $authModel = $this->getDefaultAuthModel($config);
+            $authModel = $this->getAuthModel($config);
 
             if ($authModel !== null) {
                 $found = $passable->sendToPipeline($authModel);

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -52,10 +52,10 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
 
         $authModel = $this->getDefaultAuthModel($config);
 
-        if ($authModel !== null) {
-            return TypeCombinator::addNull(new ObjectType($authModel));
+        if ($authModel === null) {
+            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        return TypeCombinator::addNull(new ObjectType($authModel));
     }
 }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -47,10 +47,12 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         StaticCall $methodCall,
         Scope $scope
     ): Type {
-        $config = $this->getContainer()
-            ->get('config');
+        $config = $this->getContainer()->get('config');
+        $authModel = null;
 
-        $authModel = $this->getAuthModel($config);
+        if ($config !== null) {
+            $authModel = $this->getAuthModel($config);
+        }
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\ReturnTypes;
 
-use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Support\Facades\Auth;
 use NunoMaduro\Larastan\Concerns;
 use PhpParser\Node\Expr\StaticCall;
@@ -22,6 +21,7 @@ use PHPStan\Type\TypeCombinator;
 final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
 {
     use Concerns\HasContainer;
+    use Concerns\LoadsAuthModel;
 
     /**
      * {@inheritdoc}
@@ -57,18 +57,5 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         }
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
-    }
-
-    private function getDefaultAuthModel(ConfigRepository $config): ?string
-    {
-        if (
-            ! ($guard = $config->get('auth.defaults.guard')) ||
-            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
-            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return null;
-        }
-
-        return $authModel;
     }
 }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -50,7 +50,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        $authModel = $this->getDefaultAuthModel($config);
+        $authModel = $this->getAuthModel($config);
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -43,10 +43,10 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
 
         $authModel = $this->getDefaultAuthModel($config);
 
-        if ($authModel !== null) {
-            return TypeCombinator::addNull(new ObjectType($authModel));
+        if ($authModel === null) {
+            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        return TypeCombinator::addNull(new ObjectType($authModel));
     }
 }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -38,10 +38,12 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        $config = $this->getContainer()
-            ->get('config');
+        $config = $this->getContainer()->get('config');
+        $authModel = null;
 
-        $authModel = $this->getAuthModel($config);
+        if ($config !== null) {
+            $authModel = $this->getAuthModel($config);
+        }
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -41,7 +41,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        $authModel = $this->getDefaultAuthModel($config);
+        $authModel = $this->getAuthModel($config);
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Auth\AuthManager;
-use Illuminate\Config\Repository as ConfigRepository;
 use NunoMaduro\Larastan\Concerns;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -19,6 +18,7 @@ use PHPStan\Type\TypeCombinator;
 final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
 {
     use Concerns\HasContainer;
+    use Concerns\LoadsAuthModel;
 
     /**
      * {@inheritdoc}
@@ -48,18 +48,5 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         }
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
-    }
-
-    private function getDefaultAuthModel(ConfigRepository $config): ?string
-    {
-        if (
-            ! ($guard = $config->get('auth.defaults.guard')) ||
-            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
-            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return null;
-        }
-
-        return $authModel;
     }
 }

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -41,11 +41,13 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        $config = $this->getContainer()
-            ->get('config');
+        $config = $this->getContainer()->get('config');
+        $authModel = null;
 
-        $guard = $this->getGuardFromMethodCall($scope, $methodCall);
-        $authModel = $this->getAuthModel($config, $guard);
+        if ($config !== null) {
+            $guard = $this->getGuardFromMethodCall($scope, $methodCall);
+            $authModel = $this->getAuthModel($config, $guard);
+        }
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
@@ -59,9 +61,12 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         if (
             ! ($methodCall->var instanceof StaticCall) &&
             ! ($methodCall->var instanceof MethodCall) &&
-            ! ($methodCall->var instanceof FuncCall) ||
-            count($methodCall->var->args) !== 1
+            ! ($methodCall->var instanceof FuncCall)
         ) {
+            return null;
+        }
+
+        if (count($methodCall->var->args) !== 1) {
             return null;
         }
 

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -6,6 +6,8 @@ namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Contracts\Auth\Guard;
 use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -65,6 +67,7 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         }
 
         if (
+            (! ($methodCall->var->name instanceof Identifier) && ! ($methodCall->var->name instanceof Name)) ||
             ! in_array((string)$methodCall->var->name, ['guard', 'auth'], true) ||
             count($methodCall->var->args) === 0 ||
             ! ($methodCall->var->args[0]->value instanceof String_)

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -6,8 +6,6 @@ namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Contracts\Auth\Guard;
 use NunoMaduro\Larastan\Concerns;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -69,7 +67,7 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
 
         $guardType = $scope->getType($methodCall->var->args[0]->value);
 
-        if (!$guardType instanceof ConstantStringType) {
+        if (! $guardType instanceof ConstantStringType) {
             return null;
         }
 

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Contracts\Auth\Guard;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class GuardExtension implements DynamicMethodReturnTypeExtension
+{
+    use Concerns\HasContainer;
+    use Concerns\LoadsAuthModel;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Guard::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'user';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $config = $this->getContainer()
+            ->get('config');
+
+        $authModel = $this->getDefaultAuthModel($config);
+
+        if ($authModel !== null) {
+            return TypeCombinator::addNull(new ObjectType($authModel));
+        }
+
+        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+    }
+}

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -43,7 +43,7 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
 
         $nodeKey = $methodCall->getAttribute('phpstan_cache_printer');
         $guard = $this->getGuardFromNodeKey($nodeKey);
-        $authModel = $this->getAuthModel($config, null);
+        $authModel = $this->getAuthModel($config, $guard);
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -41,7 +41,9 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         $config = $this->getContainer()
             ->get('config');
 
-        $authModel = $this->getDefaultAuthModel($config);
+        $nodeKey = $methodCall->getAttribute('phpstan_cache_printer');
+        $guard = $this->getGuardFromNodeKey($nodeKey);
+        $authModel = $this->getAuthModel($config, null);
 
         if ($authModel === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -43,10 +43,10 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
 
         $authModel = $this->getDefaultAuthModel($config);
 
-        if ($authModel !== null) {
-            return TypeCombinator::addNull(new ObjectType($authModel));
+        if ($authModel === null) {
+            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        return TypeCombinator::addNull(new ObjectType($authModel));
     }
 }

--- a/tests/Application/app/Admin.php
+++ b/tests/Application/app/Admin.php
@@ -2,11 +2,6 @@
 
 namespace App;
 
-use Illuminate\Foundation\Auth\User as Authenticatable;
-
-/**
- * @mixin \Eloquent
- */
-class Admin extends Authenticatable
+class Admin
 {
 }

--- a/tests/Application/app/Admin.php
+++ b/tests/Application/app/Admin.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+/**
+ * @mixin \Eloquent
+ */
+class Admin extends Authenticatable
+{
+}

--- a/tests/Application/config/auth.php
+++ b/tests/Application/config/auth.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+
+    'defaults' => [
+        'guard' => 'web',
+        'passwords' => 'users',
+    ],
+
+    'guards' => [
+        'web' => [
+            'driver' => 'session',
+            'provider' => 'users',
+        ],
+
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
+
+        'api' => [
+            'driver' => 'token',
+            'provider' => 'users',
+            'hash' => false,
+        ],
+    ],
+
+    'providers' => [
+        'users' => [
+            'driver' => 'eloquent',
+            'model' => App\User::class,
+        ],
+
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Admin::class,
+        ],
+    ],
+
+    'passwords' => [
+        'users' => [
+            'provider' => 'users',
+            'table' => 'password_resets',
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+    ],
+
+    'password_timeout' => 10800,
+
+];

--- a/tests/Features/ReturnTypes/AuthExtension.php
+++ b/tests/Features/ReturnTypes/AuthExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes;
 
+use App\Admin;
 use App\User;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Auth\Guard;
@@ -43,6 +44,11 @@ class AuthExtension
     public function testGuardUser(): ?User
     {
         return Auth::guard('web')->user();
+    }
+
+    public function testGuardAdminUser(): ?Admin
+    {
+        return Auth::guard('admin')->user();
     }
 
     public function testSessionGuard(): SessionGuard

--- a/tests/Features/ReturnTypes/AuthExtension.php
+++ b/tests/Features/ReturnTypes/AuthExtension.php
@@ -6,6 +6,7 @@ namespace Tests\Features\ReturnTypes;
 
 use App\User;
 use Illuminate\Auth\SessionGuard;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Auth;
 
 class AuthExtension
@@ -32,6 +33,16 @@ class AuthExtension
     public function testLogout(): void
     {
         Auth::guard()->logout();
+    }
+
+    public function testGuard(): Guard
+    {
+        return Auth::guard('web');
+    }
+
+    public function testGuardUser(): ?User
+    {
+        return Auth::guard('web')->user();
     }
 
     public function testSessionGuard(): SessionGuard

--- a/tests/Features/ReturnTypes/Helpers/AuthExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AuthExtension.php
@@ -17,6 +17,11 @@ class AuthExtension
 
     public function testAuthGuard(): Guard
     {
+        return auth()->guard('web');
+    }
+
+    public function testAuthGuardParameter(): Guard
+    {
         return auth('web');
     }
 
@@ -28,6 +33,16 @@ class AuthExtension
     public function testCheck(): bool
     {
         return auth()->check();
+    }
+
+    public function testAuthGuardUser(): ?User
+    {
+        return auth()->guard('web')->user();
+    }
+
+    public function testAuthGuardParameterUser(): ?User
+    {
+        return auth('web')->user();
     }
 
     /**

--- a/tests/Features/ReturnTypes/Helpers/AuthExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AuthExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes\Helpers;
 
+use App\Admin;
 use App\User;
 use Illuminate\Contracts\Auth\Factory;
 use Illuminate\Contracts\Auth\Guard;
@@ -43,6 +44,16 @@ class AuthExtension
     public function testAuthGuardParameterUser(): ?User
     {
         return auth('web')->user();
+    }
+
+    public function testAuthGuardAdminUser(): ?Admin
+    {
+        return auth()->guard('admin')->user();
+    }
+
+    public function testAuthGuardAdminParameterUser(): ?Admin
+    {
+        return auth('admin')->user();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ class TestCase extends BaseTestCase
         @File::copy(__DIR__.'/../config/mixins.php', __DIR__.'/../vendor/nunomaduro/larastan/config/mixins.php');
         @File::copy(__DIR__.'/../config/statics.php', __DIR__.'/../vendor/nunomaduro/larastan/config/statics.php');
         File::copyDirectory(__DIR__.'/Application/database/migrations', $this->getBasePath().'/database/migrations');
+        File::copyDirectory(__DIR__.'/Application/config', $this->getBasePath().'/config');
     }
 
     public function execLarastan(string $filename)


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR handles the `Guard` interface and **extracts the actual guard** specified with, after the guard is extracted it loads the matching auth model (through the guard provider) from config and **sets the return type** _(e.g. `User`, `Admin`, `Customer`...)_.

```php
auth('admin')->user();
auth()->guard('admin')->user();
Auth::guard('admin')->user();
```

There are 2 new files added for tests `app/Admin.php` and `config/auth.php`.

_(I've also added `LoadsAuthModel` trait, since `getDefaultAuthModel()` is implemented multiple times.)_

Some example errors before this PR:
```php
// Method Tests\\Features\\ReturnTypes\\Helpers\\AuthExtension::testAuthGuardUser() should return App\\User|null but returns Illuminate\\Contracts\\Auth\\Authenticatable|null.
public function testAuthGuardUser(): ?User
{
    return auth()->guard('web')->user();
}

// Method Tests\\Features\\ReturnTypes\\Helpers\\AuthExtension::testAuthGuardParameterUser() should return App\\User|null but returns Illuminate\\Contracts\\Auth\\Authenticatable|null.
public function testAuthGuardParameterUser(): ?User
{
    return auth('web')->user();
}

// Method Tests\\Features\\ReturnTypes\\AuthExtension::testGuardAdminUser() should return App\\Admin|null but returns Illuminate\\Contracts\\Auth\\Authenticatable|null.
public function testGuardAdminUser(): ?Admin
{
    return Auth::guard('admin')->user();
}

// Method Tests\\Features\\ReturnTypes\\Helpers\\AuthExtension::testAuthGuardAdminUser() should return App\\Admin|null but returns Illuminate\\Contracts\\Auth\\Authenticatable|null.
public function testAuthGuardAdminUser(): ?Admin
{
    return auth()->guard('admin')->user();
}
```
