### PR TITLE
deps: require PHPStan v0.12.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated php phpstan/phpstan from v0.12.65 -> v0.12.70 ([phpstan/releases/tag/0.12.7](https://github.com/phpstan/phpstan/releases/tag/0.12.7))
 
 ### [0.6.13] - 2021-01-22
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/pipeline": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "mockery/mockery": "^0.9 || ^1.0",
-        "phpstan/phpstan": "^0.12.65",
+        "phpstan/phpstan": "^0.12.70",
         "symfony/process": "^4.3 || ^5.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
This solves the OutOfBoundsException: Package "project/project" is not installed error

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

getsentry/sentry-symfony#383

**Changes**

Updated php phpstan/phpstan from v0.12.65 -> v0.12.70
See [phpstan/releases/tag/0.12.70](https://github.com/phpstan/phpstan/releases/tag/0.12.70)

**Breaking changes**

None
