### PR TITLE
Property check

### DIFF
--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -30,3 +30,11 @@ If the string is not an existing blade view, the following error will be display
 ```
 Parameter #1 $view of method TestClass::renderView() expects view-string, string given.  
 ```
+
+## model-property
+`model-property` extends the built-in `string` type and acts like a string in the type level. But during the analysis if Larastan finds that an argument of the method or a function has a `model-property<ModelName>`, it'll try to check that the given argument value is actually a property of the model.
+
+All of the Laravel core methods have this type thanks to the stubs. So whenever you use a Eloquent builder, relation or a model method that expects a column, it'll be checked by Larastan if the column actually exists. But you can also typehint any argument with `model-property` in your code.
+
+The actual check is done by the `ModelPropertyRule`. You can read the details [here](rules.md#ModelPropertyRule).
+

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -54,3 +54,49 @@ parameters:
     noUnnecessaryCollectionCallExcept: ['contains']
 ```
 
+## ModelPropertyRule
+
+This rule checks every argument of a method or a function, and if the argument has the type `model-property`, it will try to check the given value against the model properties. And if the model does not have the given property, it'll produce an error.
+
+### Basic example
+
+```php
+User::create([
+    'name' => 'John Doe',
+    'emaiil' => 'john@example.test'
+]);
+```
+
+Here we have a typo in `email` column. So if we run analysis on this file Larastan will generate the following error:
+
+```
+Property 'emaiil' does not exist in App\User model.
+```
+
+This check will be done automatically on Laravel's core methods where a property is expected. But you can also typehint the `model-property` in your own code to take advantage of this analysis.
+
+You can define a function like this:
+```php
+/**
+ * @phpstan-param model-property<\App\User> $property
+ */
+function takesOnlyUserModelProperties(string $property)
+{
+    // ...
+}
+```
+
+And if you call the function above with a property that does not exist in User model, Larastan will warn you about it.
+
+```php
+// Property 'emaiil' does not exist in App\User model.
+takesOnlyUserModelProperties('emaiil');
+```
+
+### Configuration
+This rule is disabled by default. You can enable it by putting
+```
+parameters:
+    checkModelProperties: true
+```
+to your `phpstan.neon` file.

--- a/extension.neon
+++ b/extension.neon
@@ -42,16 +42,22 @@ parameters:
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
     databaseMigrationsPath: null
+    checkModelProperties: false
 
 parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
     databaseMigrationsPath: schema(anyOf(string()), nullable())
+    checkModelProperties: bool()
 
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
+    NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyRule:
+        phpstan.rules.rule: %checkModelProperties%
+    NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyStaticCallRule:
+        phpstan.rules.rule: %checkModelProperties%
 
 services:
     -
@@ -293,9 +299,26 @@ services:
             excludeMethods: %noUnnecessaryCollectionCallExcept%
 
     -
+        class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyRule
+        tags:
+            - phpstan.rules.rule
+
+    -
+        class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyStaticCallRule
+        tags:
+            - phpstan.rules.rule
+
+    -
         class: NunoMaduro\Larastan\Types\GenericEloquentBuilderTypeNodeResolverExtension
         tags:
             - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
+        class: NunoMaduro\Larastan\Types\ModelProperty\ModelPropertyTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension
+        arguments:
+            active: %checkModelProperties%
 
     -
         class: NunoMaduro\Larastan\Types\RelationParserHelper
@@ -305,3 +328,7 @@ services:
         arguments:
             databaseMigrationPath: %databaseMigrationsPath%
             currentWorkingDirectory: %currentWorkingDirectory%
+
+    -
+        class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertiesRuleHelper
+

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -81,7 +81,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             }
 
             return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
+                $methodName, $classReflection, $methodReflection,
                 $parametersAcceptor->getParameters(),
                 $returnType,
                 $parametersAcceptor->isVariadic()
@@ -109,7 +109,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
 
             return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
+                $methodName, $classReflection, $methodReflection,
                 $parametersAcceptor->getParameters(),
                 new GenericObjectType($builderClass, [$modelType]),
                 $parametersAcceptor->isVariadic()

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -58,7 +58,7 @@ final class SchemaAggregator
                 && $stmt->expr instanceof PhpParser\Node\Expr\StaticCall
                 && ($stmt->expr->class instanceof PhpParser\Node\Name)
                 && $stmt->expr->name instanceof PhpParser\Node\Identifier
-                && ($stmt->expr->class->toCodeString() === '\\Illuminate\Support\Facades\Schema' || $stmt->expr->class->toCodeString() === '\Schema')
+                && ($stmt->expr->class->toCodeString() === '\Illuminate\Support\Facades\Schema' || $stmt->expr->class->toCodeString() === '\Schema')
             ) {
                 switch ($stmt->expr->name->name) {
                     case 'create':

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -27,6 +27,9 @@ final class EloquentBuilderMethodReflection implements MethodReflection
      */
     private $classReflection;
 
+    /** @var MethodReflection */
+    private $originalMethodReflection;
+
     /**
      * @var ParameterReflection[]
      */
@@ -45,14 +48,16 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     /**
      * @param string                $methodName
      * @param ClassReflection       $classReflection
+     * @param MethodReflection      $originalMethodReflection
      * @param ParameterReflection[] $parameters
      * @param Type|null             $returnType
      * @param bool                  $isVariadic
      */
-    public function __construct(string $methodName, ClassReflection $classReflection, array $parameters, ?Type $returnType = null, bool $isVariadic = false)
+    public function __construct(string $methodName, ClassReflection $classReflection, MethodReflection $originalMethodReflection, array $parameters, ?Type $returnType = null, bool $isVariadic = false)
     {
         $this->methodName = $methodName;
         $this->classReflection = $classReflection;
+        $this->originalMethodReflection = $originalMethodReflection;
         $this->parameters = $parameters;
         $this->returnType = $returnType ?? new ObjectType(Builder::class);
         $this->isVariadic = $isVariadic;
@@ -137,5 +142,13 @@ final class EloquentBuilderMethodReflection implements MethodReflection
     public function hasSideEffects(): TrinaryLogic
     {
         return TrinaryLogic::createMaybe();
+    }
+
+    /**
+     * @return MethodReflection
+     */
+    public function getOriginalMethodReflection(): MethodReflection
+    {
+        return $this->originalMethodReflection;
     }
 }

--- a/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
+++ b/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules\ModelProperties;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use NunoMaduro\Larastan\Properties\ModelAccessorExtension;
+use NunoMaduro\Larastan\Properties\ModelPropertyExtension;
+use NunoMaduro\Larastan\Types\ModelProperty\GenericModelPropertyType;
+use NunoMaduro\Larastan\Types\ModelProperty\ModelPropertyType;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Type\UnionType;
+
+class ModelPropertiesRuleHelper
+{
+    /** @var ModelPropertyExtension */
+    private $modelPropertyExtension;
+
+    /** @var AnnotationsPropertiesClassReflectionExtension */
+    private $annotationExtension;
+
+    /** @var ModelAccessorExtension */
+    private $modelAccessorExtension;
+
+    public function __construct(ModelPropertyExtension $modelPropertyExtension, ModelAccessorExtension $modelAccessorExtension, AnnotationsPropertiesClassReflectionExtension $annotationExtension)
+    {
+        $this->modelPropertyExtension = $modelPropertyExtension;
+        $this->modelAccessorExtension = $modelAccessorExtension;
+        $this->annotationExtension = $annotationExtension;
+    }
+
+    /**
+     * @param MethodReflection $methodReflection
+     * @param Scope            $scope
+     * @param Node\Arg[]       $args
+     * @param ClassReflection|null  $modelReflection
+     *
+     * @return string[]
+     */
+    public function check(MethodReflection $methodReflection, Scope $scope, array $args, ?ClassReflection $modelReflection = null): array
+    {
+        $modelPropertyParameter = $this->hasModelPropertyParameter($methodReflection, $scope, $args, $modelReflection);
+
+        if (count($modelPropertyParameter) !== 2) {
+            return [];
+        }
+
+        /** @var int $parameterIndex */
+        /** @var ObjectType $modelType */
+        [$parameterIndex, $modelType] = $modelPropertyParameter;
+
+        $modelReflection = $modelType->getClassReflection();
+
+        if ($modelReflection === null) {
+            return [];
+        }
+
+        if ($modelReflection->isAbstract()) {
+            return [];
+        }
+
+        if ($modelReflection->getName() === Model::class || ! $modelReflection->isSubclassOf(Model::class)) {
+            return [];
+        }
+
+        if (! array_key_exists($parameterIndex, $args)) {
+            return [];
+        }
+
+        $argValue = $args[$parameterIndex]->value;
+
+        if (! $argValue instanceof Node\Expr) {
+            return [];
+        }
+
+        $argType = $scope->getType($argValue);
+
+        if ($argType instanceof ConstantArrayType) {
+            $errors = [];
+
+            $keyType = TypeUtils::generalizeType($argType->getKeyType());
+
+            if ($keyType instanceof IntegerType) {
+                $valueTypes = $argType->getValuesArray()->getValueTypes();
+            } elseif ($keyType instanceof StringType) {
+                $valueTypes = $argType->getKeysArray()->getValueTypes();
+            } else {
+                $valueTypes = [];
+            }
+
+            foreach ($valueTypes as $valueType) {
+                // It could be something like `DB::raw`
+                // We only want to analyze strings
+                if (! $valueType instanceof ConstantStringType) {
+                    continue;
+                }
+
+                // TODO: maybe check table names and columns here. And for JSON access maybe just the column name
+                if (mb_strpos($valueType->getValue(), '.') !== false || mb_strpos($valueType->getValue(), '->') !== false) {
+                    continue;
+                }
+
+                if (! $this->hasProperty($modelReflection, $valueType->getValue())) {
+                    $error = sprintf('Property \'%s\' does not exist in %s model.', $valueType->getValue(), $modelReflection->getName());
+
+                    if ($methodReflection->getDeclaringClass()->getName() === BelongsToMany::class) {
+                        $error .= sprintf(" If '%s' exists as a column on the pivot table, consider using 'wherePivot' or prefix the column with table name instead.", $valueType->getValue());
+                    }
+
+                    $errors[] = $error;
+                }
+            }
+
+            return $errors;
+        }
+
+        if (! $argType instanceof ConstantStringType) {
+            return [];
+        }
+
+        // TODO: maybe check table names and columns here. And for JSON access maybe just the column name
+        if (mb_strpos($argType->getValue(), '.') !== false || mb_strpos($argType->getValue(), '->') !== false) {
+            return [];
+        }
+
+        if (! $this->hasProperty($modelReflection, $argType->getValue())) {
+            $error = sprintf('Property \'%s\' does not exist in %s model.', $argType->getValue(), $modelReflection->getName());
+
+            if ($methodReflection->getDeclaringClass()->getName() === BelongsToMany::class) {
+                $error .= sprintf(" If '%s' exists as a column on the pivot table, consider using 'wherePivot' or prefix the column with table name instead.", $argType->getValue());
+            }
+
+            return [$error];
+        }
+
+        return [];
+    }
+
+    public function hasProperty(ClassReflection $modelReflection, string $propertyName): bool
+    {
+        // First check the annotations. This is also how our own ModelProperties extension works
+        if ($this->annotationExtension->hasProperty($modelReflection, $propertyName)) {
+            return true;
+        }
+
+        // Then check accessors.
+        if ($this->modelAccessorExtension->hasProperty($modelReflection, $propertyName)) {
+            return true;
+        }
+
+        return $this->modelPropertyExtension->hasProperty($modelReflection, $propertyName);
+    }
+
+    /**
+     * @param MethodReflection $methodReflection
+     * @param Scope            $scope
+     * @param Node\Arg[]       $args
+     * @param ClassReflection|null  $modelReflection
+     *
+     * @return array<int, int|Type>
+     */
+    public function hasModelPropertyParameter(
+        MethodReflection $methodReflection,
+        Scope $scope,
+        array $args,
+        ?ClassReflection $modelReflection = null
+    ): array {
+        /** @var ParameterReflection[] $parameters */
+        $parameters = ParametersAcceptorSelector::selectFromArgs($scope, $args, $methodReflection->getVariants())->getParameters();
+
+        foreach ($parameters as $index => $parameter) {
+            $type = $parameter->getType();
+
+            if ($type instanceof UnionType) {
+                foreach ($type->getTypes() as $innerType) {
+                    if ($innerType instanceof GenericModelPropertyType) {
+                        return [$index, $innerType->getGenericType()];
+                    }
+
+                    if ($innerType instanceof ModelPropertyType && $modelReflection !== null) {
+                        return [$index, new ObjectType($modelReflection->getName())];
+                    }
+                }
+            } elseif ($type instanceof ArrayType) {
+                $keyType = $type->getKeyType();
+                $itemType = $type->getItemType();
+
+                if ($keyType instanceof GenericModelPropertyType) {
+                    return [$index, $keyType->getGenericType()];
+                }
+
+                if ($itemType instanceof GenericModelPropertyType) {
+                    return [$index, $itemType->getGenericType()];
+                }
+
+                if ($modelReflection !== null && (($keyType instanceof ModelPropertyType) || ($itemType instanceof ModelPropertyType))) {
+                    return [$index, new ObjectType($modelReflection->getName())];
+                }
+            } else {
+                if ($type instanceof GenericModelPropertyType) {
+                    return [$index, $type->getGenericType()];
+                }
+
+                if ($modelReflection !== null && $type instanceof ModelPropertyType) {
+                    return [$index, new ObjectType($modelReflection->getName())];
+                }
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Rules/ModelProperties/ModelPropertyRule.php
+++ b/src/Rules/ModelProperties/ModelPropertyRule.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules\ModelProperties;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ */
+class ModelPropertyRule implements Rule
+{
+    /** @var ModelPropertiesRuleHelper */
+    private $modelPropertiesRuleHelper;
+    /**
+     * @var RuleLevelHelper
+     */
+    private $ruleLevelHelper;
+
+    public function __construct(ModelPropertiesRuleHelper $ruleHelper, RuleLevelHelper $ruleLevelHelper)
+    {
+        $this->modelPropertiesRuleHelper = $ruleHelper;
+        $this->ruleLevelHelper = $ruleLevelHelper;
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @param Scope $scope
+     *
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (count($node->args) === 0) {
+            return [];
+        }
+
+        $name = $node->name->name;
+        $typeResult = $this->ruleLevelHelper->findTypeToCheck(
+            $scope,
+            $node->var,
+            '',
+            static function (Type $type) use ($name): bool {
+                return $type->canCallMethods()->yes() && $type->hasMethod($name)->yes();
+            }
+        );
+
+        $type = $typeResult->getType();
+
+        if ($type instanceof ErrorType) {
+            return [];
+        }
+
+        if (! $type->hasMethod($name)->yes()) {
+            return [];
+        }
+
+        $modelReflection = $this->findModelReflectionFromType($type);
+
+        $methodReflection = $type->getMethod($name, $scope);
+
+        return $this->modelPropertiesRuleHelper->check($methodReflection, $scope, $node->args, $modelReflection);
+    }
+
+    private function findModelReflectionFromType(Type $type): ?ClassReflection
+    {
+        if ((new ObjectType(Builder::class))->isSuperTypeOf($type)->no() &&
+            (new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->no() &&
+            (new ObjectType(Relation::class))->isSuperTypeOf($type)->no() &&
+            (new ObjectType(Model::class))->isSuperTypeOf($type)->no()
+        ) {
+            return null;
+        }
+
+        // We expect it to be generic builder or relation class with model type inside
+        if ((! $type instanceof GenericObjectType) && (new ObjectType(Model::class))->isSuperTypeOf($type)->no()) {
+            return null;
+        }
+
+        if ($type instanceof GenericObjectType) {
+            $modelType = $type->getTypes()[0];
+        } else {
+            $modelType = $type;
+        }
+
+        $modelType = TypeCombinator::removeNull($modelType);
+
+        if (! $modelType instanceof ObjectType) {
+            return null;
+        }
+
+        if ($modelType->getClassName() === Model::class) {
+            return null;
+        }
+
+        $modelReflection = $modelType->getClassReflection();
+
+        if ($modelReflection === null) {
+            return null;
+        }
+
+        if ($modelReflection->isAbstract()) {
+            return null;
+        }
+
+        return $modelReflection;
+    }
+}

--- a/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
+++ b/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules\ModelProperties;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\StaticCall>
+ */
+class ModelPropertyStaticCallRule implements Rule
+{
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
+    /** @var ModelPropertiesRuleHelper */
+    private $modelPropertiesRuleHelper;
+
+    /** @var RuleLevelHelper */
+    private $ruleLevelHelper;
+
+    public function __construct(ReflectionProvider $reflectionProvider, ModelPropertiesRuleHelper $ruleHelper, RuleLevelHelper $ruleLevelHelper)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->modelPropertiesRuleHelper = $ruleHelper;
+        $this->ruleLevelHelper = $ruleLevelHelper;
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\StaticCall::class;
+    }
+
+    /**
+     * @param Node\Expr\StaticCall $node
+     * @param Scope                $scope
+     *
+     * @return string[]
+     * @throws \PHPStan\ShouldNotHappenException|\PHPStan\Reflection\MissingMethodFromReflectionException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (count($node->args) === 0) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+
+        $class = $node->class;
+
+        if ($class instanceof Node\Name) {
+            $className = (string) $class;
+            $lowercasedClassName = strtolower($className);
+
+            if (in_array($lowercasedClassName, ['self', 'static'], true)) {
+                if (! $scope->isInClass()) {
+                    return [];
+                }
+
+                $modelReflection = $scope->getClassReflection();
+            } elseif ($lowercasedClassName === 'parent') {
+                if (! $scope->isInClass()) {
+                    return [];
+                }
+
+                $currentClassReflection = $scope->getClassReflection();
+
+                if ($currentClassReflection === null) {
+                    return [];
+                }
+
+                if ($currentClassReflection->getParentClass() === false) {
+                    return [];
+                }
+
+                if ($scope->getFunctionName() === null) {
+                    throw new \PHPStan\ShouldNotHappenException();
+                }
+
+                $modelReflection = $currentClassReflection->getParentClass();
+            } else {
+                if (! $this->reflectionProvider->hasClass($className)) {
+                    return [];
+                }
+
+                $modelReflection = $this->reflectionProvider->getClass($className);
+            }
+        } else {
+            $classTypeResult = $this->ruleLevelHelper->findTypeToCheck(
+                $scope,
+                $class,
+                '',
+                static function (Type $type) use ($methodName): bool {
+                    return $type->canCallMethods()->yes() && $type->hasMethod($methodName)->yes();
+                }
+            );
+
+            $classType = $classTypeResult->getType();
+
+            if ($classType instanceof ErrorType) {
+                return [];
+            }
+
+            if ($classType instanceof ConstantStringType) {
+                $modelClassName = $classType->getValue();
+            } elseif ($classType instanceof ObjectType) {
+                $modelClassName = $classType->getClassName();
+            } else {
+                return [];
+            }
+
+            $modelReflection = $this->reflectionProvider->getClass($modelClassName);
+        }
+
+        if ($modelReflection === null) {
+            return [];
+        }
+
+        if (! $modelReflection->isSubclassOf(Model::class)) {
+            return [];
+        }
+
+        if (! $modelReflection->hasMethod($methodName)) {
+            return [];
+        }
+
+        $methodReflection = $modelReflection->getMethod($methodName, $scope);
+
+        if ($methodReflection instanceof EloquentBuilderMethodReflection) {
+            $methodReflection = $methodReflection->getOriginalMethodReflection();
+        }
+
+        $className = $methodReflection->getDeclaringClass()->getName();
+
+        if ($className !== Builder::class &&
+            $className !== EloquentBuilder::class &&
+            $className !== Relation::class &&
+            $className !== Model::class
+        ) {
+            return [];
+        }
+
+        return $this->modelPropertiesRuleHelper->check($methodReflection, $scope, $node->args, $modelReflection);
+    }
+}

--- a/src/Types/ModelProperty/GenericModelPropertyType.php
+++ b/src/Types/ModelProperty/GenericModelPropertyType.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types\ModelProperty;
+
+use PHPStan\Type\ClassStringType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+
+class GenericModelPropertyType extends ModelPropertyType
+{
+    /** @var Type */
+    private $type;
+
+    public function __construct(Type $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getReferencedClasses(): array
+    {
+        return $this->getGenericType()->getReferencedClasses();
+    }
+
+    public function getGenericType(): Type
+    {
+        return $this->type;
+    }
+
+    public function traverse(callable $cb): Type
+    {
+        $newType = $cb($this->getGenericType());
+
+        if ($newType === $this->getGenericType()) {
+            return $this;
+        }
+
+        return new self($newType);
+    }
+
+    public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+    {
+        if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+            return $receivedType->inferTemplateTypesOn($this);
+        }
+
+        if ($receivedType instanceof ConstantStringType) {
+            $typeToInfer = new ObjectType($receivedType->getValue());
+        } elseif ($receivedType instanceof self) {
+            $typeToInfer = $receivedType->type;
+        } elseif ($receivedType instanceof ClassStringType) {
+            $typeToInfer = $this->getGenericType();
+
+            if ($typeToInfer instanceof TemplateType) {
+                $typeToInfer = $typeToInfer->getBound();
+            }
+
+            $typeToInfer = TypeCombinator::intersect($typeToInfer, new ObjectWithoutClassType());
+        } else {
+            return TemplateTypeMap::createEmpty();
+        }
+
+        if (! $this->getGenericType()->isSuperTypeOf($typeToInfer)->no()) {
+            return $this->getGenericType()->inferTemplateTypes($typeToInfer);
+        }
+
+        return TemplateTypeMap::createEmpty();
+    }
+
+    public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+    {
+        $variance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
+
+        return $this->getGenericType()->getReferencedTemplateTypes($variance);
+    }
+
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self($properties['type']);
+    }
+}

--- a/src/Types/ModelProperty/ModelPropertyType.php
+++ b/src/Types/ModelProperty/ModelPropertyType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types\ModelProperty;
+
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+class ModelPropertyType extends StringType
+{
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self();
+    }
+}

--- a/src/Types/ModelProperty/ModelPropertyTypeNodeResolverExtension.php
+++ b/src/Types/ModelProperty/ModelPropertyTypeNodeResolverExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types\ModelProperty;
+
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolver;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * Ensures a 'model-property' type in PHPDoc is recognised to be of type ModelPropertyType.
+ */
+class ModelPropertyTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    /** @var bool */
+    protected $active;
+
+    /** @var TypeNodeResolver */
+    protected $baseResolver;
+
+    public function __construct(TypeNodeResolver $baseResolver, bool $active)
+    {
+        $this->baseResolver = $baseResolver;
+        $this->active = $active;
+    }
+
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->name === 'model-property') {
+            return $this->active ? new ModelPropertyType() : new StringType();
+        }
+
+        if ($typeNode instanceof GenericTypeNode && $typeNode->type->name === 'model-property') {
+            if (! $this->active) {
+                return new StringType();
+            }
+
+            if (count($typeNode->genericTypes) !== 1) {
+                return new ErrorType();
+            }
+
+            $genericType = $this->baseResolver->resolve($typeNode->genericTypes[0], $nameScope);
+
+            if ((new ObjectType(Model::class))->isSuperTypeOf($genericType)->no()) {
+                return new ErrorType();
+            }
+
+            if ($genericType instanceof NeverType) {
+                return new ErrorType();
+            }
+
+            return new GenericModelPropertyType($genericType);
+        }
+
+        return null;
+    }
+}

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -11,7 +11,7 @@ class Builder
     public function getModel();
 
     /**
-     * @param array<string, mixed> $attributes
+     * @phpstan-param array<model-property<TModelClass>, mixed> $attributes
      * @phpstan-return TModelClass
      */
     public function create(array $attributes = []);
@@ -37,7 +37,7 @@ class Builder
      * Find a model by its primary key.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<TModelClass>|null
      */
     public function find($id, $columns = ['*']);
@@ -46,7 +46,7 @@ class Builder
      * Find multiple models by their primary keys.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array<mixed>  $ids
-     * @param  array<mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return \Illuminate\Database\Eloquent\Collection<TModelClass>
      */
     public function findMany($ids, $columns = ['*']);
@@ -55,7 +55,7 @@ class Builder
      * Find a model by its primary key or throw an exception.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<TModelClass>
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
@@ -66,7 +66,7 @@ class Builder
      * Find a model by its primary key or return fresh model instance.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass
      */
     public function findOrNew($id, $columns = ['*']);
@@ -74,8 +74,8 @@ class Builder
     /**
      * Get the first record matching the attributes or instantiate it.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function firstOrNew(array $attributes = [], array $values = []);
@@ -83,8 +83,8 @@ class Builder
     /**
      * Get the first record matching the attributes or create it.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function firstOrCreate(array $attributes, array $values = []);
@@ -92,16 +92,28 @@ class Builder
     /**
      * Create or update a record matching the attributes, and fill it with values.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @param  array<model-property<TModelClass>, mixed>  $values
      * @phpstan-return TModelClass
      */
     public function updateOrCreate(array $attributes, array $values = []);
 
     /**
+     * @param  array<model-property<TModelClass>, mixed>  $attributes
+     * @return \Illuminate\Database\Eloquent\Model|$this
+     */
+    public function forceCreate(array $attributes);
+
+   /**
+     * @param  array<model-property<TModelClass>, mixed>  $values
+     * @return int
+     */
+    public function update(array $values);
+
+    /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array<int, string>  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
@@ -111,16 +123,27 @@ class Builder
     /**
      * Execute the query and get the first result or call a callback.
      *
-     * @param  \Closure|array<int, string>  $columns
+     * @param  \Closure|array<int, (model-property<TModelClass>|'*')>  $columns
      * @param  \Closure|null  $callback
      * @phpstan-return TModelClass|mixed
      */
     public function firstOr($columns = ['*'], \Closure $callback = null);
 
     /**
+     * Add a basic where clause to the query.
+     *
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function where($column, $operator = null, $value = null, $boolean = 'and');
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array<string, string>  $column
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -131,7 +154,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array<int, string>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return \Illuminate\Database\Eloquent\Collection<TModelClass>
      */
     public function get($columns = ['*']);
@@ -139,7 +162,7 @@ class Builder
     /**
      * Get the hydrated models without eager loading.
      *
-     * @param  array<int, string>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass[]
      */
     public function getModels($columns = ['*']);

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -9,7 +9,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 abstract class HasOneOrMany extends Relation
 {
     /**
-     * @param array<string, mixed> $attributes
+     * @param array<model-property<TRelatedModel>, mixed> $attributes
      * @phpstan-return TRelatedModel
      */
     public function make(array $attributes = []);
@@ -26,7 +26,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get the first related model record matching the attributes or instantiate it.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<mixed, mixed>  $values
      * @return TRelatedModel
      */
@@ -35,7 +35,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get the first related record matching the attributes or create it.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<mixed, mixed>  $values
      * @return TRelatedModel
      */
@@ -44,7 +44,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<mixed, mixed>  $values
      * @return TRelatedModel
      */
@@ -59,7 +59,7 @@ abstract class HasOneOrMany extends Relation
     public function save(\Illuminate\Database\Eloquent\Model $model);
 
     /**
-     * @param array<string, mixed> $attributes
+     * @param array<model-property<TRelatedModel>, mixed> $attributes
      *
      * @phpstan-return TRelatedModel
      */

--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -7,6 +7,15 @@ namespace Illuminate\Database\Eloquent;
  */
 abstract class Model implements \JsonSerializable, \ArrayAccess
 {
+    /**
+     * Update the model in the database.
+     *
+     * @param  array<model-property, mixed>  $attributes
+     * @param  array<int|string, mixed>  $options
+     * @return bool
+     */
+    public function update(array $attributes = [], array $options = []);
+
 }
 
 class ModelNotFoundException extends \RuntimeException {}

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -306,7 +306,7 @@ class Builder
     /**
      * Add a "where" clause comparing two columns to the query.
      *
-     * @param  string|array<mixed>  $first
+     * @param  model-property|array<model-property|int, mixed>  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string|null  $boolean

--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -5,6 +5,9 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property string $name
+ */
 class Group extends Model
 {
     public function accounts(): HasMany

--- a/tests/Application/app/Post.php
+++ b/tests/Application/app/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Post extends Model
+{
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -103,6 +103,11 @@ class User extends Authenticatable
         return $this->belongsTo(get_class($this));
     }
 
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Post::class);
+    }
+
     public function hasManySyncable($related, $foreignKey = null, $localKey = null): HasManySyncable
     {
         $instance = $this->newRelatedInstance($related);

--- a/tests/Application/database/migrations/2020_03_20_000000_create_accounts_table.php
+++ b/tests/Application/database/migrations/2020_03_20_000000_create_accounts_table.php
@@ -14,6 +14,7 @@ class CreateAccountsTable extends Migration
     {
         Schema::create('accounts', static function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('name');
             $table->string('active', 1);
             $table->timestamps();
         });

--- a/tests/Application/database/migrations/2020_10_04_000000_create_posts_table.php
+++ b/tests/Application/database/migrations/2020_10_04_000000_create_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('posts_users', static function (Blueprint $table) {
+            $table->string('user_id');
+            $table->string('post_id');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -43,8 +43,8 @@ class Builder
 
     public function testToBaseReturnsQueryBuilderAfterChain(): QueryBuilder
     {
-        return User::whereNull('foo')
-            ->orderBy('fooBar')
+        return User::whereNull('name')
+            ->orderBy('email')
             ->toBase();
     }
 

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -25,19 +25,19 @@ class ModelExtension
     public function testReturnThis(): Builder
     {
         $user = User::join('tickets.tickets', 'tickets.tickets.id', '=', 'tickets.sale_ticket.ticket_id')
-            ->where(['foo' => 'bar']);
+            ->where(['email' => 'bar']);
 
         return $user;
     }
 
     public function testWhere(): Builder
     {
-        return (new Thread)->where(['foo' => 'bar']);
+        return (new Thread)->where(['name' => 'bar']);
     }
 
     public function testStaticWhere(): Builder
     {
-        return Thread::where(['foo' => 'bar']);
+        return Thread::where(['name' => 'bar']);
     }
 
     public function testDynamicWhere(): Builder
@@ -192,16 +192,16 @@ class ModelExtension
     public function testFirstOrFailWithChain(): User
     {
         return User::with('foo')
-            ->where('foo', 'bar')
-            ->orWhere('bar', 'baz')
+            ->where('email', 'bar')
+            ->orWhere('name', 'baz')
             ->firstOrFail();
     }
 
     public function testFirstWithChain(): ?User
     {
         return User::with('foo')
-            ->where('foo', 'bar')
-            ->orWhere('bar', 'baz')
+            ->where('email', 'bar')
+            ->orWhere('name', 'baz')
             ->first();
     }
 
@@ -249,7 +249,7 @@ class ModelExtension
 
     public function testFirstWhereWithBuilder(): ?User
     {
-        return User::query()->where('foo', 'bar')->firstWhere(['email' => 'foo@bar.com']);
+        return User::query()->where('name', 'bar')->firstWhere(['email' => 'foo@bar.com']);
     }
 }
 
@@ -258,16 +258,19 @@ function foo(): string
     return 'foo';
 }
 
+/**
+ * @property string $name
+ */
 class Thread extends Model
 {
     public function scopeValid(Builder $query): Builder
     {
-        return $query->where('valid', true);
+        return $query->where('name', true);
     }
 
     public static function testFindOnStaticSelf(): ?Thread
     {
-        return self::query()->where('foo', 'bar')->first();
+        return self::query()->where('name', 'bar')->first();
     }
 
     public function getCustomPropertyAttribute(): string

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -19,7 +19,7 @@ class Relations
 {
     public function testRelationWhere(): HasMany
     {
-        return (new User())->accounts()->where('foo', 'bar');
+        return (new User())->accounts()->where('name', 'bar');
     }
 
     public function testRelationWhereIn(): HasMany
@@ -49,27 +49,27 @@ class Relations
 
     public function testFirstWithRelation(): ?Account
     {
-        return (new User())->accounts()->where('foo', 'bar')->first();
+        return (new User())->accounts()->where('name', 'bar')->first();
     }
 
     public function testIncrementOnRelation(User $user): int
     {
-        return $user->accounts()->increment('counter');
+        return $user->accounts()->increment('id');
     }
 
     public function testDecrementOnRelation(User $user): int
     {
-        return $user->accounts()->decrement('counter');
+        return $user->accounts()->decrement('id');
     }
 
     public function testIncrementWithAmountOnRelation(User $user): int
     {
-        return $user->accounts()->increment('counter', 5);
+        return $user->accounts()->increment('id', 5);
     }
 
     public function testDecrementWithAmountOnRelation(User $user): int
     {
-        return $user->accounts()->decrement('counter', 5);
+        return $user->accounts()->decrement('id', 5);
     }
 
     public function testPaginate(User $user): LengthAwarePaginator
@@ -79,7 +79,7 @@ class Relations
 
     public function testMorph(User $user): MorphTo
     {
-        return $user->addressable()->where('foo', 'bar');
+        return $user->addressable()->where('name', 'bar');
     }
 
     public function testModelScopesOnRelation(User $user): HasMany
@@ -164,12 +164,12 @@ class Relations
 
     public function testFirstWhereWithHasManyRelation(User $user): ?Account
     {
-        return $user->accounts()->firstWhere('foo', 'bar');
+        return $user->accounts()->firstWhere('name', 'bar');
     }
 
     public function testFirstWhereWithBelongsToRelation(User $user): ?Group
     {
-        return $user->group()->firstWhere('foo', 'bar');
+        return $user->group()->firstWhere('name', 'bar');
     }
 }
 

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -27,21 +27,21 @@ class Scopes extends Model
 
     public function testScopeAfterQueryBuilderStaticCall(): Builder
     {
-        return User::where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->active();
+        return User::where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active();
     }
 
     public function testScopeAfterQueryBuilderVariableCall(): Builder
     {
         $this->user = new User;
 
-        return $this->user->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->where('foo', 'bar')->active();
+        return $this->user->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active();
     }
 
     public function testScopeWithFirst(): ?User
     {
         $this->user = new User;
 
-        return $this->user->where('foo', 'bar')->active()->first();
+        return $this->user->where('name', 'bar')->active()->first();
     }
 
     public function testVoidScopeStillReturnsBuilder(): Builder

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -36,8 +36,8 @@ class BuilderExtension
     public function testCallingLongGetChainOnModelWithStaticQueryBuilder(): Collection
     {
         return User::where('id', 1)
-            ->whereNotNull('active')
-            ->where('foo', 'bar')
+            ->whereNotNull('name')
+            ->where('email', 'bar')
             ->whereFoo(['bar'])
             ->get();
     }
@@ -45,8 +45,8 @@ class BuilderExtension
     /** @return Collection<User> */
     public function testCallingLongGetChainOnModelWithVariableQueryBuilder(): Collection
     {
-        return (new User)->whereNotNull('active')
-            ->where('foo', 'bar')
+        return (new User)->whereNotNull('name')
+            ->where('email', 'bar')
             ->whereFoo(['bar'])
             ->get();
     }
@@ -56,7 +56,7 @@ class BuilderExtension
     {
         $user = new User;
 
-        return $user->where('test', 1)->get();
+        return $user->where('email', 1)->get();
     }
 
     /** @return Collection<User> */
@@ -76,14 +76,14 @@ class BuilderExtension
     {
         $user = new User;
 
-        return (int) $user->where('test', 1)->max('foo');
+        return (int) $user->where('email', 1)->max('email');
     }
 
     public function testExists(): bool
     {
         $user = new User;
 
-        return $user->where('test', 1)->exists();
+        return $user->where('email', 1)->exists();
     }
 
     /**
@@ -91,7 +91,7 @@ class BuilderExtension
      */
     public function testWith(): Builder
     {
-        return User::with('foo')->whereNull('bar');
+        return User::with('email')->whereNull('name');
     }
 
     /**
@@ -99,14 +99,14 @@ class BuilderExtension
      */
     public function testWithWithBuilderMethods(): Builder
     {
-        return User::with('foo')
-            ->where('foo', 'bar')
-            ->orWhere('bar', 'baz');
+        return User::with('email')
+            ->where('email', 'bar')
+            ->orWhere('name', 'baz');
     }
 
     public function testFindWithInteger(): ?User
     {
-        return User::with(['foo'])->find(1);
+        return User::with(['email'])->find(1);
     }
 
     /**
@@ -114,12 +114,12 @@ class BuilderExtension
      */
     public function testFindWithArray()
     {
-        return User::with(['foo'])->find([1, 2, 3]);
+        return User::with(['email'])->find([1, 2, 3]);
     }
 
     public function testFindOrFailWithInteger(): User
     {
-        return User::with(['foo'])->findOrFail(1);
+        return User::with(['email'])->findOrFail(1);
     }
 
     /**
@@ -127,12 +127,12 @@ class BuilderExtension
      */
     public function testFindOrFailWithArray()
     {
-        return User::with(['foo'])->findOrFail([1, 2, 3]);
+        return User::with(['email'])->findOrFail([1, 2, 3]);
     }
 
     public function testFindOrNewWithInteger(): User
     {
-        return User::with(['foo'])->findOrNew(1);
+        return User::with(['email'])->findOrNew(1);
     }
 
     /**
@@ -140,7 +140,7 @@ class BuilderExtension
      */
     public function testFindWithCustom3rdPartyBuilder()
     {
-        return (new CustomBuilder(User::query()->getQuery()))->with('foo')->find(1);
+        return (new CustomBuilder(User::query()->getQuery()))->with('email')->find(1);
     }
 
     /**
@@ -148,7 +148,7 @@ class BuilderExtension
      */
     public function testFindOrNewWithArray()
     {
-        return User::with(['foo'])->findOrNew([1, 2, 3]);
+        return User::with(['email'])->findOrNew([1, 2, 3]);
     }
 
     /**
@@ -168,24 +168,27 @@ class BuilderExtension
     }
 }
 
+/**
+ * @property string $email
+ */
 class TestModel extends Model
 {
     /** @return Collection|TestModel[] */
     public function testCallingGetInsideModel(): Collection
     {
-        return $this->where('test', 1)->get();
+        return $this->where('email', 1)->get();
     }
 
     /** @phpstan-return Builder<TestModel> */
     public function testStaticQuery(): Builder
     {
-        return static::query()->where('foo', 'bar');
+        return static::query()->where('email', 'bar');
     }
 
     /** @phpstan-return Builder<TestModel> */
     public function testQuery(): Builder
     {
-        return $this->where('foo', 'bar');
+        return $this->where('email', 'bar');
     }
 }
 

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -13,13 +13,13 @@ class CustomEloquentBuilderTest
 {
     public function testModelWithCustomBuilderReturnsCorrectModelAfterBuilderMethod(): ?ModelWithCustomBuilder
     {
-        return ModelWithCustomBuilder::where('foo', 'bar')->first();
+        return ModelWithCustomBuilder::where('email', 'bar')->first();
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testEloquentBuilderMethodReturnsCustomBuilder(): CustomEloquentBuilder
     {
-        return ModelWithCustomBuilder::with('foo')->where('foo', 'bar');
+        return ModelWithCustomBuilder::with('foo')->where('email', 'bar');
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
@@ -112,18 +112,23 @@ class FooModel extends Model
     }
 }
 
+/**
+ * @property string $email
+ * @property string $category
+ * @property string $type
+ */
 class ModelWithCustomBuilder extends Model
 {
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function scopeFoo(CustomEloquentBuilder $query, string $foo): CustomEloquentBuilder
     {
-        return $query->where(['foo' => $foo]);
+        return $query->where(['email' => $foo]);
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testCustomBuilderReturnType(): CustomEloquentBuilder
     {
-        return $this->where('foo', 'bar');
+        return $this->where('email', 'bar');
     }
 
     /**

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -96,7 +96,7 @@ class CorrectCollectionCalls
             ->withCount(['accounts' => function ($query) {
                 $query->where('id', '<>', 1);
             }])
-            ->pluck('accounts_count')
+            ->pluck('id')
             ->avg();
     }
 }

--- a/tests/Rules/Data/ModelPropertyStaticCallsInClass.php
+++ b/tests/Rules/Data/ModelPropertyStaticCallsInClass.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $name
+ */
+class ModelPropertyStaticCallsInClass extends Model
+{
+    public static function foo(): ModelPropertyStaticCallsInClass
+    {
+        return static::create([
+            'foo' => 'bar',
+            'name' => 'John Doe',
+        ]);
+    }
+
+    public function bar(): ModelPropertyStaticCallsInClass
+    {
+        return self::create([
+            'foo' => 'bar',
+            'name' => 'John Doe',
+        ]);
+    }
+}

--- a/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
@@ -47,7 +47,7 @@ class UnnecessaryCollectionCallsEloquent
 
     public function testVarWrong(): bool
     {
-        $query = User::query()->limit(3)->where('status', 'active');
+        $query = User::query()->limit(3)->where('email', 'foo@bar.com');
 
         return $query->get()->isEmpty();
     }

--- a/tests/Rules/Data/User.php
+++ b/tests/Rules/Data/User.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelPropertyCustomMethods extends Model
+{
+    /**
+     * @phpstan-param model-property<\App\User> $property
+     * @param string $property
+     */
+    public function foo(string $property): void
+    {
+        // Do something with property
+    }
+
+    public function bar(): void
+    {
+        $this->foo('email'); // 'email' exists on \App\User
+        $this->foo('foo'); // 'foo' does not exist on \App\User
+    }
+}
+
+class ModelPropertyCustomMethodsInNormalClass
+{
+    /**
+     * @phpstan-param model-property<\App\User> $property
+     * @param string $property
+     */
+    public function foo(string $property): void
+    {
+        // Do something with property
+    }
+
+    public function bar(): void
+    {
+        $this->foo('email'); // 'email' exists on \App\User
+        $this->foo('foo'); // 'foo' does not exist on \App\User
+    }
+}

--- a/tests/Rules/Data/model-property-builder.php
+++ b/tests/Rules/Data/model-property-builder.php
@@ -1,0 +1,33 @@
+<?php
+
+\App\User::query()->firstWhere('foo', 'bar');
+\App\User::query()->where('foo', 'bar')->get();
+
+function foo(\App\User $user): \Illuminate\Database\Eloquent\Builder
+{
+    return $user->where('foo', 'bar');
+}
+
+/**
+ * @param \Illuminate\Database\Eloquent\Builder<\App\User> $builder
+ *
+ * @return \Illuminate\Database\Eloquent\Builder<\App\User>
+ */
+function bar(\Illuminate\Database\Eloquent\Builder $builder): \Illuminate\Database\Eloquent\Builder
+{
+    return $builder->where('foo', 'bar');
+}
+
+\App\User::query()->firstWhere(\Illuminate\Support\Facades\DB::raw('name LIKE \'%john%\''));
+
+\App\User::query()->whereColumn('foo', '=', 'foo');
+\App\User::query()->where(getKey(), '=', 'foo');
+
+function getKey(): string
+{
+    if (random_int(0, 1)) {
+        return 'foo';
+    }
+
+    return 'bar';
+}

--- a/tests/Rules/Data/model-property-model.php
+++ b/tests/Rules/Data/model-property-model.php
@@ -1,0 +1,11 @@
+<?php
+
+class ModelPropertyOnModel extends \Illuminate\Database\Eloquent\Model
+{
+    public function foo(): void
+    {
+        $this->update([
+            'foo' => 'bar',
+        ]);
+    }
+}

--- a/tests/Rules/Data/model-property-relation.php
+++ b/tests/Rules/Data/model-property-relation.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \App\User $user */
+$user = \App\User::findOrFail(1);
+
+$user->accounts()->where('foo', 'bar');
+$user->accounts()->create(['foo' => 'bar']);
+$user->accounts()->firstOrNew(['foo' => 'bar']);
+$user->accounts()->firstOrCreate(['foo' => 'bar']);
+$user->accounts()->updateOrCreate(['foo' => 'bar']);
+
+$user->posts()->where('foo', 'bar');

--- a/tests/Rules/Data/model-property-static-call.php
+++ b/tests/Rules/Data/model-property-static-call.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+$foo = \App\User::class;
+
+$foo::create([
+    'foo' => 'bar',
+]);
+
+function foo(\App\User $foo): \App\User
+{
+    return $foo::create([
+        'foo' => 'bar',
+    ]);
+}
+
+\App\User::create([
+    'foo' => 'bar',
+]);

--- a/tests/Rules/Data/modelPropertyConfig.neon
+++ b/tests/Rules/Data/modelPropertyConfig.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    checkModelProperties: true

--- a/tests/Rules/ModelPropertyRuleTest.php
+++ b/tests/Rules/ModelPropertyRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Tests\RulesTest;
+
+class ModelPropertyRuleTest extends RulesTest
+{
+    public function testModelPropertyRuleOnBuilder(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/model-property-builder.php');
+
+        self::assertEquals([
+            3 => 'Property \'foo\' does not exist in App\\User model.',
+            4 => 'Property \'foo\' does not exist in App\\User model.',
+            8 => 'Property \'foo\' does not exist in App\\User model.',
+            18 => 'Property \'foo\' does not exist in App\\User model.',
+            23 => 'Property \'foo\' does not exist in App\\User model.',
+        ], $errors);
+    }
+
+    public function testModelPropertyRuleOnRelation(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/model-property-relation.php');
+
+        self::assertEquals([
+            6 => 'Property \'foo\' does not exist in App\\Account model.',
+            7 => 'Property \'foo\' does not exist in App\\Account model.',
+            8 => 'Property \'foo\' does not exist in App\\Account model.',
+            9 => 'Property \'foo\' does not exist in App\\Account model.',
+            10 => 'Property \'foo\' does not exist in App\\Account model.',
+            12 => 'Property \'foo\' does not exist in App\Post model. If \'foo\' exists as a column on the pivot table, consider using \'wherePivot\' or prefix the column with table name instead.',
+        ], $errors);
+    }
+
+    public function testModelPropertyRuleOnModel(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/model-property-model.php');
+
+        self::assertEquals([
+            7 => 'Property \'foo\' does not exist in ModelPropertyOnModel model.',
+        ], $errors);
+    }
+}

--- a/tests/Rules/ModelPropertyStaticCallRuleTest.php
+++ b/tests/Rules/ModelPropertyStaticCallRuleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Tests\RulesTest;
+
+class ModelPropertyStaticCallRuleTest extends RulesTest
+{
+    public function testModelPropertyRuleOnStaticCallsToModel(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/model-property-static-call.php');
+
+        self::assertEquals([
+            7 => 'Property \'foo\' does not exist in App\\User model.',
+            13 => 'Property \'foo\' does not exist in App\\User model.',
+            18 => 'Property \'foo\' does not exist in App\\User model.',
+        ], $errors);
+    }
+
+    public function testModelPropertyRuleOnStaticCallsInClass(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/ModelPropertyStaticCallsInClass.php');
+
+        self::assertEquals([
+            16 => 'Property \'foo\' does not exist in Tests\\Rules\\Data\\ModelPropertyStaticCallsInClass model.',
+            24 => 'Property \'foo\' does not exist in Tests\\Rules\\Data\\ModelPropertyStaticCallsInClass model.',
+        ], $errors);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,9 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
+    /** @var string */
+    private $configPath;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -19,20 +22,33 @@ class TestCase extends BaseTestCase
         File::copyDirectory(__DIR__.'/Application/database/migrations', $this->getBasePath().'/database/migrations');
         File::copyDirectory(__DIR__.'/Application/config', $this->getBasePath().'/config');
         File::copyDirectory(__DIR__.'/Application/resources', $this->getBasePath().'/resources');
+
+        $this->configPath = __DIR__.'/../extension.neon';
     }
 
     public function execLarastan(string $filename)
     {
-        $configPath = __DIR__.'/../extension.neon';
         $command = escapeshellcmd(__DIR__.'/../vendor/bin/phpstan');
 
         exec(sprintf('%s %s analyse --no-progress  --level=max --configuration %s  %s --error-format=%s',
             escapeshellarg(PHP_BINARY), $command,
-            escapeshellarg($configPath),
+            escapeshellarg($this->configPath),
             escapeshellarg($filename),
             'json'),
             $jsonResult);
 
         return json_decode($jsonResult[0], true);
+    }
+
+    /**
+     * @param string $configPath
+     *
+     * @return static
+     */
+    public function setConfigPath(string $configPath): self
+    {
+        $this->configPath = $configPath;
+
+        return $this;
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

This PR adds support for checking arguments passed to methods that expect model properties. For example

```php
// `foo` does not exist in `users` table. So an error will occur
User::where('foo', 'bar')->get();
```

## How it works?
This PR uses the types introduced in #657 by @Daanra But unlike that PR there is no check done in type level. Instead there are 2 new rules (currently, more to come) that check severy method call and inspects if any of the arguments have the new `model-property` or generic `model-property<Model>` type. If so the parameter will be checked against the model property.

### Using in custom methods
It's not limited to Laravel core methods. Any custom method can typehint that it expects properties of a model with `model-property<Model>` typehint.

```php
class HelloWorld
{
	/**
	 * @phpstan-param model-property<\App\User> $property
	 */
    public function hello(string $property)
    {
		// here we can be sure `$property` is actually a property of User model
    }
}

// Will produce error. `foo` is not a \App\User property
(new HelloWorld)->hello('foo');
```

### Stubs
New types added to Laravel core methods by the help of stubs. Currently not all methods have the new type in docblocks. But it's fairly easy to add them to stubs so I'm thinking preparing a guide of how-to, and ask people to contribute. Would be a cool and easy way to contribute to OSS and Hacktoberfest.


## Next steps

- We need to test it on more projects. I already did some testing on some open-source Laravel projects + my work projects and fixed couple of bugs. But I'm sure there are more edge cases :smile: 
- I'll add property checking to dynamic wheres. 
```php
// `whereFoo` will look at the `users` column for `foo` column. We can report if this does not exists
User::whereFoo('bar');
```

- New rule for variable/property assigning. If a variable has a type for `model-property<Model>` we should check the assigned value.
```php
/** @var model-property<\App\User>` */
$property = 'foo';

// Should error if `foo` is not a property of `\App\User`

// Same here as `someProperty`
$someObject->someProperty = 'foo';
```
