### PR TITLE
feat: add support for file method call on Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Dynamic return type support for `$request->file()` method call.
+
 ## [0.6.7] - 2020-10-21
 
 ### Fixed

--- a/src/ReturnTypes/RequestExtension.php
+++ b/src/ReturnTypes/RequestExtension.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\MixedType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 /**
  * @internal
@@ -30,7 +34,7 @@ final class RequestExtension implements DynamicMethodReturnTypeExtension
      */
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return $methodReflection->getName() === 'input';
+        return $methodReflection->getName() === 'file';
     }
 
     /**
@@ -41,6 +45,17 @@ final class RequestExtension implements DynamicMethodReturnTypeExtension
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        return new MixedType;
+        $uploadedFileType = new ObjectType(UploadedFile::class);
+        $uploadedFileArrayType = new ArrayType(new IntegerType(), $uploadedFileType);
+
+        if (count($methodCall->args) === 0) {
+            return new ArrayType(new IntegerType(), $uploadedFileType);
+        }
+
+        if (count($methodCall->args) === 1) {
+            return TypeCombinator::union($uploadedFileArrayType, TypeCombinator::addNull($uploadedFileType));
+        }
+
+        return TypeCombinator::union(TypeCombinator::union($uploadedFileArrayType, $uploadedFileType), $scope->getType($methodCall->args[1]->value));
     }
 }

--- a/tests/Features/ReturnTypes/RequestExtension.php
+++ b/tests/Features/ReturnTypes/RequestExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+
+class RequestExtension
+{
+    /** @phpstan-return UploadedFile[] */
+    public function testRequestFileWithNoArguments(Request $request): array
+    {
+        return $request->file();
+    }
+
+    /** @phpstan-return UploadedFile[]|UploadedFile|null */
+    public function testRequestFileWithJustKey(Request $request)
+    {
+        return $request->file('foo');
+    }
+
+    /** @phpstan-return DummyFile|UploadedFile|UploadedFile[] */
+    public function testRequestFileWithKeyAndDefaultValue(Request $request)
+    {
+        return $request->file('foo', new DummyFile());
+    }
+}
+
+class DummyFile
+{
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Fixes #248 

**Changes**

This PR adds dynamic return type support for `$request->file()` calls.
