### PR TITLE
feat: infer custom collection type on model relation properties

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Properties;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use NunoMaduro\Larastan\Concerns;
+use NunoMaduro\Larastan\Methods\BuilderHelper;
 use NunoMaduro\Larastan\Types\RelationParserHelper;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
@@ -39,10 +38,17 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
     /** @var AnnotationsPropertiesClassReflectionExtension */
     private $annotationExtension;
 
-    public function __construct(RelationParserHelper $relationParserHelper, AnnotationsPropertiesClassReflectionExtension $annotationExtension)
+    /** @var BuilderHelper */
+    private $builderHelper;
+
+    public function __construct(
+        RelationParserHelper $relationParserHelper,
+        AnnotationsPropertiesClassReflectionExtension $annotationExtension,
+        BuilderHelper $builderHelper)
     {
         $this->relationParserHelper = $relationParserHelper;
         $this->annotationExtension = $annotationExtension;
+        $this->builderHelper = $builderHelper;
     }
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
@@ -77,10 +83,6 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         /** @var ObjectType $returnType */
         $returnType = ParametersAcceptorSelector::selectSingle($method->getVariants())->getReturnType();
 
-        if (! (new ObjectType(Relation::class))->isSuperTypeOf($returnType)->yes()) {
-            return new DummyPropertyReflection();
-        }
-
         if ($returnType instanceof GenericObjectType) {
             /** @var ObjectType $relatedModelType */
             $relatedModelType = $returnType->getTypes()[0];
@@ -96,11 +98,12 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         $relatedModel = new ObjectType($relatedModelClassName);
+        $collectionClass = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
 
         if (Str::contains($returnType->getClassName(), 'Many')) {
             return new ModelProperty(
                 $classReflection,
-                new GenericObjectType(Collection::class, [$relatedModel]),
+                new GenericObjectType($collectionClass, [$relatedModel]),
                 new NeverType(), false
             );
         }

--- a/tests/Application/app/AccountCollection.php
+++ b/tests/Application/app/AccountCollection.php
@@ -10,5 +10,11 @@ use Illuminate\Database\Eloquent\Collection;
  */
 class AccountCollection extends Collection
 {
-    //
+    /**
+     * @return self<TModel>
+     */
+    public function filterByActive(): self
+    {
+        return $this->where('active', true);
+    }
 }

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -17,7 +17,6 @@ use Tests\Application\HasManySyncable;
 
 /**
  * @property string $propertyDefinedOnlyInAnnotation
- * @property-read \App\AccountCollection $accounts
  * @mixin \Eloquent
  */
 class User extends Authenticatable

--- a/tests/Features/ReturnTypes/CustomEloquentCollectionTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentCollectionTest.php
@@ -520,6 +520,14 @@ class CustomEloquentCollectionTest
     }
 
     /**
+     * @phpstan-return AccountCollection<Account>
+     */
+    public function testCustomMethodInCustomCollection(User $user): AccountCollection
+    {
+        return $user->accounts->filterByActive();
+    }
+
+    /**
      * @phpstan-return Collection<User>
      */
     public function testEloquentCollectionWhereReturnsEloquentCollection(): Collection


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Related: https://github.com/nunomaduro/larastan/issues/436#issuecomment-734814388

**Changes**

Accessing model relation as a property will return custom collection if the related model has one.
