### PR TITLE
refactor: use updated excludePaths parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/pipeline": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "mockery/mockery": "^0.9 || ^1.0",
-        "phpstan/phpstan": "^0.12.34",
+        "phpstan/phpstan": "^0.12.65",
         "symfony/process": "^4.3 || ^5.0",
         "ext-json": "*"
     },

--- a/extension.neon
+++ b/extension.neon
@@ -35,7 +35,7 @@ parameters:
     earlyTerminatingFunctionCalls:
         - abort
         - dd
-    excludes_analyse:
+    excludePaths:
         - *.blade.php
     mixinExcludeClasses:
         - Eloquent


### PR DESCRIPTION
PHPStan introduced a new `excludePaths` parameter in `0.12.65`. The old `excludes_analyse` parameter is now deprecated and throws an error when using both at the same time in your own config:

```
Configuration parameters excludes_analyse and excludePaths cannot be used at the same time.

Parameter excludes_analyse has been deprecated so use excludePaths only from now on.
```

This PR updates this project to only use `excludePaths`. This however requires us to bump the minimum version of PHPStan to `0.12.65`, but I don't think that should be a big issue.