### PR TITLE
feat: support SoftDeletes methods on relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `SoftDeletes` methods on relations are no longer marked as undefined ([#692](https://github.com/nunomaduro/larastan/pull/692))
 - Generic model type is preserved when `with` method is used on a model instance.
 
 ## [0.6.6] - 2020-10-17

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -6,12 +6,10 @@ namespace NunoMaduro\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Str;
 use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
@@ -213,10 +211,6 @@ class BuilderHelper
             $methodReflection = $this->searchOnQueryBuilder($methodName, $modelName);
         }
 
-        if ($methodReflection === null) {
-            $methodReflection = $this->searchOnSoftDeletesTraitOfRelatedModel($methodName, $modelName);
-        }
-
         if ($methodReflection !== null) {
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
 
@@ -273,17 +267,5 @@ class BuilderHelper
         }
 
         return $returnType->describe(VerbosityLevel::value());
-    }
-
-    private function searchOnSoftDeletesTraitOfRelatedModel(string $methodName, string $modelName): ?MethodReflection
-    {
-        $relatedModel = $this->reflectionProvider->getClass($modelName);
-        $hasSoftDeletesTrait = $relatedModel->hasTraitUse(SoftDeletes::class);
-        $isSoftDeletesMethod = in_array($methodName, ['withTrashed', 'withoutTrashed', 'onlyTrashed']);
-        if ($hasSoftDeletesTrait && $isSoftDeletesMethod) {
-            return new DummyMethodReflection($methodName);
-        }
-
-        return null;
     }
 }

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
+use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
@@ -42,7 +45,11 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             new GenericObjectType($classReflection->getName(), [$relatedModel])
         );
 
-        return $returnMethodReflection !== null;
+        if ($returnMethodReflection === null) {
+            return $relatedModel->hasMethod($methodName)->yes();
+        }
+
+        return true;
     }
 
     public function getMethod(
@@ -62,6 +69,17 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             $relatedModel->getClassName(),
             new GenericObjectType($classReflection->getName(), [$relatedModel])
         );
+
+        if ($returnMethodReflection === null) {
+            $originalMethodReflection = $relatedModel->getMethod($methodName, new OutOfClassScope());
+
+            return new EloquentBuilderMethodReflection(
+                $methodName, $classReflection, $originalMethodReflection,
+                ParametersAcceptorSelector::selectSingle($originalMethodReflection->getVariants())->getParameters(),
+                new GenericObjectType($classReflection->getName(), [$relatedModel]),
+                false
+            );
+        }
 
         if ($returnMethodReflection === null) {
             throw new ShouldNotHappenException(sprintf('%s does not have %s method. But it should.', $classReflection->getName(), $methodName));

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -73,7 +73,7 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
         if ($returnMethodReflection === null) {
             $originalMethodReflection = $relatedModel->getMethod($methodName, new OutOfClassScope());
 
-            return new EloquentBuilderMethodReflection(
+            $returnMethodReflection = new EloquentBuilderMethodReflection(
                 $methodName, $classReflection, $originalMethodReflection,
                 ParametersAcceptorSelector::selectSingle($originalMethodReflection->getVariants())->getParameters(),
                 new GenericObjectType($classReflection->getName(), [$relatedModel]),

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -81,10 +81,6 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             );
         }
 
-        if ($returnMethodReflection === null) {
-            throw new ShouldNotHappenException(sprintf('%s does not have %s method. But it should.', $classReflection->getName(), $methodName));
-        }
-
         return $returnMethodReflection;
     }
 }

--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -4,12 +4,15 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property string $name
  */
 class Group extends Model
 {
+    use SoftDeletes;
+
     public function accounts(): HasMany
     {
         return $this->hasMany(Account::class);

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -171,6 +171,21 @@ class Relations
     {
         return $user->group()->firstWhere('name', 'bar');
     }
+
+    public function testWithTrashedWithBelongsToRelation(User $user): BelongsTo
+    {
+        return $user->group()->withTrashed();
+    }
+
+    public function testOnlyTrashedWithBelongsToRelation(User $user): BelongsTo
+    {
+        return $user->group()->onlyTrashed();
+    }
+
+    public function testWithoutTrashedWithBelongsToRelation(User $user): BelongsTo
+    {
+        return $user->group()->withoutTrashed();
+    }
 }
 
 /**


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Issue: #690

**Changes**

This introduces additional test cases to prove there is a regression issue that was introduced in version 0.6.6.
Methods from the `SoftDeletes` trait are not recognized on Relations even though this is supported through `ForwardsCalls` in Laravel.

---

Note that this PR does not yet introduce a fix but aims to clarify the issue defined in #690. I tried coming up with a solution but couldn't find it yet. Any pointers as to how to approach this would be welcome.