### PR TITLE
Fix stubs for certain query builder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix false positive for NoUnnecessaryCollectionCallRule when statically calling hydrate on a Model class. ([#609](https://github.com/nunomaduro/larastan/pull/609))
+- Fixed slightly incorrect stubs for accepted $values for `whereBetween`/`orWhereBetween` and `whereRowValues`/`orWhereRowValues` ([#626](https://github.com/nunomaduro/larastan/pull/626))
 
 ## [0.6.1] - 2020-06-20
 

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -467,7 +467,7 @@ class Builder
      * Add a where between statement to the query.
      *
      * @param  string  $column
-     * @param  array<string, mixed>  $values
+     * @param  array<string|int, mixed>  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -479,7 +479,7 @@ class Builder
      * Add an or where between statement to the query.
      *
      * @param  string  $column
-     * @param  array<string, mixed>  $values
+     * @param  array<string|int, mixed>  $values
      * @return $this
      */
     public function orWhereBetween($column, array $values)
@@ -739,7 +739,7 @@ class Builder
      *
      * @param  array<string>  $columns
      * @param  string  $operator
-     * @param  array<string, mixed>  $values
+     * @param  array<string|int, mixed>  $values
      * @param  string  $boolean
      * @return $this
      *
@@ -753,7 +753,7 @@ class Builder
      *
      * @param  array<string>  $columns
      * @param  string  $operator
-     * @param  array<string, mixed>  $values
+     * @param  array<string|int, mixed>  $values
      * @return $this
      */
     public function orWhereRowValues($columns, $operator, $values)


### PR DESCRIPTION
`whereBetween`/`orWhereBetween` for the 2nd and `whereRowValues`/
`orWhereRowValues` for the 3rd arg also accept "array of values" and
not only key => values.

- Fixes https://github.com/nunomaduro/larastan/issues/624
- Fixes https://github.com/nunomaduro/larastan/issues/625

----
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md