### PR TITLE
Add Illuminate\Database\Query\Expression to stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Support for HigherOrderCollectionProxy ([#781](https://github.com/nunomaduro/larastan/pull/781))
+- SUpport for Illuminate\Database\Query\Expression as column ([#784](https://github.com/nunomaduro/larastan/issues/784))
 
 ## [0.7.0] - 2021-02-01
 ### Changed

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -132,7 +132,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>  $column
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -153,7 +153,7 @@ class Builder
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>  $column
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -180,7 +180,7 @@ class Builder
     /**
      * Get a single column's value from the first result of a query.
      *
-     * @param  model-property<TModelClass>  $column
+     * @param  model-property<TModelClass>|\Illuminate\Database\Query\Expression  $column
      * @return mixed
      */
     public function value($column);

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -143,7 +143,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -143,7 +143,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|model-property<TModelClass>|array<model-property<TModelClass>|int, mixed>  $column
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -946,7 +946,7 @@ class Builder
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this
      */
     public function latest($column = 'created_at')
@@ -955,7 +955,7 @@ class Builder
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this
      */
     public function oldest($column = 'created_at')
@@ -1134,7 +1134,7 @@ class Builder
     /**
      * Get an array with the values of a given column.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection<string, mixed>
      */
@@ -1341,7 +1341,7 @@ class Builder
     /**
      * Increment a column's value by a given amount.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  float|int  $amount
      * @param  array<string, mixed>  $extra
      * @return int
@@ -1354,7 +1354,7 @@ class Builder
     /**
      * Decrement a column's value by a given amount.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  float|int  $amount
      * @param  array<string, mixed>  $extra
      * @return int

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -7,6 +7,7 @@ namespace Tests\Features\Methods;
 use App\User;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
 use stdClass;
 
 class Builder
@@ -69,5 +70,49 @@ class Builder
     public function testWithTrashedOnBuilderWithModel(): EloquentBuilder
     {
         return User::query()->withTrashed();
+    }
+
+    public function testOrderByToBaseWithQueryExpression(): ?QueryBuilder
+    {
+        return User::whereNull('name')
+            ->orderBy(\Illuminate\Support\Facades\DB::raw('name'))
+            ->toBase();
+    }
+
+    public function testLatestToBaseWithQueryExpression(): ?QueryBuilder
+    {
+        return User::whereNull('name')
+            ->latest(\Illuminate\Support\Facades\DB::raw('created_at'))
+            ->toBase();
+    }
+
+    public function testOldestToBaseWithQueryExpression(): ?QueryBuilder
+    {
+        return User::whereNull('name')
+            ->oldest(\Illuminate\Support\Facades\DB::raw('created_at'))
+            ->toBase();
+    }
+
+    public function testPluckToBaseWithQueryExpression(): ?Collection
+    {
+        return User::whereNull('name')
+            ->pluck(\Illuminate\Support\Facades\DB::raw('created_at'))
+            ->toBase();
+    }
+
+    public function testIncrementWithQueryExpression(): int
+    {
+        /** @var User $user */
+        $user = new User;
+
+        return $user->increment(\Illuminate\Support\Facades\DB::raw('counter'));
+    }
+
+    public function testDecrementWithQueryExpression(): int
+    {
+        /** @var User $user */
+        $user = new User;
+
+        return $user->decrement(\Illuminate\Support\Facades\DB::raw('counter'));
     }
 }

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -305,6 +305,19 @@ class ModelExtension
             ->orWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%')
             ->first();
     }
+
+    public function testWhereWithQueryExpression(): ?User
+    {
+        return User::with('foo')
+            ->where(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%')
+            ->first();
+    }
+
+    public function testFirstWhereWithQueryExpression(): ?User
+    {
+        return User::with('foo')
+            ->firstWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%');
+    }
 }
 
 function foo(): string

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -298,6 +298,13 @@ class ModelExtension
     {
         return User::where('id', '>', 5)->newQuery();
     }
+
+    public function testOrWhereWithQueryExpression(): ?User
+    {
+        return User::with('foo')
+            ->orWhere(\Illuminate\Support\Facades\DB::raw('name LIKE \'%john%\''))
+            ->first();
+    }
 }
 
 function foo(): string

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -302,7 +302,7 @@ class ModelExtension
     public function testOrWhereWithQueryExpression(): ?User
     {
         return User::with('foo')
-            ->orWhere(\Illuminate\Support\Facades\DB::raw('name LIKE \'%john%\''))
+            ->orWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%')
             ->first();
     }
 }

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -318,6 +318,12 @@ class ModelExtension
         return User::with('foo')
             ->firstWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%');
     }
+
+    public function testValueWithQueryExpression(): ?string
+    {
+        return User::with('foo')
+            ->value(\Illuminate\Support\Facades\DB::raw('name'));
+    }
 }
 
 function foo(): string

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -166,12 +166,6 @@ class BuilderExtension
     {
         return User::fromQuery('SELECT * FROM users');
     }
-
-    public function testOrWhereWithQueryExpression(): Builder
-    {
-        return User::with('foo')
-            ->orWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', 'baz');
-    }
 }
 
 /**

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -170,7 +170,7 @@ class BuilderExtension
     public function testOrWhereWithQueryExpression(): Builder
     {
         return User::with('foo')
-            ->orWhere(\Illuminate\Support\Facades\DB::raw('name LIKE \'%baz%\''));
+            ->orWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', 'baz');
     }
 }
 

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -166,6 +166,12 @@ class BuilderExtension
     {
         return User::fromQuery('SELECT * FROM users');
     }
+
+    public function testOrWhereWithQueryExpression(): Builder
+    {
+        return User::with('foo')
+            ->orWhere(\Illuminate\Support\Facades\DB::raw('name LIKE \'%baz%\''));
+    }
 }
 
 /**


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Resolves #784

**Changes**

Adds the `Illuminate\Database\Query\Expression` as DocBlock parameter to the `orWhere()` stub (more stubs will follow once this is in an acceptable and tested state).

**Breaking changes**

I don't believe anything breaks with these changes?
