### PR TITLE
Adds support for additional migration directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Add support for additional database migrations paths using `additionalDatabaseMigrationPaths`.
+- BREAKING: Changed `databaseMigrationsPath` to be an array instead of a string, so it allows multiple directories.
 
 ### [0.6.13] - 2021-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add support for additional database migrations paths using `additionalDatabaseMigrationPaths`.
+
 ### [0.6.13] - 2021-01-22
 
 ### Added

--- a/docs/custom-config-paramaters.md
+++ b/docs/custom-config-paramaters.md
@@ -10,18 +10,6 @@ These parameters are related to the `NoUnnecessaryCollectionCall` rule. You can 
 
 By default, the default Laravel database migration path (`database/migrations`) is used to scan migration files to understand the table structure and model properties. If you have database migrations in other place than the default, you can use this config parameter to tell Larastan where the database migrations are stored.
 
-You can give an absolute path, or a path relative to the PHPStan config file.
-
-#### Example
-```neon
-parameters:
-    databaseMigrationsPath: ../custom/migrations/path
-```
-
-## `additionalDatabaseMigrationPaths`
-
-If your Laravel configuration uses database paths in multiple directories, you can extend `databaseMigrationsPath` by setting `additionalDatabaseMigrationPaths`.
-
 You can give absolute paths, or paths relative to the PHPStan config file.
 
 #### Example

--- a/docs/custom-config-paramaters.md
+++ b/docs/custom-config-paramaters.md
@@ -18,6 +18,20 @@ parameters:
     databaseMigrationsPath: ../custom/migrations/path
 ```
 
+## `additionalDatabaseMigrationPaths`
+
+If your Laravel configuration uses database paths in multiple directories, you can extend `databaseMigrationsPath` by setting `additionalDatabaseMigrationPaths`.
+
+You can give absolute paths, or paths relative to the PHPStan config file.
+
+#### Example
+```neon
+parameters:
+    additionalDatabaseMigrationPaths:
+        - app/Domain/DomainA/migrations
+        - app/Domain/DomainB/migrations
+```
+
 ## `checkModelProperties`
 **default**: `false`
 

--- a/docs/custom-config-paramaters.md
+++ b/docs/custom-config-paramaters.md
@@ -15,7 +15,7 @@ You can give absolute paths, or paths relative to the PHPStan config file.
 #### Example
 ```neon
 parameters:
-    additionalDatabaseMigrationPaths:
+    databaseMigrationsPath:
         - app/Domain/DomainA/migrations
         - app/Domain/DomainB/migrations
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -46,16 +46,14 @@ parameters:
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
-    databaseMigrationsPath: null
-    additionalDatabaseMigrationPaths: []
+    databaseMigrationsPath: []
     checkModelProperties: false
 
 parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
-    databaseMigrationsPath: schema(anyOf(string()), nullable())
-    additionalDatabaseMigrationPaths: listOf(string())
+    databaseMigrationsPath: listOf(string())
     checkModelProperties: bool()
 
 conditionalTags:
@@ -335,7 +333,6 @@ services:
         arguments:
             databaseMigrationPath: %databaseMigrationsPath%
             currentWorkingDirectory: %currentWorkingDirectory%
-            additionalDatabaseMigrationPaths: %additionalDatabaseMigrationPaths%
 
     -
         class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertiesRuleHelper

--- a/extension.neon
+++ b/extension.neon
@@ -47,6 +47,7 @@ parameters:
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
     databaseMigrationsPath: null
+    additionalDatabaseMigrationPaths: []
     checkModelProperties: false
 
 parametersSchema:
@@ -54,6 +55,7 @@ parametersSchema:
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
     databaseMigrationsPath: schema(anyOf(string()), nullable())
+    additionalDatabaseMigrationPaths: listOf(string())
     checkModelProperties: bool()
 
 conditionalTags:
@@ -333,6 +335,7 @@ services:
         arguments:
             databaseMigrationPath: %databaseMigrationsPath%
             currentWorkingDirectory: %currentWorkingDirectory%
+            additionalDatabaseMigrationPaths: %additionalDatabaseMigrationPaths%
 
     -
         class: NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertiesRuleHelper

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -23,7 +23,7 @@ class MigrationHelper
     private $currentWorkingDirectory;
 
     /**
-     * @var string[] $additionalDatabaseMigrationPaths
+     * @var string[]
      */
     private $additionalDatabaseMigrationPaths;
 
@@ -53,7 +53,7 @@ class MigrationHelper
             $this->databaseMigrationPath = database_path('migrations');
         }
 
-        if (!is_dir($this->databaseMigrationPath)) {
+        if (! is_dir($this->databaseMigrationPath)) {
             return [];
         }
 

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -25,7 +25,8 @@ class MigrationHelper
     /**
      * @param string[] $databaseMigrationPath
      */
-    public function __construct(CachedParser $parser, string $currentWorkingDirectory, array $databaseMigrationPath) {
+    public function __construct(CachedParser $parser, string $currentWorkingDirectory, array $databaseMigrationPath)
+    {
         $this->parser = $parser;
         $this->databaseMigrationPath = $databaseMigrationPath;
         $this->currentWorkingDirectory = $currentWorkingDirectory;
@@ -36,7 +37,7 @@ class MigrationHelper
      */
     public function initializeTables(): array
     {
-        if(empty($this->databaseMigrationPath)) {
+        if (empty($this->databaseMigrationPath)) {
             $this->databaseMigrationPath = [database_path('migrations')];
         }
 

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -69,7 +69,7 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_can_read_additional_directories(): void
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__ . '/data/basic_migration', [
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__.'/data/basic_migration', [
             __DIR__.'/data/additional_migrations',
         ]);
 

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -66,6 +66,20 @@ class MigrationHelperTest extends TestCase
         self::assertSame('int', $tables['users']->columns['active']->readableType);
     }
 
+    /** @test */
+    public function it_can_read_additional_directories(): void
+    {
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__ . '/data/basic_migration', [
+            __DIR__.'/data/additional_migrations',
+        ]);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(2, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertArrayHasKey('teams', $tables);
+    }
+
     /**
      * @param array<string, SchemaTable> $tables
      */

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -22,7 +22,7 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_will_return_empty_array_if_migrations_path_is_not_a_directory()
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', 'foobar');
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', ['foobar']);
 
         self::assertSame([], $migrationHelper->initializeTables());
     }
@@ -30,7 +30,7 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_can_read_basic_migrations_and_create_table_structure()
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__.'/data/basic_migration');
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', [__DIR__.'/data/basic_migration']);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -40,7 +40,7 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_can_read_schema_definitions_from_any_method_in_class()
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__.'/data/migrations_with_different_methods');
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', [__DIR__.'/data/migrations_with_different_methods']);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -50,7 +50,7 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_can_read_schema_definitions_with_multiple_create_and_drop_methods_for_one_table()
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__.'/data/complex_migrations');
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', [__DIR__.'/data/complex_migrations']);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -69,7 +69,8 @@ class MigrationHelperTest extends TestCase
     /** @test */
     public function it_can_read_additional_directories(): void
     {
-        $migrationHelper = new MigrationHelper($this->cachedParser, '', __DIR__.'/data/basic_migration', [
+        $migrationHelper = new MigrationHelper($this->cachedParser, '', [
+            __DIR__.'/data/basic_migration',
             __DIR__.'/data/additional_migrations',
         ]);
 

--- a/tests/Unit/data/additional_migrations/2021_02_01_000000_create_teams_table.php
+++ b/tests/Unit/data/additional_migrations/2021_02_01_000000_create_teams_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AdditionalMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTeamsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('team')->nullable();
+            $table->string('owner_email')->unique();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Fixes: #715

**Changes**

Add support for additional database migrations paths using `additionalDatabaseMigrationPaths`

**Breaking changes**

None, original parameter is left, only additional migrations paths can be defined (did not want to introduce multiple types for a single parameter string|array|null).
