### PR TITLE
fix: return type of `associate`, `dissociate` and `getChild` methods of `BelongsTo` relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Return type of `associate`, `dissociate` and `getChild` methods of `BelongsTo` relations ([#633](https://github.com/nunomaduro/larastan/pull/633))
+
 ## [0.6.2] - 2020-07-30
 
 ### Fixed

--- a/src/Types/ModelRelationsDynamicMethodReturnTypeExtension.php
+++ b/src/Types/ModelRelationsDynamicMethodReturnTypeExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Types;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use NunoMaduro\Larastan\Concerns\HasContainer;
 use PhpParser\Node\Expr\MethodCall;
@@ -92,6 +93,15 @@ class ModelRelationsDynamicMethodReturnTypeExtension implements DynamicMethodRet
         $relatedModelClassName = $this
             ->relationParserHelper
             ->findRelatedModelInRelationMethod($methodReflection);
+
+        $classReflection = $methodReflection->getDeclaringClass();
+
+        if ($returnType->isInstanceOf(BelongsTo::class)->yes()) {
+            return new GenericObjectType($returnType->getClassName(), [
+                new ObjectType($relatedModelClassName),
+                new ObjectType($classReflection->getName())
+            ]);
+        }
 
         return new GenericObjectType($returnType->getClassName(), [new ObjectType($relatedModelClassName)]);
     }

--- a/stubs/BelongsTo.stub
+++ b/stubs/BelongsTo.stub
@@ -4,12 +4,19 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TChildModel of \Illuminate\Database\Eloquent\Model
  * @extends Relation<TRelatedModel>
  */
 class BelongsTo extends Relation
 {
-    /** @phpstan-return TRelatedModel */
+    /** @phpstan-return TChildModel */
     public function associate();
+
+    /** @phpstan-return TChildModel */
+    public function dissociate();
+
+    /** @phpstan-return TChildModel */
+    public function getChild();
 
     /**
      * Get the results of the relationship.

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -135,7 +135,7 @@ class Relations
     }
 
     /**
-     * @phpstan-return BelongsTo<User>
+     * @phpstan-return BelongsTo<User, Account>
      */
     public function testRelationWithTrait(Account $account): BelongsTo
     {
@@ -143,7 +143,7 @@ class Relations
     }
 
     /**
-     * @phpstan-return BelongsTo<Account>
+     * @phpstan-return BelongsTo<Account, Account>
      */
     public function testRelationInTraitWithStaticClass(Account $account): BelongsTo
     {
@@ -156,7 +156,7 @@ class Relations
         return $user->children();
     }
 
-    /** @phpstan-return BelongsTo<User> */
+    /** @phpstan-return BelongsTo<User, User> */
     public function testSameClassRelationWithGetClass(User $user): BelongsTo
     {
         return $user->parent();
@@ -200,5 +200,18 @@ class TestRelationCreateOnExistingModel
     public function testRelationCreateOnExistingModel(): Account
     {
         return $this->user->accounts()->create();
+    }
+}
+
+class Post extends Model
+{
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function addUser(User $user): self
+    {
+        return $this->author()->associate($user);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR fixes #631 
