### PR TITLE
chore: change deprecated excludes_analyse to excludePaths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ parameters:
     ignoreErrors:
         - '#Unsafe usage of new static#'
 
-    excludes_analyse:
+    excludePaths:
         - ./*/*/FileToBeExcluded.php
 
     checkMissingIterableValueType: false


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

I updated the example `phpstan.neon` snippet in the README.md to use the new excludePaths parameter. Relates to #759.