### PR TITLE
fix: corrected return type for some QueryBuilder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected return type for some QueryBuilder methods ([#702](https://github.com/nunomaduro/larastan/pull/702))
+
 ## [0.6.8] - 2020-10-23
 
 ### Added

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -656,7 +656,7 @@ class Builder
     /**
      * Create a new query instance for nested where condition.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return $this
      */
     public function forNestedWhere()
     {}
@@ -1098,7 +1098,7 @@ class Builder
     /**
      * Lock the selected rows in the table for updating.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return $this
      */
     public function lockForUpdate()
     {}
@@ -1106,7 +1106,7 @@ class Builder
     /**
      * Share lock the selected rows in the table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return $this
      */
     public function sharedLock()
     {}
@@ -1384,7 +1384,7 @@ class Builder
     /**
      * Get a new instance of the query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return $this
      */
     public function newQuery()
     {}

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -261,6 +261,24 @@ class ModelExtension
     {
         return $user->with('accounts')->with('group')->find(1);
     }
+
+    /** @phpstan-return Builder<User> */
+    public function testLockForUpdate(): Builder
+    {
+        return User::where('id', '>', 5)->lockForUpdate();
+    }
+
+    /** @phpstan-return Builder<User> */
+    public function testSharedLock(): Builder
+    {
+        return User::where('id', '>', 5)->sharedLock();
+    }
+
+    /** @phpstan-return Builder<User> */
+    public function testNewQuery(): Builder
+    {
+        return User::where('id', '>', 5)->newQuery();
+    }
 }
 
 function foo(): string


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Fixes #700 

**Changes**

This PR fixes the return type of some of the `QueryBuilder` methods and adds tests.
