### PR TITLE
Test Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,16 @@ env:
   - LARAVEL_VERSION="^6.0" COMPOSER_VERSION="^2.0"
   - LARAVEL_VERSION="^7.0" COMPOSER_VERSION="^1.0"
   - LARAVEL_VERSION="^7.0" COMPOSER_VERSION="^2.0"
+  - LARAVEL_VERSION="^8.0" COMPOSER_VERSION="^1.0"
+  - LARAVEL_VERSION="^8.0" COMPOSER_VERSION="^2.0"
 
 jobs:
   fast_finish: true
+  exclude:
+    - php: 7.2
+      env: LARAVEL_VERSION="^8.0" COMPOSER_VERSION="^1.0"
+    - php: 7.2
+      env: LARAVEL_VERSION="^8.0" COMPOSER_VERSION="^2.0"
   include:
     - name: "Static Analysis"
       php:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0 || ^5.0",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^7.3 || ^8.2"
     },
     "suggest": {


### PR DESCRIPTION
This PR adds Laravel 8 to Travis testing matrix. Also requires version 0.6 of `orchestra/testbench` for Laravel 8.

I guess with this Laravel 8 support is ready.

Am I missing something?