### PR TITLE
refactor: improve database migration scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Parameter type of the query builder's `where`, `orWhere` and `addArrayOfWheres` ([#651](https://github.com/nunomaduro/larastan/pull/651)).
 - Using Reflection to initiate a model in `ModelPropertyExtension` to avoid errors caused by using Model constructor. ([#666](https://github.com/nunomaduro/larastan/pull/666))
 
+### Changed
+- Made improvements to database migrations scanning. ([#670](https://github.com/nunomaduro/larastan/pull/670))
+
 ## [0.6.4] - 2020-09-02
 
 ### Changed

--- a/extension.neon
+++ b/extension.neon
@@ -41,11 +41,13 @@ parameters:
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
+    databaseMigrationsPath: null
 
 parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
+    databaseMigrationsPath: schema(anyOf(string()), nullable())
 
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
@@ -297,3 +299,6 @@ services:
 
     -
         class: NunoMaduro\Larastan\Types\RelationParserHelper
+
+    -
+        class: NunoMaduro\Larastan\Properties\MigrationHelper

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Properties;
+
+use Iterator;
+use PHPStan\Parser\CachedParser;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use SplFileInfo;
+
+class MigrationHelper
+{
+    /**  @var CachedParser */
+    private $parser;
+
+    /** @var ?string */
+    private $databaseMigrationPath;
+
+    public function __construct(CachedParser $parser, ?string $databaseMigrationPath)
+    {
+        $this->parser = $parser;
+        $this->databaseMigrationPath = $databaseMigrationPath;
+    }
+
+    /**
+     * @return array<string, SchemaTable>
+     */
+    public function initializeTables(): array
+    {
+        if ($this->databaseMigrationPath === null) {
+            $this->databaseMigrationPath = database_path() . '/migrations';
+        }
+
+        if (! is_dir($this->databaseMigrationPath)) {
+            return [];
+        }
+
+        $schemaAggregator = new SchemaAggregator();
+        $files = $this->getMigrationFiles($this->databaseMigrationPath);
+        $filesArray = iterator_to_array($files);
+        ksort($filesArray);
+
+        $this->requireFiles($filesArray);
+
+        foreach ($filesArray as $file) {
+            $schemaAggregator->addStatements($this->parser->parseFile($file->getPathname()));
+        }
+
+        return $schemaAggregator->tables;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return Iterator<SplFileInfo>
+     */
+    private function getMigrationFiles(string $path): Iterator
+    {
+        return new RegexIterator(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path)), '/\.php$/i');
+    }
+
+    /**
+     * @param SplFileInfo[] $files
+     */
+    private function requireFiles(array $files): void
+    {
+        foreach ($files as $file) {
+            require_once $file;
+        }
+    }
+}

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use NunoMaduro\Larastan\Properties\MigrationHelper;
+use NunoMaduro\Larastan\Properties\SchemaTable;
+use PHPStan\Parser\CachedParser;
+use PHPStan\Testing\TestCase;
+
+class MigrationHelperTest extends TestCase
+{
+    /** @var CachedParser */
+    private $cachedParser;
+
+    public function setUp(): void
+    {
+        $this->cachedParser = self::getContainer()->getByType(CachedParser::class);
+    }
+
+    /** @test */
+    function it_will_return_empty_array_if_migrations_path_is_not_a_directory()
+    {
+        $migrationHelper = new MigrationHelper($this->cachedParser, 'foobar');
+
+        self::assertSame([], $migrationHelper->initializeTables());
+    }
+
+    /** @test */
+    function it_can_read_basic_migrations_and_create_table_structure()
+    {
+        $migrationHelper = new MigrationHelper($this->cachedParser, __DIR__ . '/data/basic_migration');
+
+        $tables = $migrationHelper->initializeTables();
+
+        $this->assertUsersTableSchema($tables);
+    }
+
+    /** @test */
+    function it_can_read_schema_definitions_from_any_method_in_class()
+    {
+        $migrationHelper = new MigrationHelper($this->cachedParser, __DIR__ . '/data/migrations_with_different_methods');
+
+        $tables = $migrationHelper->initializeTables();
+
+        $this->assertUsersTableSchema($tables);
+    }
+
+    /** @test */
+    function it_can_read_schema_definitions_with_multiple_create_and_drop_methods_for_one_table()
+    {
+        $migrationHelper = new MigrationHelper($this->cachedParser, __DIR__ . '/data/complex_migrations');
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(6, $tables['users']->columns);
+        self::assertSame(['id', 'email', 'birthday', 'created_at', 'updated_at', 'active'], array_keys($tables['users']->columns));
+        self::assertSame('int', $tables['users']->columns['id']->readableType);
+        self::assertSame('string', $tables['users']->columns['email']->readableType);
+        self::assertSame('string', $tables['users']->columns['birthday']->readableType);
+        self::assertSame('string', $tables['users']->columns['created_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
+        self::assertSame('int', $tables['users']->columns['active']->readableType);
+    }
+
+    /**
+     * @param array<string, SchemaTable> $tables
+     */
+    private function assertUsersTableSchema(array $tables): void
+    {
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(5, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+        self::assertSame('int', $tables['users']->columns['id']->readableType);
+        self::assertSame('string', $tables['users']->columns['name']->readableType);
+        self::assertSame('string', $tables['users']->columns['email']->readableType);
+        self::assertSame('string', $tables['users']->columns['created_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
+    }
+}

--- a/tests/Unit/data/basic_migration/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/basic_migration/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Unit/data/complex_migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/complex_migrations/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\ComplexMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Unit/data/complex_migrations/2020_01_31_000000_alter_users_table.php
+++ b/tests/Unit/data/complex_migrations/2020_01_31_000000_alter_users_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\ComplexMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Do Some stuff, create temp tables
+        Schema::drop('users');
+
+        // Do more stuff
+
+        $this->createTable();
+
+        // Stuff
+
+        $this->alterTable();
+    }
+
+    private function createTable(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->date('birthday');
+            $table->timestamps();
+        });
+    }
+
+    private function alterTable(): void
+    {
+        Schema::table('users', static function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->integer('active');
+        });
+    }
+}

--- a/tests/Unit/data/migrations_with_different_methods/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migrations_with_different_methods/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->createUsersTable();
+    }
+
+    public function down(): void
+    {
+        Schema::drop('users');
+    }
+
+    private function createUsersTable(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

This PR improves database migration scanning by checking not just the `up` method but also other methods for `Schema` calls. Also resolves #507 
