### PR TITLE
Fix when and unless return value

### DIFF
--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -189,8 +189,8 @@ class Builder
      * Apply the callback's query changes if the given "value" is true.
      *
      * @param mixed  $value
-     * @param callable($this, mixed): null|Builder<TModelClass> $callback
-     * @param callable($this, mixed): null|Builder<TModelClass>|null  $default
+     * @param callable($this, mixed): (null|Builder<TModelClass>) $callback
+     * @param callable($this, mixed): (null|Builder<TModelClass>)|null  $default
      * @return mixed|$this
      */
     public function when($value, $callback, $default = null);
@@ -199,8 +199,8 @@ class Builder
      * Apply the callback's query changes if the given "value" is false.
      *
      * @param  mixed  $value
-     * @param  callable($this, mixed): null|Builder<TModelClass>  $callback
-     * @param  callable($this, mixed): null|Builder<TModelClass>|null  $default
+     * @param  callable($this, mixed): (null|Builder<TModelClass>)  $callback
+     * @param  callable($this, mixed): (null|Builder<TModelClass>)|null  $default
      * @return mixed|$this
      */
     public function unless($value, $callback, $default = null);

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -52,10 +52,10 @@ class Builder
     public function testQueryBuilderChainStartedWithGetQueryReturnsStdClass(): ?stdClass
     {
         return User::getQuery()
-        ->select('some_model.created')
-        ->where('some_model.some_column', '=', true)
-        ->orderBy('some_model.created', 'desc')
-        ->first();
+            ->select('some_model.created')
+            ->where('some_model.some_column', '=', true)
+            ->orderBy('some_model.created', 'desc')
+            ->first();
     }
 
     public function testWhereNotBetweenInt(): QueryBuilder
@@ -121,9 +121,10 @@ class Builder
     {
         $innerQuery = null;
         User::query()->when($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
+            /** @phpstan-var EloquentBuilder<User> $query */
             $innerQuery = $query;
 
-            return $query->active();
+            return $query->whereNull('name');
         });
 
         return $innerQuery;
@@ -134,9 +135,10 @@ class Builder
     {
         $innerQuery = null;
         User::query()->unless($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
+            /** @phpstan-var EloquentBuilder<User> $query */
             $innerQuery = $query;
 
-            return $query->active();
+            return $query->whereNull('name');
         });
 
         return $innerQuery;


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
This PR fixes the return value validation for the when and unless methods on the Models

I'm also not sure about this whole feature as it does what the `when` method should do but not what it actually can.

A more realistic (and invalid) version:
```php
    /**
     * Apply the callback's query changes if the given "value" is true.
     *
     * @template TValue
     * @template TCallbackResult
     * @template TDefaultResult
     *
     * @param TValue  $value
     * @param callable($this, TValue): TCallbackResult $callback
     * @param callable($this, TValue): TDefaultResult|null  $default
     * @return TCallbackResult|TDefaultResult|$this
     */
    public function when($value, $callback, $default = null);
```

Or a valid version: A more realistic (and invalid) version:
```php
    /**
     * Apply the callback's query changes if the given "value" is true.
     *
     * @param mixed  $value
     * @param callable($this, mixed): mixed $callback
     * @param callable($this, mixed): mixed $default
     * @return mixed|$this
     */
    public function when($value, $callback, $default = null);
```
<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None
