### PR TITLE
fix: corrected return type of MorphToMany methods

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -166,7 +166,7 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: NunoMaduro\Larastan\ReturnTypes\RelationExtension
+        class: NunoMaduro\Larastan\ReturnTypes\RelationCollectionExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class Relations
 {
@@ -186,6 +187,22 @@ class Relations
     {
         return $user->group()->withoutTrashed();
     }
+
+    /**
+     * @phpstan-return MorphToMany<Address>
+     */
+    public function testMorphToManyWithTimestamps(Tag $tag): MorphToMany
+    {
+        return $tag->addresses();
+    }
+
+    /**
+     * @phpstan-return MorphToMany<Address>
+     */
+    public function testMorphToManyWithPivot(Tag $tag): MorphToMany
+    {
+        return $tag->addresses();
+    }
 }
 
 /**
@@ -210,33 +227,27 @@ class ModelWithoutPropertyAnnotation extends Model
     {
         return $this->hasMany(User::class);
     }
+}
 
-    public function addRelation(): User
+class Tag extends Model
+{
+    /**
+     * @phpstan-return MorphToMany<Address>
+     */
+    public function addresses(): MorphToMany
     {
-        return $this->relation()->create([]);
+        return $this->morphToMany(Address::class, 'taggable')->withTimestamps();
+    }
+
+    /**
+     * @phpstan-return MorphToMany<Address>
+     */
+    public function addressesWithPivot(): MorphToMany
+    {
+        return $this->morphToMany(Address::class, 'taggable')->withPivot('foo');
     }
 }
 
-class TestRelationCreateOnExistingModel
+class Address extends Model
 {
-    /** @var User */
-    private $user;
-
-    public function testRelationCreateOnExistingModel(): Account
-    {
-        return $this->user->accounts()->create();
-    }
-}
-
-class Post extends Model
-{
-    public function author(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    public function addUser(User $user): self
-    {
-        return $this->author()->associate($user);
-    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #698

**Changes**

This PR fixes the return type of `MorphToMany` methods.

`RelationExtension` was somehow "swallowing" the return type if the return type was an instance of `ThisType` So since that extensions only purpose was to correct the return types for methods that are returning collections, I added a check to limit the extension to only those methods.
