### PR TITLE
Add dd to list of early terminating functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `dd` to list of early terminating functions ([#710](https://github.com/nunomaduro/larastan/pull/710))
+
 ## [0.6.9] - 2020-10-30
 
 ### Added

--- a/extension.neon
+++ b/extension.neon
@@ -31,6 +31,7 @@ parameters:
         - Illuminate\Http\Request
     earlyTerminatingFunctionCalls:
         - abort
+        - dd
     excludes_analyse:
         - *.blade.php
     mixinExcludeClasses:


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds `dd` to the list of early terminating function calls. I could possibly add `ddd` as well, but since the method definition does not reside in the Laravel package I decided to omit it.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
