### PR TITLE
fix: correct return type for `firstWhere` method on model, builder and relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Return type of `firstWhere` method on model, builder and relations ([#649](https://github.com/nunomaduro/larastan/pull/649))
 
 ## [0.6.3] - 2020-08-31
 

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -18,9 +18,14 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateObjectType;
+use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypehintHelper;
+use PHPStan\Type\UnionTypeHelper;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 
@@ -171,7 +176,9 @@ class BuilderHelper
 
         if ($methodReflection !== null) {
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
-            $returnType = $parametersAcceptor->getReturnType();
+
+            // Resolve any generic models in the return type
+            $returnType = TemplateTypeHelper::resolveTemplateTypes($parametersAcceptor->getReturnType(), new TemplateTypeMap(['TModelClass' => new ObjectType($modelName)]));
 
             // If a model scope has a void return type, return the builder
             if ($returnType instanceof VoidType && $model->hasNativeMethod('scope'.ucfirst($methodName))) {

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -118,6 +118,17 @@ class Builder
     public function firstOr($columns = ['*'], \Closure $callback = null);
 
     /**
+     * Add a basic where clause to the query, and return the first result.
+     *
+     * @param  \Closure|string|array<string, string>  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @phpstan-return TModelClass|null
+     */
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and');
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array<int, string>|string  $columns

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -60,7 +60,7 @@ class User extends Authenticatable
         return $query->where('active', 1);
     }
 
-    /** @phpstan-return BelongsTo<Group> */
+    /** @phpstan-return BelongsTo<Group, User> */
     public function group(): BelongsTo
     {
         return $this->belongsTo(Group::class);

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -241,6 +241,16 @@ class ModelExtension
     {
         return User::onlyTrashed()->findOrFail(5);
     }
+
+    public function testFirstWhere(): ?User
+    {
+        return User::firstWhere(['email' => 'foo@bar.com']);
+    }
+
+    public function testFirstWhereWithBuilder(): ?User
+    {
+        return User::query()->where('foo', 'bar')->firstWhere(['email' => 'foo@bar.com']);
+    }
 }
 
 function foo(): string

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -161,6 +161,16 @@ class Relations
     {
         return $user->parent();
     }
+
+    public function testFirstWhereWithHasManyRelation(User $user): ?Account
+    {
+        return $user->accounts()->firstWhere('foo', 'bar');
+    }
+
+    public function testFirstWhereWithBelongsToRelation(User $user): ?Group
+    {
+        return $user->group()->firstWhere('foo', 'bar');
+    }
 }
 
 /**


### PR DESCRIPTION

- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes #647 

**Changes**

This PR fixes the return type of `firstWhere` method called on model, builder and relations.
