### PR TITLE
feat: support for `when` and `unless` methods on Eloquent builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for HigherOrderCollectionProxy ([#781](https://github.com/nunomaduro/larastan/pull/781))
 - SUpport for Illuminate\Database\Query\Expression as column ([#784](https://github.com/nunomaduro/larastan/issues/784))
+- Support for `when` and `unless` methods on Eloquent builder ([#791](https://github.com/nunomaduro/larastan/pull/791))
 
 ## [0.7.0] - 2021-02-01
 ### Changed

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -184,4 +184,24 @@ class Builder
      * @return mixed
      */
     public function value($column);
+
+    /**
+     * Apply the callback's query changes if the given "value" is true.
+     *
+     * @param mixed  $value
+     * @param callable($this, mixed): null|Builder<TModelClass> $callback
+     * @param callable($this, mixed): null|Builder<TModelClass>|null  $default
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null);
+
+    /**
+     * Apply the callback's query changes if the given "value" is false.
+     *
+     * @param  mixed  $value
+     * @param  callable($this, mixed): null|Builder<TModelClass>  $callback
+     * @param  callable($this, mixed): null|Builder<TModelClass>|null  $default
+     * @return mixed|$this
+     */
+    public function unless($value, $callback, $default = null);
 }

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -115,4 +115,30 @@ class Builder
 
         return $user->decrement(\Illuminate\Support\Facades\DB::raw('counter'));
     }
+
+    /** @phpstan-return null|EloquentBuilder<User> */
+    public function testWhen(bool $foo): ?EloquentBuilder
+    {
+        $innerQuery = null;
+        User::query()->when($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
+            $innerQuery = $query;
+
+            return $query->active();
+        });
+
+        return $innerQuery;
+    }
+
+    /** @phpstan-return null|EloquentBuilder<User> */
+    public function testUnless(bool $foo): ?EloquentBuilder
+    {
+        $innerQuery = null;
+        User::query()->unless($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
+            $innerQuery = $query;
+
+            return $query->active();
+        });
+
+        return $innerQuery;
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

This PR adds support for `when` and `unless` methods on Eloquent builder.

**Breaking changes**
n/a
