### PR TITLE
feat: support for HigherOrderCollectionProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for HigherOrderCollectionProxy ([#781](https://github.com/nunomaduro/larastan/pull/781))
+
 ## [0.7.0] - 2021-02-01
 ### Changed
 - Updated `phpstan/phpstan` from v0.12.65 to v0.12.70 ([#774](https://github.com/nunomaduro/larastan/pull/774)) Thanks @chrisp-github

--- a/docs/errors-to-ignore.md
+++ b/docs/errors-to-ignore.md
@@ -7,7 +7,7 @@ If you hit those errors in your project, you can add them to your `phpstan.neon`
 
 ### Higher Order Messages
 
-This comes up when using [higher order messages](https://laravel.com/docs/collections#higher-order-messages). 
+Although Larastan has support for [HigherOrderCollectionProxy](https://laravel.com/docs/collections#higher-order-messages), you can still have some errors if you are using higher order messages with `Support\Collection` rather than `Eloquent\Collection` . 
 
 ```neon
 - '#Call to an undefined method Illuminate\\Support\\HigherOrder#'

--- a/extension.neon
+++ b/extension.neon
@@ -22,7 +22,7 @@ parameters:
         - stubs/MorphToMany.stub
         - stubs/MorphMany.stub
         - stubs/Helpers.stub
-        - stubs/HigherOrderTapProxy.stub
+        - stubs/HigherOrderProxies.stub
         - stubs/QueryBuilder.stub
         - stubs/Facades.stub
         - stubs/Pagination.stub
@@ -30,6 +30,7 @@ parameters:
         - stubs/Contracts/Support.stub
         - stubs/Redis/Connection.stub
         - stubs/Logger.stub
+        - stubs/EnumeratesValues.stub
     scopeClass: NunoMaduro\Larastan\Analyser\Scope
     universalObjectCratesClasses:
         - Illuminate\Http\Request
@@ -86,6 +87,11 @@ services:
             - phpstan.broker.methodsClassReflectionExtension
 
     -
+        class: NunoMaduro\Larastan\Methods\HigherOrderCollectionProxyExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+
+    -
         class: NunoMaduro\Larastan\Methods\StorageMethodsClassReflectionExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
@@ -107,6 +113,11 @@ services:
 
     -
         class: NunoMaduro\Larastan\Properties\Extension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\Properties\HigherOrderCollectionProxyPropertyExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension
 

--- a/src/Methods/HigherOrderCollectionProxyExtension.php
+++ b/src/Methods/HigherOrderCollectionProxyExtension.php
@@ -14,7 +14,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type;
 
-class HigherOrderCollectionProxyExtension implements MethodsClassReflectionExtension
+final class HigherOrderCollectionProxyExtension implements MethodsClassReflectionExtension
 {
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
@@ -30,17 +30,16 @@ class HigherOrderCollectionProxyExtension implements MethodsClassReflectionExten
         /** @var Type\Constant\ConstantStringType $methodType */
         $methodType = $activeTemplateTypeMap->getType('T');
 
-        /** @var Type\ObjectType $modelType */
-        $modelType = $activeTemplateTypeMap->getType('TModel');
+        /** @var Type\ObjectType $valueType */
+        $valueType = $activeTemplateTypeMap->getType('TValue');
 
-        $modelMethodReflection = $modelType->getMethod($methodName, new OutOfClassScope());
+        $modelMethodReflection = $valueType->getMethod($methodName, new OutOfClassScope());
 
         $modelMethodReturnType = ParametersAcceptorSelector::selectSingle($modelMethodReflection->getVariants())->getReturnType();
 
-        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $modelType, $modelMethodReturnType);
+        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $valueType, $modelMethodReturnType);
 
-        /** @phpstan-ignore-next-line */
-        return new class($modelType->getClassReflection(), $methodName, $modelMethodReflection, $returnType) implements MethodReflection {
+        return new class($classReflection, $methodName, $modelMethodReflection, $returnType) implements MethodReflection {
             /** @var ClassReflection */
             private $classReflection;
 

--- a/src/Methods/HigherOrderCollectionProxyExtension.php
+++ b/src/Methods/HigherOrderCollectionProxyExtension.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Methods;
+
+use NunoMaduro\Larastan\Support\HigherOrderCollectionProxyHelper;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type;
+
+class HigherOrderCollectionProxyExtension implements MethodsClassReflectionExtension
+{
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return HigherOrderCollectionProxyHelper::hasPropertyOrMethod($classReflection, $methodName, 'method');
+    }
+
+    public function getMethod(
+        ClassReflection $classReflection,
+        string $methodName
+    ): MethodReflection {
+        $activeTemplateTypeMap = $classReflection->getActiveTemplateTypeMap();
+
+        /** @var Type\Constant\ConstantStringType $methodType */
+        $methodType = $activeTemplateTypeMap->getType('T');
+
+        /** @var Type\ObjectType $modelType */
+        $modelType = $activeTemplateTypeMap->getType('TModel');
+
+        $modelMethodReflection = $modelType->getMethod($methodName, new OutOfClassScope());
+
+        $modelMethodReturnType = ParametersAcceptorSelector::selectSingle($modelMethodReflection->getVariants())->getReturnType();
+
+        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $modelType, $modelMethodReturnType);
+
+        /** @phpstan-ignore-next-line */
+        return new class($modelType->getClassReflection(), $methodName, $modelMethodReflection, $returnType) implements MethodReflection {
+            /** @var ClassReflection */
+            private $classReflection;
+
+            /** @var string */
+            private $methodName;
+
+            /** @var MethodReflection */
+            private $modelMethodReflection;
+
+            /** @var Type\Type */
+            private $returnType;
+
+            public function __construct(ClassReflection $classReflection, string $methodName, MethodReflection $modelMethodReflection, Type\Type $returnType)
+            {
+                $this->classReflection = $classReflection;
+                $this->methodName = $methodName;
+                $this->modelMethodReflection = $modelMethodReflection;
+                $this->returnType = $returnType;
+            }
+
+            public function getDeclaringClass(): \PHPStan\Reflection\ClassReflection
+            {
+                return $this->classReflection;
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): ?string
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->methodName;
+            }
+
+            public function getPrototype(): \PHPStan\Reflection\ClassMemberReflection
+            {
+                return $this;
+            }
+
+            public function getVariants(): array
+            {
+                return [
+                    new FunctionVariant(
+                        ParametersAcceptorSelector::selectSingle($this->modelMethodReflection->getVariants())->getTemplateTypeMap(),
+                        ParametersAcceptorSelector::selectSingle($this->modelMethodReflection->getVariants())->getResolvedTemplateTypeMap(),
+                        ParametersAcceptorSelector::selectSingle($this->modelMethodReflection->getVariants())->getParameters(),
+                        ParametersAcceptorSelector::selectSingle($this->modelMethodReflection->getVariants())->isVariadic(),
+                        $this->returnType
+                    ),
+                ];
+            }
+
+            public function isDeprecated(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): ?string
+            {
+                return null;
+            }
+
+            public function isFinal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function isInternal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getThrowType(): ?\PHPStan\Type\Type
+            {
+                return null;
+            }
+
+            public function hasSideEffects(): TrinaryLogic
+            {
+                return TrinaryLogic::createMaybe();
+            }
+        };
+    }
+}

--- a/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
+++ b/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Properties;
+
+use NunoMaduro\Larastan\Support\HigherOrderCollectionProxyHelper;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type;
+
+class HigherOrderCollectionProxyPropertyExtension implements PropertiesClassReflectionExtension
+{
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        return HigherOrderCollectionProxyHelper::hasPropertyOrMethod($classReflection, $propertyName, 'property');
+    }
+
+    public function getProperty(
+        ClassReflection $classReflection,
+        string $propertyName
+    ): PropertyReflection {
+        $activeTemplateTypeMap = $classReflection->getActiveTemplateTypeMap();
+
+        /** @var Type\Constant\ConstantStringType $methodType */
+        $methodType = $activeTemplateTypeMap->getType('T');
+
+        /** @var Type\ObjectType $modelType */
+        $modelType = $activeTemplateTypeMap->getType('TModel');
+
+        $propertyType = $modelType->getProperty($propertyName, new OutOfClassScope())->getReadableType();
+
+        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $modelType, $propertyType);
+
+        return new class($modelType, $returnType) implements PropertyReflection {
+            /** @var Type\ObjectType */
+            private $modelType;
+
+            /** @var Type\Type */
+            private $returnType;
+
+            public function __construct(Type\ObjectType $modelType, Type\Type $returnType)
+            {
+                $this->modelType = $modelType;
+                $this->returnType = $returnType;
+            }
+
+            public function getDeclaringClass(): \PHPStan\Reflection\ClassReflection
+            {
+                /** @phpstan-ignore-next-line */
+                return $this->modelType->getClassReflection();
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): ?string
+            {
+                return null;
+            }
+
+            public function getReadableType(): Type\Type
+            {
+                return $this->returnType;
+            }
+
+            public function getWritableType(): Type\Type
+            {
+                return $this->returnType;
+            }
+
+            public function canChangeTypeAfterAssignment(): bool
+            {
+                return false;
+            }
+
+            public function isReadable(): bool
+            {
+                return true;
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function isDeprecated(): \PHPStan\TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): ?string
+            {
+                return null;
+            }
+
+            public function isInternal(): \PHPStan\TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+        };
+    }
+}

--- a/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
+++ b/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
@@ -29,7 +29,7 @@ class HigherOrderCollectionProxyPropertyExtension implements PropertiesClassRefl
         $methodType = $activeTemplateTypeMap->getType('T');
 
         /** @var Type\ObjectType $modelType */
-        $modelType = $activeTemplateTypeMap->getType('TModel');
+        $modelType = $activeTemplateTypeMap->getType('TValue');
 
         $propertyType = $modelType->getProperty($propertyName, new OutOfClassScope())->getReadableType();
 

--- a/src/Support/HigherOrderCollectionProxyHelper.php
+++ b/src/Support/HigherOrderCollectionProxyHelper.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Support;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HigherOrderCollectionProxy;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type;
+
+class HigherOrderCollectionProxyHelper
+{
+    /**
+     * @phpstan-param 'method'|'property' $propertyOrMethod
+     */
+    public static function hasPropertyOrMethod(ClassReflection $classReflection, string $name, string $propertyOrMethod): bool
+    {
+        if ($classReflection->getName() !== HigherOrderCollectionProxy::class) {
+            return false;
+        }
+
+        $activeTemplateTypeMap = $classReflection->getActiveTemplateTypeMap();
+
+        if ($activeTemplateTypeMap->count() !== 2) {
+            return false;
+        }
+
+        $methodType = $activeTemplateTypeMap->getType('T');
+        /** @var ?Type\ObjectType $modelType */
+        $modelType = $activeTemplateTypeMap->getType('TModel');
+
+        if (($methodType === null) || ($modelType === null)) {
+            return false;
+        }
+
+        if (! (new Type\ObjectType(Model::class))->isSuperTypeOf($modelType)->yes()) {
+            return false;
+        }
+
+        if ($propertyOrMethod === 'method') {
+            return $modelType->hasMethod($name)->yes();
+        }
+
+        return $modelType->hasProperty($name)->yes();
+    }
+
+    public static function determineReturnType(string $name, Type\Type $modelType, Type\Type $methodOrPropertyReturnType): Type\Type
+    {
+        switch ($name) {
+            case 'average':
+            case 'avg':
+                $returnType = new Type\FloatType();
+                break;
+            case 'contains':
+            case 'every':
+            case 'some':
+                $returnType = new Type\BooleanType();
+                break;
+            case 'each':
+            case 'filter':
+            case 'keyBy':
+            case 'reject':
+            case 'skipUntil':
+            case 'skipWhile':
+            case 'sortBy':
+            case 'sortByDesc':
+            case 'takeUntil':
+            case 'takeWhile':
+            case 'unique':
+                $returnType = new Type\Generic\GenericObjectType(Collection::class, [$modelType]);
+                break;
+            case 'first':
+                $returnType = Type\TypeCombinator::addNull($modelType);
+                break;
+            case 'flatMap':
+                $returnType = new Type\Generic\GenericObjectType(\Illuminate\Support\Collection::class, [new Type\IntegerType(), new Type\MixedType()]);
+                break;
+            case 'groupBy':
+            case 'partition':
+                $returnType = new Type\Generic\GenericObjectType(Collection::class, [
+                    new Type\Generic\GenericObjectType(Collection::class, [$modelType]),
+                ]);
+                break;
+            case 'map':
+                $returnType = new Type\Generic\GenericObjectType(\Illuminate\Support\Collection::class, [
+                    new Type\IntegerType(),
+                    $methodOrPropertyReturnType,
+                ]);
+                break;
+            case 'max':
+            case 'min':
+                $returnType = $methodOrPropertyReturnType;
+                break;
+            case 'sum':
+                if ($methodOrPropertyReturnType->accepts(new Type\IntegerType(), true)->yes()) {
+                    $returnType = new Type\IntegerType();
+                } else {
+                    $returnType = new Type\ErrorType();
+                }
+
+                break;
+            default:
+                $returnType = new Type\ErrorType();
+                break;
+        }
+
+        return $returnType;
+    }
+}

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -5,37 +5,37 @@ namespace Illuminate\Database\Eloquent;
 use Illuminate\Support\Traits\EnumeratesValues;
 
 /**
- * @template TModel
- * @extends \Illuminate\Support\Collection<int, TModel>
+ * @template TValue
+ * @extends \Illuminate\Support\Collection<int, TValue>
  */
 class Collection extends \Illuminate\Support\Collection
 {
 
-    /** @phpstan-use EnumeratesValues<TModel> */
+    /** @phpstan-use EnumeratesValues<TValue> */
     use EnumeratesValues;
 
     /**
      * @param  mixed  $key
      * @param  mixed  $default
-     * @phpstan-return TModel|null
+     * @phpstan-return TValue|null
      */
     public function find($key, $default = null) {}
 
     /**
      * @template TReturn
-     * @param callable(TModel, int): TReturn $callable
+     * @param callable(TValue, int): TReturn $callable
      * @return static<TReturn>|\Illuminate\Support\Collection<int, TReturn>
      */
     public function map($callable) {}
 
     /**
-     * @param callable(TModel, int): array<mixed> $callback
+     * @param callable(TValue, int): array<mixed> $callback
      * @return \Illuminate\Support\Collection<mixed, static<mixed>>
      */
     public function mapToGroups(callable $callback) {}
 
     /**
-     * @param callable(TModel, int): mixed $callback
+     * @param callable(TValue, int): mixed $callback
      * @return \Illuminate\Support\Collection<mixed, mixed>
      */
     public function flatMap(callable $callback) {}

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -2,12 +2,18 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Traits\EnumeratesValues;
+
 /**
  * @template TModel
  * @extends \Illuminate\Support\Collection<int, TModel>
  */
 class Collection extends \Illuminate\Support\Collection
 {
+
+    /** @phpstan-use EnumeratesValues<TModel> */
+    use EnumeratesValues;
+
     /**
      * @param  mixed  $key
      * @param  mixed  $default

--- a/stubs/EnumeratesValues.stub
+++ b/stubs/EnumeratesValues.stub
@@ -5,32 +5,32 @@ namespace Illuminate\Support\Traits;
 use Illuminate\Support\HigherOrderCollectionProxy;
 
 /**
- * @template TModel
- * @property-read HigherOrderCollectionProxy<'average', TModel> $average
- * @property-read HigherOrderCollectionProxy<'avg', TModel> $avg
- * @property-read HigherOrderCollectionProxy<'contains', TModel> $contains
- * @property-read HigherOrderCollectionProxy<'each', TModel> $each
- * @property-read HigherOrderCollectionProxy<'every', TModel> $every
- * @property-read HigherOrderCollectionProxy<'filter', TModel> $filter
- * @property-read HigherOrderCollectionProxy<'first', TModel> $first
- * @property-read HigherOrderCollectionProxy<'flatMap', TModel> $flatMap
- * @property-read HigherOrderCollectionProxy<'groupBy', TModel> $groupBy
- * @property-read HigherOrderCollectionProxy<'keyBy', TModel> $keyBy
- * @property-read HigherOrderCollectionProxy<'map', TModel> $map
- * @property-read HigherOrderCollectionProxy<'max', TModel> $max
- * @property-read HigherOrderCollectionProxy<'min', TModel> $min
- * @property-read HigherOrderCollectionProxy<'partition', TModel> $partition
- * @property-read HigherOrderCollectionProxy<'reject', TModel> $reject
- * @property-read HigherOrderCollectionProxy<'some', TModel> $some
- * @property-read HigherOrderCollectionProxy<'sortBy', TModel> $sortBy
- * @property-read HigherOrderCollectionProxy<'sortByDesc', TModel> $sortByDesc
- * @property-read HigherOrderCollectionProxy<'skipUntil', TModel> $skipUntil
- * @property-read HigherOrderCollectionProxy<'skipWhile', TModel> $skipWhile
- * @property-read HigherOrderCollectionProxy<'sum', TModel> $sum
- * @property-read HigherOrderCollectionProxy<'takeUntil', TModel> $takeUntil
- * @property-read HigherOrderCollectionProxy<'takeWhile', TModel> $takeWhile
- * @property-read HigherOrderCollectionProxy<'unique', TModel> $unique
- * @property-read HigherOrderCollectionProxy<'until', TModel> $until
+ * @template TValue
+ * @property-read HigherOrderCollectionProxy<'average', TValue> $average
+ * @property-read HigherOrderCollectionProxy<'avg', TValue> $avg
+ * @property-read HigherOrderCollectionProxy<'contains', TValue> $contains
+ * @property-read HigherOrderCollectionProxy<'each', TValue> $each
+ * @property-read HigherOrderCollectionProxy<'every', TValue> $every
+ * @property-read HigherOrderCollectionProxy<'filter', TValue> $filter
+ * @property-read HigherOrderCollectionProxy<'first', TValue> $first
+ * @property-read HigherOrderCollectionProxy<'flatMap', TValue> $flatMap
+ * @property-read HigherOrderCollectionProxy<'groupBy', TValue> $groupBy
+ * @property-read HigherOrderCollectionProxy<'keyBy', TValue> $keyBy
+ * @property-read HigherOrderCollectionProxy<'map', TValue> $map
+ * @property-read HigherOrderCollectionProxy<'max', TValue> $max
+ * @property-read HigherOrderCollectionProxy<'min', TValue> $min
+ * @property-read HigherOrderCollectionProxy<'partition', TValue> $partition
+ * @property-read HigherOrderCollectionProxy<'reject', TValue> $reject
+ * @property-read HigherOrderCollectionProxy<'some', TValue> $some
+ * @property-read HigherOrderCollectionProxy<'sortBy', TValue> $sortBy
+ * @property-read HigherOrderCollectionProxy<'sortByDesc', TValue> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<'skipUntil', TValue> $skipUntil
+ * @property-read HigherOrderCollectionProxy<'skipWhile', TValue> $skipWhile
+ * @property-read HigherOrderCollectionProxy<'sum', TValue> $sum
+ * @property-read HigherOrderCollectionProxy<'takeUntil', TValue> $takeUntil
+ * @property-read HigherOrderCollectionProxy<'takeWhile', TValue> $takeWhile
+ * @property-read HigherOrderCollectionProxy<'unique', TValue> $unique
+ * @property-read HigherOrderCollectionProxy<'until', TValue> $until
  */
 trait EnumeratesValues
 {}

--- a/stubs/EnumeratesValues.stub
+++ b/stubs/EnumeratesValues.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Illuminate\Support\HigherOrderCollectionProxy;
+
+/**
+ * @template TModel
+ * @property-read HigherOrderCollectionProxy<'average', TModel> $average
+ * @property-read HigherOrderCollectionProxy<'avg', TModel> $avg
+ * @property-read HigherOrderCollectionProxy<'contains', TModel> $contains
+ * @property-read HigherOrderCollectionProxy<'each', TModel> $each
+ * @property-read HigherOrderCollectionProxy<'every', TModel> $every
+ * @property-read HigherOrderCollectionProxy<'filter', TModel> $filter
+ * @property-read HigherOrderCollectionProxy<'first', TModel> $first
+ * @property-read HigherOrderCollectionProxy<'flatMap', TModel> $flatMap
+ * @property-read HigherOrderCollectionProxy<'groupBy', TModel> $groupBy
+ * @property-read HigherOrderCollectionProxy<'keyBy', TModel> $keyBy
+ * @property-read HigherOrderCollectionProxy<'map', TModel> $map
+ * @property-read HigherOrderCollectionProxy<'max', TModel> $max
+ * @property-read HigherOrderCollectionProxy<'min', TModel> $min
+ * @property-read HigherOrderCollectionProxy<'partition', TModel> $partition
+ * @property-read HigherOrderCollectionProxy<'reject', TModel> $reject
+ * @property-read HigherOrderCollectionProxy<'some', TModel> $some
+ * @property-read HigherOrderCollectionProxy<'sortBy', TModel> $sortBy
+ * @property-read HigherOrderCollectionProxy<'sortByDesc', TModel> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<'skipUntil', TModel> $skipUntil
+ * @property-read HigherOrderCollectionProxy<'skipWhile', TModel> $skipWhile
+ * @property-read HigherOrderCollectionProxy<'sum', TModel> $sum
+ * @property-read HigherOrderCollectionProxy<'takeUntil', TModel> $takeUntil
+ * @property-read HigherOrderCollectionProxy<'takeWhile', TModel> $takeWhile
+ * @property-read HigherOrderCollectionProxy<'unique', TModel> $unique
+ * @property-read HigherOrderCollectionProxy<'until', TModel> $until
+ */
+trait EnumeratesValues
+{}

--- a/stubs/HigherOrderProxies.stub
+++ b/stubs/HigherOrderProxies.stub
@@ -15,3 +15,10 @@ class HigherOrderTapProxy
     {
     }
 }
+
+/**
+ * @template T
+ * @template TModel
+ */
+class HigherOrderCollectionProxy
+{}

--- a/stubs/HigherOrderProxies.stub
+++ b/stubs/HigherOrderProxies.stub
@@ -18,7 +18,7 @@ class HigherOrderTapProxy
 
 /**
  * @template T
- * @template TModel
+ * @template TValue
  */
 class HigherOrderCollectionProxy
 {}

--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -17,4 +17,9 @@ class Group extends Model
     {
         return $this->hasMany(Account::class);
     }
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
 }

--- a/tests/Application/app/Importer.php
+++ b/tests/Application/app/Importer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Support\Str;
+
+class Importer
+{
+    /** @var bool */
+    public $isImported;
+
+    public function isImported(): bool
+    {
+        return random_int(0,1) > 0;
+    }
+
+    public function import(): bool
+    {
+        return random_int(0,1) > 0;
+    }
+
+    public function getKey(): string
+    {
+        return Str::random(5);
+    }
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -66,6 +66,7 @@ class User extends Authenticatable
         return $this->belongsTo(Group::class);
     }
 
+    /** @phpstan-return HasMany<Account> */
     public function accounts(): HasMany
     {
         return $this->hasMany(Account::class);
@@ -124,5 +125,15 @@ class User extends Authenticatable
     public function getOnlyAvailableWithAccessorAttribute(): string
     {
         return 'foo';
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active === 1;
+    }
+
+    public function setActive(): void
+    {
+        $this->active = 1;
     }
 }

--- a/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
+++ b/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Methods;
+
+use App\Account;
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class HigherOrderCollectionProxyMethods
+{
+    /** @var Collection<User> */
+    public $users;
+
+    public function testAverage(): float
+    {
+        return $this->users->avg->id() + $this->users->average->id();
+    }
+
+    public function testContains(): bool
+    {
+        return $this->users->contains->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testEach(): Collection
+    {
+        return $this->users->each->delete();
+    }
+
+    public function testEvery(): bool
+    {
+        return $this->users->every->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testFilter(): Collection
+    {
+        return $this->users->filter->isActive();
+    }
+
+    public function testFirst(): ?User
+    {
+        return $this->users->first->isActive();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, mixed> */
+    public function testFlatMap(): \Illuminate\Support\Collection
+    {
+        return $this->users->flatMap->isActive();
+    }
+
+    /** @return Collection<Collection<User>> */
+    public function testGroupBy(): Collection
+    {
+        return $this->users->groupBy->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testKeyBy(): Collection
+    {
+        return $this->users->keyBy->isActive();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, bool> */
+    public function testMapWithBoolMethod(): \Illuminate\Support\Collection
+    {
+        return $this->users->map->isActive();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, HasMany<Account>> */
+    public function testMapWithRelationMethod(): \Illuminate\Support\Collection
+    {
+        return $this->users->map->accounts();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, int> */
+    public function testMapWithIntegerMethod(): \Illuminate\Support\Collection
+    {
+        return $this->users->map->id();
+    }
+
+    /** @return array<mixed> */
+    public function testMapOnRelation(User $user): array
+    {
+        return $user->accounts->map->getAttributes()->all();
+    }
+
+    public function testMax(): int
+    {
+        return $this->users->max->id();
+    }
+
+    public function testMin(): int
+    {
+        return $this->users->min->id();
+    }
+
+    /** @return Collection<Collection<User>> */
+    public function testPartition(): Collection
+    {
+        return $this->users->partition->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testReject(): Collection
+    {
+        return $this->users->reject->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testSkipUntil(): Collection
+    {
+        return $this->users->skipUntil->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testSkipWhile(): Collection
+    {
+        return $this->users->skipWhile->isActive();
+    }
+
+    public function testSum(): int
+    {
+        return $this->users->sum->id();
+    }
+
+    /** @return Collection<User> */
+    public function testTakeUntil(): Collection
+    {
+        return $this->users->takeUntil->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testTakeWhile(): Collection
+    {
+        return $this->users->takeWhile->isActive();
+    }
+
+    /** @return Collection<User> */
+    public function testUnique(): Collection
+    {
+        return $this->users->unique->isActive();
+    }
+}

--- a/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
+++ b/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Features\Methods;
 
-use App\Account;
+use App\Importer;
 use App\User;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection as SupportCollection;
 
 class HigherOrderCollectionProxyMethods
 {
@@ -46,8 +46,8 @@ class HigherOrderCollectionProxyMethods
         return $this->users->first->isActive();
     }
 
-    /** @return \Illuminate\Support\Collection<int, mixed> */
-    public function testFlatMap(): \Illuminate\Support\Collection
+    /** @return SupportCollection */
+    public function testFlatMap(): SupportCollection
     {
         return $this->users->flatMap->isActive();
     }
@@ -64,20 +64,20 @@ class HigherOrderCollectionProxyMethods
         return $this->users->keyBy->isActive();
     }
 
-    /** @return \Illuminate\Support\Collection<int, bool> */
-    public function testMapWithBoolMethod(): \Illuminate\Support\Collection
+    /** @return SupportCollection */
+    public function testMapWithBoolMethod(): SupportCollection
     {
         return $this->users->map->isActive();
     }
 
-    /** @return \Illuminate\Support\Collection<int, HasMany<Account>> */
-    public function testMapWithRelationMethod(): \Illuminate\Support\Collection
+    /** @return SupportCollection */
+    public function testMapWithRelationMethod(): SupportCollection
     {
         return $this->users->map->accounts();
     }
 
-    /** @return \Illuminate\Support\Collection<int, int> */
-    public function testMapWithIntegerMethod(): \Illuminate\Support\Collection
+    /** @return SupportCollection */
+    public function testMapWithIntegerMethod(): SupportCollection
     {
         return $this->users->map->id();
     }
@@ -143,5 +143,50 @@ class HigherOrderCollectionProxyMethods
     public function testUnique(): Collection
     {
         return $this->users->unique->isActive();
+    }
+
+    /**
+     * @param SupportCollection $collection
+     *
+     * @return SupportCollection
+     */
+    public function testMapWithSupportCollection(SupportCollection $collection): SupportCollection
+    {
+        return $collection->map->import();
+    }
+
+    /**
+     * @param SupportCollection $collection
+     * @return SupportCollection
+     */
+    public function testEachWithSupportCollection(SupportCollection $collection): SupportCollection
+    {
+        return $collection->each->import();
+    }
+
+    /**
+     * @param SupportCollection $collection
+     * @return SupportCollection
+     */
+    public function testKeyByWithSupportCollection(SupportCollection $collection): SupportCollection
+    {
+        return $collection->keyBy->getKey();
+    }
+
+    /**
+     * @param SupportCollection $collection
+     * @return SupportCollection
+     */
+    public function testFilterWithSupportCollection(SupportCollection $collection): SupportCollection
+    {
+        return $collection->filter->isImported();
+    }
+
+    /**
+     * @return SupportCollection<int, Importer>
+     */
+    public function testFilterWithSupportCollectionWithUnknownType(SupportCollection $collection): SupportCollection
+    {
+        return $collection->filter->isImported(); //Intentional typo
     }
 }

--- a/tests/Features/Properties/HigherOrderCollectionProxyProperties.php
+++ b/tests/Features/Properties/HigherOrderCollectionProxyProperties.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Properties;
+
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+
+class HigherOrderCollectionProxyProperties
+{
+    /** @var Collection<User> */
+    public $users;
+
+    public function testAverage(): float
+    {
+        return $this->users->avg->id + $this->users->average->id;
+    }
+
+    public function testContains(): bool
+    {
+        return $this->users->contains->email;
+    }
+
+    /** @return Collection<User> */
+    public function testEach(): Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->each->email;
+    }
+
+    public function testEvery(): bool
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->every->email;
+    }
+
+    /** @return Collection<User> */
+    public function testFilter(): Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->filter->email;
+    }
+
+    public function testFirst(): ?User
+    {
+        return $this->users->first->email;
+    }
+
+    /** @return \Illuminate\Support\Collection<int, mixed> */
+    public function testFlatMap(): \Illuminate\Support\Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->flatMap->email;
+    }
+
+    /** @return Collection<Collection<User>> */
+    public function testGroupBy(): Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->groupBy->email;
+    }
+
+    /** @return Collection<User> */
+    public function testKeyBy(): Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->keyBy->email;
+    }
+
+    /** @return \Illuminate\Support\Collection<int, string> */
+    public function testMapWithStringProperty(): \Illuminate\Support\Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->map->email;
+    }
+
+    /** @return \Illuminate\Support\Collection<int, ?Carbon> */
+    public function testMapWithCarbonProperty(): \Illuminate\Support\Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->map->created_at;
+    }
+
+    /** @return \Illuminate\Support\Collection<int, int> */
+    public function testMapWithIntegerProperty(): \Illuminate\Support\Collection
+    {
+        // Does not make too much sense, but it should work
+        return $this->users->map->id;
+    }
+
+    public function testMaxWithStringProperty(): string
+    {
+        return $this->users->max->email;
+    }
+
+    public function testMaxWithIntegerProperty(): int
+    {
+        return $this->users->max->id;
+    }
+
+    public function testMaxWithCarbonProperty(): ?Carbon
+    {
+        return $this->users->max->created_at;
+    }
+
+    public function testMinWithStringProperty(): string
+    {
+        return $this->users->min->email;
+    }
+
+    public function testMinWithIntegerProperty(): int
+    {
+        return $this->users->min->id;
+    }
+
+    public function testMinWithCarbonProperty(): ?Carbon
+    {
+        return $this->users->min->created_at;
+    }
+
+    /** @return Collection<Collection<User>> */
+    public function testPartition(): Collection
+    {
+        return $this->users->partition->email;
+    }
+
+    /** @return Collection<User> */
+    public function testReject(): Collection
+    {
+        return $this->users->reject->email;
+    }
+
+    /** @return Collection<User> */
+    public function testSkipUntil(): Collection
+    {
+        return $this->users->skipUntil->email;
+    }
+
+    /** @return Collection<User> */
+    public function testSkipWhile(): Collection
+    {
+        return $this->users->skipWhile->email;
+    }
+
+    public function testSum(): int
+    {
+        return $this->users->sum->id;
+    }
+
+    /** @return Collection<User> */
+    public function testTakeUntil(): Collection
+    {
+        return $this->users->takeUntil->email;
+    }
+
+    /** @return Collection<User> */
+    public function testTakeWhile(): Collection
+    {
+        return $this->users->takeWhile->email;
+    }
+
+    /** @return Collection<User> */
+    public function testUnique(): Collection
+    {
+        return $this->users->unique->email;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Closes #200 

**Changes**

This PR adds support for [HigherOrderCollectionProxy](https://laravel.com/docs/8.x/collections#higher-order-messages)

Larastan now correctly understands, for example
```php
User::all()->each->markAsActive();
```
returns a collection and `markAsActive` is called on `User` class

**Breaking changes**

None
