### PR TITLE
styleci: remove disabling of self_accessor

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-disabled:
-  - self_accessor


### PR DESCRIPTION
See https://github.styleci.io/analyses/m4oYjV
> **Config Issue**
> The 'self_accessor' fixer cannot be disabled because it is not enabled by your preset.

- [ ] ~Added or updated tests~
- [ ] ~Documented user facing changes~
- [ ] ~Updated CHANGELOG.md~
