### PR TITLE
feat: property check on dynamic wheres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support fot checking model properties on dynamic wheres ([#686](https://github.com/nunomaduro/larastan/pull/686))
+
 ## [0.6.5] - 2020-10-15
 
 This release introduces a new rule that can check the arguments of methods that expects a model property name, and can warn you if the passed argument is not actually a property of the model. You can read the details about the rule [here](https://github.com/nunomaduro/larastan/blob/master/docs/rules.md#modelpropertyrule).

--- a/extension.neon
+++ b/extension.neon
@@ -332,3 +332,7 @@ services:
     -
         class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertiesRuleHelper
 
+    -
+        class: NunoMaduro\Larastan\Methods\BuilderHelper
+        arguments:
+            checkProperties: %checkModelProperties%

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -36,6 +36,14 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
     ];
 
+    /** @var BuilderHelper */
+    private $builderHelper;
+
+    public function __construct(BuilderHelper $builderHelper)
+    {
+        $this->builderHelper = $builderHelper;
+    }
+
     private function getBuilderReflection(): ClassReflection
     {
         return $this->broker->getClass(QueryBuilder::class);
@@ -117,15 +125,13 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         }
 
         if ($modelType instanceof ObjectType) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
             if ($classReflection->isSubclassOf(EloquentBuilder::class)) {
                 $eloquentBuilderClass = $classReflection->getName();
             } else {
-                $eloquentBuilderClass = $builderHelper->determineBuilderType($modelType->getClassName());
+                $eloquentBuilderClass = $this->builderHelper->determineBuilderType($modelType->getClassName());
             }
 
-            $returnMethodReflection = $builderHelper->getMethodReflectionFromBuilder(
+            $returnMethodReflection = $this->builderHelper->getMethodReflectionFromBuilder(
                 $classReflection,
                 $methodName,
                 $modelType->getClassName(),

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -4,14 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Methods;
 
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Support\Str;
-use NunoMaduro\Larastan\Concerns;
-use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
@@ -19,13 +13,14 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 
-final class ModelForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
+final class ModelForwardsCallsExtension implements MethodsClassReflectionExtension
 {
-    use Concerns\HasBroker;
+    /** @var BuilderHelper */
+    private $builderHelper;
 
-    private function getBuilderReflection(): ClassReflection
+    public function __construct(BuilderHelper $builderHelper)
     {
-        return $this->broker->getClass(EloquentBuilder::class);
+        $this->builderHelper = $builderHelper;
     }
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
@@ -34,26 +29,16 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             return false;
         }
 
-        if (in_array($methodName, ['increment', 'decrement', 'paginate', 'simplePaginate'], true)) {
-            return true;
-        }
+        $customBuilderName = $this->builderHelper->determineBuilderType($classReflection->getName());
 
-        // Model scopes
-        if ($classReflection->hasNativeMethod('scope'.ucfirst($methodName))) {
-            return true;
-        }
+        $returnMethodReflection = $this->builderHelper->getMethodReflectionFromBuilder(
+            $classReflection,
+            $methodName,
+            $classReflection->getName(),
+            new GenericObjectType($customBuilderName, [new ObjectType($classReflection->getName())])
+        );
 
-        // Dynamic wheres
-        if (Str::startsWith($methodName, 'where')) {
-            return true;
-        }
-
-        $builderHelper = new BuilderHelper($this->getBroker());
-        $customBuilder = $builderHelper->determineBuilderType($classReflection->getName());
-
-        return $this->getBuilderReflection()->hasNativeMethod($methodName)
-            || $this->broker->getClass(QueryBuilder::class)->hasNativeMethod($methodName)
-            || ($customBuilder && $this->broker->getClass($customBuilder)->hasNativeMethod($methodName));
+        return $returnMethodReflection !== null;
     }
 
     /**
@@ -66,20 +51,19 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
      */
     public function getMethod(ClassReflection $originalModelReflection, string $methodName): MethodReflection
     {
-        $builderHelper = new BuilderHelper($this->getBroker());
-        $customBuilderName = $builderHelper->determineBuilderType($originalModelReflection->getName());
+        $customBuilderName = $this->builderHelper->determineBuilderType($originalModelReflection->getName());
 
-        $returnMethodReflection = $builderHelper->getMethodReflectionFromBuilder(
+        $returnMethodReflection = $this->builderHelper->getMethodReflectionFromBuilder(
             $originalModelReflection,
             $methodName,
             $originalModelReflection->getName(),
             new GenericObjectType($customBuilderName, [new ObjectType($originalModelReflection->getName())])
         );
 
-        if ($returnMethodReflection !== null) {
-            return $returnMethodReflection;
+        if ($returnMethodReflection === null) {
+            throw new ShouldNotHappenException();
         }
 
-        return new DummyMethodReflection($methodName);
+        return $returnMethodReflection;
     }
 }

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -7,14 +7,13 @@ namespace NunoMaduro\Larastan\ReturnTypes;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
-use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\BuilderHelper;
 use NunoMaduro\Larastan\Methods\ModelTypeHelper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
@@ -22,9 +21,19 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 
-final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 {
-    use Concerns\HasBroker;
+    /** @var BuilderHelper */
+    private $builderHelper;
+
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider, BuilderHelper $builderHelper)
+    {
+        $this->builderHelper = $builderHelper;
+        $this->reflectionProvider = $reflectionProvider;
+    }
 
     public function getClass(): string
     {
@@ -33,7 +42,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        $builderReflection = $this->getBroker()->getClass(EloquentBuilder::class);
+        $builderReflection = $this->reflectionProvider->getClass(EloquentBuilder::class);
 
         // Don't handle dynamic wheres
         if (Str::startsWith($methodReflection->getName(), 'where') &&
@@ -70,7 +79,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 
         if ($methodReflection instanceof DummyMethodReflection && $modelType instanceof ObjectType) {
             $scopeMethodName = 'scope'.ucfirst($methodReflection->getName());
-            $modelReflection = $this->getBroker()->getClass($modelType->getClassName());
+            $modelReflection = $this->reflectionProvider->getClass($modelType->getClassName());
 
             if ($modelReflection->hasNativeMethod($scopeMethodName)) {
                 return new ObjectType(EloquentBuilder::class);
@@ -82,18 +91,14 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         }
 
         if (($modelType instanceof ObjectType || $modelType instanceof ThisType) && in_array(EloquentBuilder::class, $returnType->getReferencedClasses(), true)) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
             $returnType = new GenericObjectType(
-                $builderHelper->determineBuilderType($modelType->getClassName()),
+                $this->builderHelper->determineBuilderType($modelType->getClassName()),
                 [$modelType]
             );
         }
 
         if ($modelType instanceof ObjectType && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
-            $collectionClassName = $builderHelper->determineCollectionClassName($modelType->getClassName());
+            $collectionClassName = $this->builderHelper->determineCollectionClassName($modelType->getClassName());
 
             return new GenericObjectType($collectionClassName, [$modelType]);
         }

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -8,15 +8,14 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\BuilderHelper;
 use NunoMaduro\Larastan\Methods\ModelTypeHelper;
 use NunoMaduro\Larastan\Methods\Pipes\Mixins;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
@@ -26,23 +25,26 @@ use ReflectionClass;
 /**
  * @internal
  */
-final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, BrokerAwareExtension
+final class ModelExtension implements DynamicStaticMethodReturnTypeExtension
 {
-    use Concerns\HasBroker;
-
-    /**
-     * @var \NunoMaduro\Larastan\Methods\Pipes\Mixins
-     */
+    /** @var Mixins */
     private $mixins;
 
+    /** @var BuilderHelper */
+    private $builderHelper;
+
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
     /**
-     * @param \NunoMaduro\Larastan\Methods\Pipes\Mixins $mixins
-     *
-     * @return void
+     * @param BuilderHelper $builderHelper
+     * @param Mixins|null   $mixins
      */
-    public function __construct(Mixins $mixins = null)
+    public function __construct(ReflectionProvider $reflectionProvider, BuilderHelper $builderHelper, Mixins $mixins = null)
     {
         $this->mixins = $mixins ?? new Mixins();
+        $this->builderHelper = $builderHelper;
+        $this->reflectionProvider = $reflectionProvider;
     }
 
     /**
@@ -94,8 +96,8 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
                 $classReflection = new ReflectionClass($className);
                 $isValidInstance = false;
                 foreach ($this->mixins->getMixinsFromClass(
-                    $this->broker,
-                    $this->broker->getClass(Collection::class)
+                    $this->reflectionProvider,
+                    $this->reflectionProvider->getClass(Collection::class)
                 ) as $mixin) {
                     if ($isValidInstance = $classReflection->isSubclassOf($mixin)) {
                         break;
@@ -111,18 +113,14 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension, Br
         if ((count(array_intersect([EloquentBuilder::class, QueryBuilder::class], $returnType->getReferencedClasses())) > 0)
             && $methodCall->class instanceof \PhpParser\Node\Name
         ) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
             $returnType = new GenericObjectType(
-                $builderHelper->determineBuilderType($scope->resolveName($methodCall->class)) ?? EloquentBuilder::class,
+                $this->builderHelper->determineBuilderType($scope->resolveName($methodCall->class)) ?? EloquentBuilder::class,
                 [new ObjectType($scope->resolveName($methodCall->class))]
             );
         }
 
         if ($methodCall->class instanceof \PhpParser\Node\Name && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
-            $collectionClassName = $builderHelper->determineCollectionClassName($scope->resolveName($methodCall->class));
+            $collectionClassName = $this->builderHelper->determineCollectionClassName($scope->resolveName($methodCall->class));
 
             return new GenericObjectType($collectionClassName, [new ObjectType($scope->resolveName($methodCall->class))]);
         }

--- a/src/ReturnTypes/RelationExtension.php
+++ b/src/ReturnTypes/RelationExtension.php
@@ -7,11 +7,9 @@ namespace NunoMaduro\Larastan\ReturnTypes;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
-use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\BuilderHelper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
@@ -21,9 +19,15 @@ use PHPStan\Type\Type;
 /**
  * @internal
  */
-final class RelationExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
+final class RelationExtension implements DynamicMethodReturnTypeExtension
 {
-    use Concerns\HasBroker;
+    /** @var BuilderHelper */
+    private $builderHelper;
+
+    public function __construct(BuilderHelper $builderHelper)
+    {
+        $this->builderHelper = $builderHelper;
+    }
 
     /**
      * {@inheritdoc}
@@ -65,9 +69,7 @@ final class RelationExtension implements DynamicMethodReturnTypeExtension, Broke
         $returnType = $methodReflection->getVariants()[0]->getReturnType();
 
         if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $builderHelper = new BuilderHelper($this->getBroker());
-
-            $collectionClassName = $builderHelper->determineCollectionClassName($modelType->getClassname());
+            $collectionClassName = $this->builderHelper->determineCollectionClassName($modelType->getClassname());
 
             return new GenericObjectType($collectionClassName, [$modelType]);
         }

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -18,7 +18,7 @@ class Builder
 
     public function testDynamicWhereAsString(): ?User
     {
-        return (new User())->whereFoo('bar')->first();
+        return (new User())->whereEmail('bar')->first();
     }
 
     public function testDynamicWhereMultiple(): ?User
@@ -28,7 +28,7 @@ class Builder
 
     public function testDynamicWhereAsInt(): ?User
     {
-        return (new User())->whereFoo(1)->first();
+        return (new User())->whereEmail(1)->first();
     }
 
     public function testGetQueryReturnsQueryBuilder(): QueryBuilder

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -42,12 +42,12 @@ class ModelExtension
 
     public function testDynamicWhere(): Builder
     {
-        return (new Thread)->whereFoo(['bar']);
+        return (new Thread)->whereName(['bar']);
     }
 
     public function testStaticDynamicWhere(): Builder
     {
-        return Thread::whereFoo(['bar']);
+        return Thread::whereName(['bar']);
     }
 
     public function testWhereIn(): Builder

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -29,7 +29,7 @@ class Relations
 
     public function testRelationDynamicWhere(): HasMany
     {
-        return (new User())->accounts()->whereFoo(['bar']);
+        return (new User())->accounts()->whereActive(true);
     }
 
     public function testCreateWithRelation(User $user): Account

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -45,23 +45,23 @@ class CustomEloquentBuilderTest
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testCustomBuilderMethodAfterDynamicWhere(): CustomEloquentBuilder
     {
-        return ModelWithCustomBuilder::whereFoo(['bar'])->type('foo')->whereFoo(['bar']);
+        return ModelWithCustomBuilder::whereEmail(['bar'])->type('foo')->whereEmail(['bar']);
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testCustomBuilderMethodWithQueryBuilderMethod(): CustomEloquentBuilder
     {
-        return ModelWithCustomBuilder::whereFoo(['bar'])->categories(['foo'])->whereFoo(['bar']);
+        return ModelWithCustomBuilder::whereEmail(['bar'])->categories(['foo'])->whereType(['bar']);
     }
 
     public function testFindAfterCustomBuilderMethodAfterDynamicWhere(): ?ModelWithCustomBuilder
     {
-        return ModelWithCustomBuilder::whereFoo(['bar'])->type('foo')->first();
+        return ModelWithCustomBuilder::whereEmail(['bar'])->type('foo')->first();
     }
 
     public function testFindAfterCustomBuilderMethodAfterDynamicWhereOnExistingVariable(): ?ModelWithCustomBuilder
     {
-        $query = ModelWithCustomBuilder::whereFoo(['bar'])->type('foo');
+        $query = ModelWithCustomBuilder::whereEmail(['bar'])->type('foo');
 
         return $query->first();
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

This PR adds support for model property check to dynamic wheres. For example
```php
User::whereIdAndEmaiil(...)->get();
```

would produce an error. Because while `id` exists as a property on `User` class, `emaiil` does not.

This does not produce the same error message as our property check rule. It will just complain about that method not exists in the class. I guess this is ok. Developers will see the missing method error and can figure out it's coming from a missing property.

The one thing I wasn't certain about is, should this check be also under the `checkModelProperties` flag? I think it should. Or maybe a new flag like `checkPropertiesonDynamicWheres`?