### PR TITLE
feat: return type extension for `validator` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Return type extension for `validator` helper ([#641](https://github.com/nunomaduro/larastan/pull/641))
+
 ### Fixed
 
 - Return type of `associate`, `dissociate` and `getChild` methods of `BelongsTo` relations ([#633](https://github.com/nunomaduro/larastan/pull/633))

--- a/extension.neon
+++ b/extension.neon
@@ -217,6 +217,11 @@ services:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\ValidatorExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.functionTypeSpecifyingExtension

--- a/src/ReturnTypes/Helpers/ValidatorExtension.php
+++ b/src/ReturnTypes/Helpers/ValidatorExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypehintHelper;
+use function count;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @internal
+ */
+final class ValidatorExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'validator';
+    }
+
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        if (count($functionCall->args) === 0) {
+            return new ObjectType(\Illuminate\Contracts\Validation\Factory::class);
+        }
+
+        return new IntersectionType([
+            new ObjectType(\Illuminate\Validation\Validator::class),
+            new ObjectType(\Illuminate\Contracts\Validation\Validator::class)
+        ]);
+    }
+}

--- a/tests/Features/ReturnTypes/Helpers/ValidatorExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/ValidatorExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Request;
+
+class ValidatorExtension
+{
+    public function testWithNoArgument(): Factory
+    {
+        return validator();
+    }
+
+    public function testWithArgument(): Validator
+    {
+        return validator(['foo' => 'bar'], ['foo' => 'required']);
+    }
+
+    /** @return array<string, mixed> */
+    public function testValid(): array
+    {
+        return validator(['foo' => 'bar'], ['foo' => 'required'])->valid();
+    }
+
+    public function testIssue638(Request $request): Validator
+    {
+        $validator = validator($request->all(), [
+            'message' => 'required',
+        ]);
+
+        $validationAttributeNames = [
+            'message' => trans('g.label.message'),
+        ];
+
+        $validator->setAttributeNames($validationAttributeNames);
+        $validator->validate();
+
+        return $validator;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Fixes #638 

**Changes**

This PR adds a new return type extension to support `validator` helper.

**Breaking changes**

n/a
