### PR TITLE
Model::with() accepts array of Closure

### DIFF
--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -19,7 +19,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     /**
      * Begin querying a model with eager loading.
      *
-     * @param  string[]|string  $relations
+     * @param  string|array<int|string, (\Closure)|string>  $relations
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public static function with($relations);

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ModelExtension
@@ -203,6 +204,13 @@ class ModelExtension
             ->where('email', 'bar')
             ->orWhere('name', 'baz')
             ->first();
+    }
+
+    public function testWithAcceptsArrayOfClosures(): ?User
+    {
+        return User::with(['accounts' => function (Relation $relation) {
+            return $relation->where('active', true);
+        }])->find(1);
     }
 
     /** @return Collection<User>|null */


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes #712

**Changes**

Ensures that if you call a Model::with() method with array of Closures it does not result in a false positive.

