### PR TITLE
Add return type for Eloquent Factories

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -121,6 +121,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\ModelDynamicStaticMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension

--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'factory';
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): Type
+    {
+        $modelName = $methodReflection->getDeclaringClass()->getName();
+
+        $factoryName = Factory::resolveFactoryName($modelName);
+
+        return new ObjectType($factoryName);
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use function get_class;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,6 +24,7 @@ class User extends Authenticatable
 {
     use Notifiable;
     use SoftDeletes;
+    use HasFactory;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/Application/database/factories/UserFactory.php
+++ b/tests/Application/database/factories/UserFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Application\database\factories;
+
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'email' => $this->faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    public function randomPassword()
+    {
+        return $this->state([
+            'password' => bcrypt(Str::random(10)),
+        ]);
+    }
+}

--- a/tests/Features/ReturnTypes/ModelFactoryReturnTypeTest.php
+++ b/tests/Features/ReturnTypes/ModelFactoryReturnTypeTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+use Tests\Application\database\factories\UserFactory;
+
+class ModelFactoryReturnTypeTest
+{
+    /** @phpstan-return UserFactory */
+    public function testFactoryCallFromModelReturnsSpecificFactory()
+    {
+        return User::factory();
+    }
+}

--- a/tests/Features/ReturnTypes/ModelFactoryReturnTypeTest.php
+++ b/tests/Features/ReturnTypes/ModelFactoryReturnTypeTest.php
@@ -7,8 +7,7 @@ use Tests\Application\database\factories\UserFactory;
 
 class ModelFactoryReturnTypeTest
 {
-    /** @phpstan-return UserFactory */
-    public function testFactoryCallFromModelReturnsSpecificFactory()
+    public function testFactoryCallFromModelReturnsSpecificFactory(): UserFactory
     {
         return User::factory();
     }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #661

_Will update with more info soon_

Test is still failing, proper return type is included but in union type with basic factory class, not sure how to resolve this yet.
```
There was 1 failure:

1) Tests\FeaturesTest::testFeatures with data set "ReturnTypes/ModelFactoryReturnTypeTest.php" ('/Users/robbinploeger/larastan...st.php')
{
    "totals": {
        "errors": 0,
        "file_errors": 1
    },
    "files": {
        "\/Users\/robbinploeger\/larastan\/tests\/Features\/ReturnTypes\/ModelFactoryReturnTypeTest.php": {
            "errors": 1,
            "messages": [
                {
                    "message": "Method Tests\\Features\\ReturnTypes\\ModelFactoryReturnTypeTest::testFactoryCallFromModelReturnsSpecificFactory() should return Tests\\Application\\database\\factories\\UserFactory but returns Database\\Factories\\UserFactory|Illuminate\\Database\\Eloquent\\Factories\\Factory.",
                    "line": 13,
                    "ignorable": true
                }
            ]
        }
    },
    "errors": []
}
```

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
