### PR TITLE
fix: use reflection to get table name in ModelPropertyExtension

### DIFF
--- a/tests/Application/app/GuardedModel.php
+++ b/tests/Application/app/GuardedModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GuardedModel extends Model
+{
+    protected $guarded = ['text'];
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        dd(debug_backtrace()[0]);
+        $attributes['name'] = $attributes['name'] ?? 'foo';
+
+        parent::__construct($attributes);
+    }
+}

--- a/tests/Application/database/migrations/2020_09_25_190200_create_guarded_models_table.php
+++ b/tests/Application/database/migrations/2020_09_25_190200_create_guarded_models_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateGuardedModelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guarded_models', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('text');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -6,6 +6,7 @@ namespace Tests\Features\Properties;
 
 use App\Account;
 use App\Group;
+use App\GuardedModel;
 use App\Role;
 use App\User;
 use Carbon\Carbon as BaseCarbon;
@@ -109,5 +110,10 @@ class ModelPropertyExtension
         $group->id = 5;
 
         return $group->save();
+    }
+
+    public function testModelWithGuardedProperties(GuardedModel $guardedModel): string
+    {
+        return $guardedModel->name;
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Fixes #656

**Changes**

Initiating a new model class in `ModelPropertyExtension` was causing some issues.

Now we use reflection to get an instance of the model. It should work the same way as before. With the added benefit of not calling the actual constructor.
