### PR TITLE
Exclude test providers from autoloading

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -17,7 +17,7 @@ final class ApplicationResolver
 {
     use CreatesApplication;
 
-    /** @var mixed $composer */
+    /** @var mixed */
     public static $composer;
 
     /**
@@ -99,7 +99,7 @@ final class ApplicationResolver
         // Create array of dev classes from Composer configuration.
         $devClasses = [];
         $autoloadDev = self::$composer['autoload-dev'] ?? [];
-        $autoloadDevPsr4 = $autoload4['psr-4'] ?? [];
+        $autoloadDevPsr4 = $autoloadDev['psr-4'] ?? [];
         foreach ($autoloadDevPsr4 as $path) {
             $devClasses = array_merge($devClasses, array_keys(ClassMapGenerator::createMap($path)));
         }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -98,7 +98,9 @@ final class ApplicationResolver
 
         // Create array of dev classes from Composer configuration.
         $devClasses = [];
-        foreach (self::$composer['autoload-dev']['psr-4'] as $path) {
+        $autoloadDev = self::$composer['autoload-dev'] ?? [];
+        $autoloadDevPsr4 = $autoload4['psr-4'] ?? [];
+        foreach ($autoloadDevPsr4 as $path) {
             $devClasses = array_merge($devClasses, array_keys(ClassMapGenerator::createMap($path)));
         }
 

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -18,7 +18,7 @@ final class ApplicationResolver
     use CreatesApplication;
 
     /** @var mixed $composer */
-    static $composer;
+    public static $composer;
 
     /**
      * Creates an application and registers service providers found.
@@ -107,7 +107,7 @@ final class ApplicationResolver
         // now class list of maps are assembled, use class_exists calls to explicitly autoload them,
         // while not running them
         foreach ($maps as $class => $file) {
-            if (!in_array($class, $devClasses)) {
+            if (! in_array($class, $devClasses)) {
                 class_exists($class, true);
             }
         }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -17,6 +17,9 @@ final class ApplicationResolver
 {
     use CreatesApplication;
 
+    /** @var mixed $composer */
+    static $composer;
+
     /**
      * Creates an application and registers service providers found.
      *
@@ -30,7 +33,8 @@ final class ApplicationResolver
         $composerFile = getcwd().DIRECTORY_SEPARATOR.'composer.json';
 
         if (file_exists($composerFile)) {
-            $namespace = (string) key(json_decode((string) file_get_contents($composerFile), true)['autoload']['psr-4']);
+            self::$composer = json_decode((string) file_get_contents($composerFile), true);
+            $namespace = (string) key(self::$composer['autoload']['psr-4']);
             $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace, dirname($composerFile)), function (string $class) use (
                 $namespace
             ) {
@@ -92,10 +96,18 @@ final class ApplicationResolver
             $maps = array_merge($maps, ClassMapGenerator::createMap($dir));
         }
 
+        // Create array of dev classes from Composer configuration.
+        $devClasses = [];
+        foreach (self::$composer['autoload-dev']['psr-4'] as $path) {
+            $devClasses = array_merge($devClasses, array_keys(ClassMapGenerator::createMap($path)));
+        }
+
         // now class list of maps are assembled, use class_exists calls to explicitly autoload them,
         // while not running them
         foreach ($maps as $class => $file) {
-            class_exists($class, true);
+            if (!in_array($class, $devClasses)) {
+                class_exists($class, true);
+            }
         }
 
         return get_declared_classes();

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -25,7 +25,7 @@ abstract class RulesTest extends TestCase
      */
     protected function findErrorsByLine(string $filename): array
     {
-        $errors = $this->findErrors($filename);
+        $errors = $this->findErrors(realpath($filename));
 
         return collect($errors['messages'] ?? [])->mapWithKeys(function ($message) {
             return [$message['line'] => $message['message']];


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #683 

**Changes**
Previously an instance of all detected service providers was created during analysis. This is changed. Now  classes with namespaces defined in psr-4 paths in the _autoload-dev_ configuration of `composer.json` are skipped. 


**Breaking changes**
Since a number of classes previously autoloaded are skipped runtime behavior is changed. But I don't think it changes the outcome of the analysis.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
