### PR TITLE
fix: correct parameter type for  `where`, `orWhere` and `addArrayOfWheres` in stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Parameter type of the query builder's `where`, `orWhere` and `addArrayOfWheres` ([#651](https://github.com/nunomaduro/larastan/pull/651)).
+
 ## [0.6.4] - 2020-09-02
 
 ### Changed

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -238,7 +238,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array<string, mixed>  $column
+     * @param  \Closure|string|array<string|int, mixed>  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -250,7 +250,7 @@ class Builder
     /**
      * Add an array of where clauses to the query.
      *
-     * @param  array<string>  $column
+     * @param  array<string|int, mixed>  $column
      * @param  string  $boolean
      * @param  string  $method
      * @return $this
@@ -295,7 +295,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|string|array<string, mixed>  $column
+     * @param  \Closure|string|array<string|int, mixed>  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -11,6 +11,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class BuilderExtension
 {
+    public function testArrayOfWheres(): Collection
+    {
+        return User::where([
+            ['active', true],
+            ['id', '>=', 5],
+            ['id', '<=', 10]
+        ])->get();
+    }
+
     /** @return Collection<User> */
     public function testCallingGetOnModelWithStaticQueryBuilder(): Collection
     {

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -16,7 +16,7 @@ class BuilderExtension
         return User::where([
             ['active', true],
             ['id', '>=', 5],
-            ['id', '<=', 10]
+            ['id', '<=', 10],
         ])->get();
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Updates the QueryBuilder stubs such that the following expression does not result in an error:
```php
return User::where([
        ['active', true],
        ['id', '>=', 5],
        ['id', '<=', 10]
])->get();
```
