### PR TITLE
[POC] feat: Add model-property type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,9 +61,11 @@
     },
     "scripts": {
         "test:types": "phpstan analyse --ansi",
+        "test:laravel-types": "phpstan analyse --ansi --level=max --configuration ./extension.neon ./tests/Application/app",
         "test:unit": "phpunit --colors=always",
         "test": [
             "@test:types",
+            "@test:laravel-types",
             "@test:unit"
         ]
     }

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -36,9 +36,8 @@ The `model-property` type is a generic type that validates whether a string
 exists as a property on a subclass of `\Illuminate\Database\Eloquent\Model`. 
 
 Given the type `model-property<\App\Models\User>`, Larastan will check whether 
-the string exists as a property on the `\App\Models\User` class. This is true if there
-exists a PHPDoc annotation for this property, or if Larastan is able to infer
-this from your migrations.
+the string exists as a property on the `\App\Models\User` class. This is true if 
+Larastan finds a column definition on the corresponding table in one of your migrations.
 
 **Example:**
 

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -30,3 +30,39 @@ If the string is not an existing blade view, the following error will be display
 ```
 Parameter #1 $view of method TestClass::renderView() expects view-string, string given.  
 ```
+
+## model-property
+The `model-property` type is a generic type that validates whether a string 
+exists as a property on a subclass of `\Illuminate\Database\Eloquent\Model`. 
+
+Given the type `model-property<\App\Models\User>`, Larastan will check whether 
+the string exists as a property on the `\App\Models\User` class. This is true if there
+exists a PHPDoc annotation for this property, or if Larastan is able to infer
+this from your migrations.
+
+**Example:**
+
+```php
+class User extends \Illuminate\Database\Eloquent\Model
+{
+    /**
+     * @phpstan-param model-property<self> $column
+     * @param string $column
+     * @return Builder
+     */
+    public function scopeWhereTrue($query, string $column): Builder
+    {
+        return $query->where($column, true);
+    }
+}
+```
+
+Larastan will then make sure that the string passed to the `whereTrue` scope
+actually exists as a property on your User model.
+
+This type is disabled by default. To allow Larastan to inspect these strings, set
+```
+parameters:
+    checkModelProperties: true
+```
+in your configuration file.

--- a/extension.neon
+++ b/extension.neon
@@ -41,11 +41,13 @@ parameters:
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
+    checkModelProperties: false
 
 parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
+    checkModelProperties: bool()
 
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
@@ -283,6 +285,13 @@ services:
         class: NunoMaduro\Larastan\Types\ViewStringTypeNodeResolverExtension
         tags:
             - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
+        class: NunoMaduro\Larastan\Types\ModelPropertyTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension
+        arguments:
+            active: %checkModelProperties%
 
     -
         class: NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -163,7 +163,8 @@ class BuilderHelper
         // This can be a custom EloquentBuilder or the normal one
         $builderName = $this->determineBuilderType($modelName);
 
-        $builderReflection = $this->broker->getClass($builderName);
+        /** @var \PHPStan\Reflection\ClassReflection $builderReflection */
+        $builderReflection = (new GenericObjectType($builderName, [new ObjectType($modelName)]))->getClassReflection();
 
         $methodReflection = $this->searchOnEloquentBuilder($builderReflection, $methodName, $modelName);
 

--- a/src/Types/GenericModelPropertyType.php
+++ b/src/Types/GenericModelPropertyType.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use NunoMaduro\Larastan\Properties\ModelPropertyExtension;
+use PHPStan\Broker\Broker;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ClassStringType;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+
+class GenericModelPropertyType extends ModelPropertyType
+{
+    /** @var Type */
+    private $type;
+
+    /** @var ModelPropertyExtension */
+    protected $propertyExtension;
+
+    public function __construct(Type $type, ModelPropertyExtension $propertyExtension)
+    {
+        $this->type = $type;
+        $this->propertyExtension = $propertyExtension;
+    }
+
+    public function getReferencedClasses(): array
+    {
+        return $this->getGenericType()->getReferencedClasses();
+    }
+
+    public function getGenericType(): Type
+    {
+        return $this->type;
+    }
+
+    public function describe(VerbosityLevel $level): string
+    {
+        return sprintf('%s<%s>', parent::describe($level), $this->getGenericType()->describe($level));
+    }
+
+    public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+    {
+        if ($type instanceof CompoundType) {
+            return $type->isAcceptedBy($this, $strictTypes);
+        }
+
+        if ($type instanceof ConstantStringType) {
+            $genericType = $this->getGenericType();
+
+            if ($genericType instanceof UnionType || $genericType instanceof IntersectionType) {
+                $types = $genericType->getTypes();
+                /** @var Type $lastType */
+                $lastType = array_pop($types);
+                $newGenericType1 =  new self($lastType, $this->propertyExtension);
+                if ($genericType instanceof UnionType) {
+                    $newGenericType2 = (new self(count($types) > 1 ? new UnionType($types) : $types[0], $this->propertyExtension));
+
+                    return TrinaryLogic::createNo()->or(
+                        $newGenericType1->accepts($type, $strictTypes),
+                        $newGenericType2->accepts($type, $strictTypes)
+                );
+                }
+                $newGenericType2 = (new self(count($types) > 1 ? new IntersectionType($types) : $types[0], $this->propertyExtension));
+
+                if ($newGenericType1->accepts($type, $strictTypes)->no() || $newGenericType2->accepts($type, $strictTypes)->no()) {
+                    return TrinaryLogic::createNo();
+                }
+
+                return TrinaryLogic::createYes();
+            }
+
+            if ($genericType instanceof MixedType) {
+                return TrinaryLogic::createYes();
+            }
+
+            if (! $genericType instanceof ObjectType) {
+                return TrinaryLogic::createNo();
+            }
+
+            $classReflection = $genericType->getClassReflection();
+
+
+            if ($classReflection === null) {
+                return TrinaryLogic::createNo();
+            }
+
+            return TrinaryLogic::createFromBoolean(
+                $this->propertyExtension->hasProperty($classReflection, $type->getValue())
+            );
+        } elseif ($type instanceof self) {
+            $objectType = $type->type;
+        } elseif ($type instanceof ClassStringType) {
+            $objectType = new ObjectWithoutClassType();
+        } elseif ($type instanceof StringType) {
+            return TrinaryLogic::createMaybe();
+        } else {
+            return TrinaryLogic::createNo();
+        }
+
+        return $this->getGenericType()->accepts($objectType, $strictTypes);
+    }
+
+    public function isSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+
+        if ($type instanceof ConstantStringType) {
+            $genericType = $this->getGenericType();
+            if ($genericType instanceof MixedType) {
+                return TrinaryLogic::createYes();
+            }
+
+            if ($genericType instanceof StaticType) {
+                $genericType = $genericType->getStaticObjectType();
+            }
+
+            // We are transforming constant class-string to ObjectType. But we need to filter out
+            // an uncertainty originating in possible ObjectType's class subtypes.
+            $objectType = new ObjectType($type->getValue());
+
+            // Do not use TemplateType's isSuperTypeOf handling directly because it takes ObjectType
+            // uncertainty into account.
+            if ($genericType instanceof TemplateType) {
+                $isSuperType = $genericType->getBound()->isSuperTypeOf($objectType);
+            } else {
+                $isSuperType = $genericType->isSuperTypeOf($objectType);
+            }
+
+            // Explicitly handle the uncertainty for Maybe.
+            if ($isSuperType->maybe()) {
+                return TrinaryLogic::createNo();
+            }
+
+            return $isSuperType;
+        } elseif ($type instanceof self) {
+            return $this->getGenericType()->isSuperTypeOf($type->type);
+        } elseif ($type instanceof StringType) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    public function traverse(callable $cb): Type
+    {
+        $newType = $cb($this->getGenericType());
+        if ($newType === $this->getGenericType()) {
+            return $this;
+        }
+
+        return new self($newType, $this->propertyExtension);
+    }
+
+    public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+    {
+        if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+            return $receivedType->inferTemplateTypesOn($this);
+        }
+
+        if ($receivedType instanceof ConstantStringType) {
+            $typeToInfer = new ObjectType($receivedType->getValue());
+        } elseif ($receivedType instanceof self) {
+            $typeToInfer = $receivedType->type;
+        } elseif ($receivedType instanceof ClassStringType) {
+            $typeToInfer = $this->getGenericType();
+            if ($typeToInfer instanceof TemplateType) {
+                $typeToInfer = $typeToInfer->getBound();
+            }
+
+            $typeToInfer = TypeCombinator::intersect($typeToInfer, new ObjectWithoutClassType());
+        } else {
+            return TemplateTypeMap::createEmpty();
+        }
+
+        if (!$this->getGenericType()->isSuperTypeOf($typeToInfer)->no()) {
+            return $this->getGenericType()->inferTemplateTypes($typeToInfer);
+        }
+
+        return TemplateTypeMap::createEmpty();
+    }
+
+    public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+    {
+        $variance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
+
+        return $this->getGenericType()->getReferencedTemplateTypes($variance);
+    }
+
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self($properties['type'], $properties['extension']);
+    }
+
+}

--- a/src/Types/ModelPropertyType.php
+++ b/src/Types/ModelPropertyType.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+class ModelPropertyType extends StringType
+{
+    public function describe(\PHPStan\Type\VerbosityLevel $level): string
+    {
+        return 'model-property';
+    }
+
+    public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+    {
+        if ($type instanceof CompoundType) {
+            return $type->isAcceptedBy($this, $strictTypes);
+        }
+
+        if ($type instanceof ConstantStringType) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof StringType) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    public function isSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof ConstantStringType) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof parent) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self();
+    }
+}

--- a/src/Types/ModelPropertyTypeNodeResolverExtension.php
+++ b/src/Types/ModelPropertyTypeNodeResolverExtension.php
@@ -11,8 +11,11 @@ use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDoc\TypeNodeResolverExtension;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -56,6 +59,10 @@ class ModelPropertyTypeNodeResolverExtension implements TypeNodeResolverExtensio
             $genericType = $this->baseResolver->resolve($typeNode->genericTypes[0], $nameScope);
 
             if ((new ObjectType(Model::class))->isSuperTypeOf($genericType)->no()) {
+                return new ErrorType();
+            }
+
+            if ($genericType instanceof NeverType) {
                 return new ErrorType();
             }
 

--- a/src/Types/ModelPropertyTypeNodeResolverExtension.php
+++ b/src/Types/ModelPropertyTypeNodeResolverExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Larastan\Properties\ModelPropertyExtension;
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolver;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * Ensures a 'model-property' type in PHPDoc is recognised to be of type ModelPropertyType.
+ */
+class ModelPropertyTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    /** @var bool */
+    protected $active;
+
+    /** @var TypeNodeResolver */
+    protected $baseResolver;
+
+    /** @var ModelPropertyExtension */
+    protected $propertyExtension;
+
+    public function __construct(TypeNodeResolver $baseResolver, ModelPropertyExtension $propertyExtension, bool $active)
+    {
+        $this->baseResolver = $baseResolver;
+        $this->propertyExtension = $propertyExtension;
+        $this->active = $active;
+    }
+
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->name === 'model-property') {
+            return $this->active ? new ModelPropertyType() : new StringType();
+        }
+
+        if ($typeNode instanceof GenericTypeNode && $typeNode->type->name === 'model-property') {
+            if (! $this->active) {
+                return new StringType();
+            }
+
+            if (count($typeNode->genericTypes) !== 1) {
+                return new ErrorType();
+            }
+
+            $genericType = $this->baseResolver->resolve($typeNode->genericTypes[0], $nameScope);
+
+            if ((new ObjectType(Model::class))->isSuperTypeOf($genericType)->no()) {
+                return new ErrorType();
+            }
+
+            return new GenericModelPropertyType($genericType, $this->propertyExtension);
+        }
+
+        return null;
+    }
+}

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -11,7 +11,7 @@ class Builder
     public function getModel();
 
     /**
-     * @param array<string, mixed> $attributes
+     * @phpstan-param array<model-property<TModelClass>, mixed> $attributes
      * @phpstan-return TModelClass
      */
     public function create(array $attributes = []);
@@ -37,7 +37,7 @@ class Builder
      * Find a model by its primary key.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<TModelClass>|null
      */
     public function find($id, $columns = ['*']);
@@ -46,7 +46,7 @@ class Builder
      * Find multiple models by their primary keys.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array<mixed>  $ids
-     * @param  array<mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return \Illuminate\Database\Eloquent\Collection<TModelClass>
      */
     public function findMany($ids, $columns = ['*']);
@@ -55,7 +55,7 @@ class Builder
      * Find a model by its primary key or throw an exception.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<TModelClass>
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
@@ -66,7 +66,7 @@ class Builder
      * Find a model by its primary key or return fresh model instance.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass
      */
     public function findOrNew($id, $columns = ['*']);
@@ -74,8 +74,8 @@ class Builder
     /**
      * Get the first record matching the attributes or instantiate it.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function firstOrNew(array $attributes = [], array $values = []);
@@ -83,8 +83,8 @@ class Builder
     /**
      * Get the first record matching the attributes or create it.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function firstOrCreate(array $attributes, array $values = []);
@@ -92,16 +92,28 @@ class Builder
     /**
      * Create or update a record matching the attributes, and fill it with values.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function updateOrCreate(array $attributes, array $values = []);
 
     /**
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @return \Illuminate\Database\Eloquent\Model|$this
+     */
+    public function forceCreate(array $attributes);
+
+   /**
+     * @param  array<model-property<TModelClass>, mixed>  $values
+     * @return int
+     */
+    public function update(array $values);
+
+    /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array<int, string>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
@@ -111,7 +123,7 @@ class Builder
     /**
      * Execute the query and get the first result or call a callback.
      *
-     * @param  \Closure|array<int, string>  $columns
+     * @param  \Closure|array<int, (model-property<TModelClass>|'*')>  $columns
      * @param  \Closure|null  $callback
      * @phpstan-return TModelClass|mixed
      */
@@ -120,7 +132,7 @@ class Builder
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array<string, string>  $column
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>, mixed>  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -131,7 +143,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array<int, string>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return \Illuminate\Database\Eloquent\Collection<TModelClass>
      */
     public function get($columns = ['*']);
@@ -139,7 +151,7 @@ class Builder
     /**
      * Get the hydrated models without eager loading.
      *
-     * @param  array<int, string>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass[]
      */
     public function getModels($columns = ['*']);

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -24,22 +24,18 @@ class User extends Authenticatable
     use Notifiable;
     use SoftDeletes;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
+    /** @var array<int, model-property<self>|'*'> */
     protected $fillable = [
         'name', 'email', 'password',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<model-property<self>, string> */
     protected $casts = ['meta' => 'array', 'blocked' => 'boolean'];
 
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var array
+     * @var array<model-property<self>>
      */
     protected $hidden = [
         'password', 'remember_token',
@@ -55,12 +51,27 @@ class User extends Authenticatable
         return Str::upper($this->name);
     }
 
+    /**
+     * @param model-property<self> $property
+     */
+    public function printPropertySelf(string $property): void
+    {
+        echo $this->{$property};
+    }
+
+    /**
+     * @param model-property<static> $property
+     */
+    public function printPropertyStatic(string $property): void
+    {
+        echo $this->{$property};
+    }
+
     public function scopeActive(Builder $query): Builder
     {
         return $query->where('active', 1);
     }
 
-    /** @phpstan-return BelongsTo<Group, User> */
     public function group(): BelongsTo
     {
         return $this->belongsTo(Group::class);
@@ -103,6 +114,12 @@ class User extends Authenticatable
         return $this->belongsTo(get_class($this));
     }
 
+    /**
+     * @param string $related
+     * @param string|null $foreignKey
+     * @param string|null $localKey
+     * @return HasManySyncable
+     */
     public function hasManySyncable($related, $foreignKey = null, $localKey = null): HasManySyncable
     {
         $instance = $this->newRelatedInstance($related);

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -164,12 +164,12 @@ class Relations
 
     public function testFirstWhereWithHasManyRelation(User $user): ?Account
     {
-        return $user->accounts()->firstWhere('foo', 'bar');
+        return $user->accounts()->firstWhere('active', 'bar');
     }
 
     public function testFirstWhereWithBelongsToRelation(User $user): ?Group
     {
-        return $user->group()->firstWhere('foo', 'bar');
+        return $user->group()->firstWhere('id', 'bar');
     }
 }
 

--- a/tests/Features/Types/GenericModelPropertyType.php
+++ b/tests/Features/Types/GenericModelPropertyType.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Types;
+
+use App\User;
+
+class GenericModelPropertyType
+{
+    public function testBuilderCreate(): void
+    {
+        User::create([
+            'password' => 'hello',
+            'email' => 'some-email@laravel.com',
+        ]);
+    }
+
+    public function testGenericModelPropertySimple(): void
+    {
+        $this->showFirstUserProperty('id');
+        $this->showFirstUserProperty('password');
+        $this->showFirstUserProperty('email');
+    }
+
+    public function testGenericModelPropertyUnion(): void
+    {
+        $this->doSomethingWithTemplateUnion('id');
+        $this->doSomethingWithUnion('everything-should-be-allowed');
+    }
+
+    public function testTemplateUnionProperty(): void
+    {
+        $this->doSomethingWithTemplateUnion('id');
+        $this->doSomethingWithTemplateUnion('password');
+        $this->doSomethingWithTemplateUnion('active');
+    }
+
+    public function testTemplateIntersectionProperty(): void
+    {
+        $this->doSomethingWithTemplateIntersection('id');
+        $this->doSomethingWithTemplateUnion('password');
+    }
+
+    public function testTemplateSelf(): void
+    {
+        (new User)->printPropertySelf('id');
+    }
+
+    public function testTemplateStatic(): void
+    {
+        (new User)->printPropertyStatic('id');
+    }
+
+    public function testTemplateMixed(): void
+    {
+        $this->doSomethingWithTemplateMixed('anything should be allowed');
+    }
+
+    /**
+     * @param model-property<mixed> $arg
+     * @return void
+     */
+    private function doSomethingWithTemplateMixed($arg)
+    {
+    }
+
+    /**
+     * @param model-property<User|\App\Account> $arg
+     * @return void
+     */
+    private function doSomethingWithTemplateUnion($arg)
+    {
+    }
+
+    /**
+     * @param model-property<User&\App\Account> $arg
+     * @return void
+     */
+    private function doSomethingWithTemplateIntersection($arg)
+    {
+    }
+
+    /**
+     * @param string|model-property<User> $arg
+     * @return void
+     */
+    public function doSomethingWithUnion($arg): void
+    {
+
+    }
+
+    /**
+     * @phpstan-param model-property<\App\User> $property
+     * @param string $property
+     * @return void
+     */
+    private function showFirstUserProperty(string $property): void
+    {
+        echo User::query()->firstOrFail()[$property];
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

## Introduction

Laravel has a lot of methods that have string parameters that represent a property of a Model class. For example, the `where()` method on a query builder could receive a model property string as its first parameter:
```php
// Here, we expect 'username' to be a property on the User model.
User::where('username', 'test')->get();
``` 

Similarly, when creating a new User:
```php
User::create([
   'name' => 'Test',
   'email' => 'test@tester.com',
]);
```
we're expected both `name` and `email` to be a property on the User class.


This pull request attempts to provide a proof of concept for easily verifying that these strings actually exists as a property on a model by introducing a new type: `model-property`.

## How does it work?

The `model-property` type is a generic type whose argument can be a subclass of `\Illuminate\Database\Eloquent\Model`. For example, the type `model-property<User>` only accepts strings that are properties on the User class. 

The property uses the `ModelPropertyExtension` under the hood, so this type is very dependent on Larastan being able to analyze the migrations. I've currently disabled the type by default. It will just be seen as a string. To enable it, you have to set `checkModelProperties: true` in your configuration file.

## Caveats

In the case of Builders methods, the current implementation can give false positives. E.g. the following examples are perfectly valid but are seen as invalid:
```php
User::selectRaw('id as newid')->pluck('newid')
User::get('users.id')
```

I could remove the typehint from all Builder `where` methods and only put them on `update()`, `create()` and, for example, on model properties such as `$fillable` and `$hidden`.


The errors are not clear at all. If a property does not exist on your model the following error will be printed:
```
Parameter #1 $property of method TestClass::test() expects model-property<App\\User>, string given.
```
which most users probably won't understand unless they read through the documentation.

The current implementation is not entirely finished yet, but before I put more time in it, I'd like to know whether this is something you'd consider adding to Larastan. If you like the idea, I could brush it up and add some more extensive testing. Any suggestions would also be appreciated.

If this is something you'd see the potential in, then I think a similar `model-relation` property would also be of great value. This could verify the strings passed to `whereHas()`, `with()`, `load()` and many more.