### PR TITLE
feat: Octane compatibility checking rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3] - 2021-04-12
+
+### Added
+
+- Octane compatibility checking rule ([#809](https://github.com/nunomaduro/larastan/pull/809))
+
 ## [0.7.2] - 2021-04-08
 
 ### Fixed
@@ -538,7 +544,8 @@ Upgrade guide: [UPGRADE.md](https://github.com/nunomaduro/larastan/blob/master/U
 ### Added
 - Adds first alpha version
 
-[Unreleased]: https://github.com/nunomaduro/larastan/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/nunomaduro/larastan/compare/v0.7.3...HEAD
+[0.7.2]: https://github.com/nunomaduro/larastan/compare/v0.7.2...0.7.3
 [0.7.2]: https://github.com/nunomaduro/larastan/compare/v0.7.1...0.7.2
 [0.7.1]: https://github.com/nunomaduro/larastan/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/nunomaduro/larastan/compare/v0.6.13...v0.7.0

--- a/extension.neon
+++ b/extension.neon
@@ -44,6 +44,7 @@ parameters:
     bootstrapFiles:
         - bootstrap.php
     checkGenericClassInNonGenericObjectType: false
+    checkOctaneCompatibility: false
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
@@ -51,6 +52,7 @@ parameters:
     checkModelProperties: false
 
 parametersSchema:
+    checkOctaneCompatibility: bool()
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
@@ -60,6 +62,8 @@ parametersSchema:
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
+    NunoMaduro\Larastan\Rules\OctaneCompatibilityRule:
+        phpstan.rules.rule: %checkOctaneCompatibility%
     NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyRule:
         phpstan.rules.rule: %checkModelProperties%
     NunoMaduro\Larastan\Rules\ModelProperties\ModelPropertyStaticCallRule:
@@ -307,6 +311,9 @@ services:
         class: NunoMaduro\Larastan\Types\ViewStringTypeNodeResolverExtension
         tags:
             - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
+        class: NunoMaduro\Larastan\Rules\OctaneCompatibilityRule
 
     -
         class: NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule

--- a/src/Rules/OctaneCompatibilityRule.php
+++ b/src/Rules/OctaneCompatibilityRule.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules;
+
+use Illuminate\Contracts\Foundation\Application;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+class OctaneCompatibilityRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /** @param MethodCall $node */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (! in_array($node->name->name, ['singleton', 'bind'], true)) {
+            return [];
+        }
+
+        $args = $node->args;
+
+        if (count($args) < 2) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+
+        if (! $calledOnType instanceof ObjectType) {
+            return [];
+        }
+
+        if ($calledOnType->getClassName() !== Application::class &&
+            ! (new ObjectType(Application::class))->isSuperTypeOf($calledOnType)->yes()
+        ) {
+            return [];
+        }
+
+        if (! $args[1]->value instanceof Node\Expr\Closure) {
+            return [];
+        }
+
+        /** @var Node\Expr\Closure $closure */
+        $closure = $args[1]->value;
+
+        /** @var Node\Param[] $closureParams */
+        $closureParams = $closure->getParams();
+
+        // Closure should have at least one parameter. First param
+        // is container, second is parameters. If no parameter
+        // is given we will check for the usage of `$this->app`
+        if (count($closureParams) < 1) {
+            return $this->checkForThisAppUsage($scope, $closure);
+        }
+
+        // Using `$app` with `bind` is ok, so we return early
+        if ($node->name->name === 'bind') {
+            return [];
+        }
+
+        if (! $closureParams[0]->var instanceof Node\Expr\Variable) {
+            return [];
+        }
+
+        $containerParameterName = $closureParams[0]->var->name;
+
+        $nodes = (new NodeFinder)->find($closure->getStmts(), function (Node $node) use ($containerParameterName): bool {
+            if (! $node instanceof Node\Expr\New_) {
+                return false;
+            }
+
+            if (count($node->args) < 1) {
+                return false;
+            }
+
+            if (! $node->args[0]->value instanceof Node\Expr\Variable && ! $node->args[0]->value instanceof Node\Expr\ArrayDimFetch) {
+                return false;
+            }
+
+            if ($node->args[0]->value instanceof Node\Expr\ArrayDimFetch) {
+                /** @var Node\Expr\Variable $var */
+                $var = $node->args[0]->value->var;
+
+                if ($var->name !== $containerParameterName) {
+                    return false;
+                }
+
+                if ($node->args[0]->value->dim === null) {
+                    return false;
+                }
+
+                if (! $node->args[0]->value->dim instanceof Node\Scalar\String_) {
+                    return false;
+                }
+
+                return in_array($node->args[0]->value->dim->value, ['request', 'config'], true);
+            }
+
+            if ($node->args[0]->value->name !== $containerParameterName) {
+                return false;
+            }
+
+            return true;
+        });
+
+        if (count($nodes) > 0) {
+            $errors = [];
+
+            foreach ($nodes as $node) {
+                $errors[] = RuleErrorBuilder::message('Consider using bind method instead or pass a closure.')
+                    ->identifier('rules.octane')->tip('See: https://github.com/laravel/octane#dependency-injection--octane')->line($node->getAttribute('startLine'))->build();
+            }
+
+            return $errors;
+        }
+
+        return [];
+    }
+
+    /** @return \PHPStan\Rules\RuleError[] */
+    private function checkForThisAppUsage(Scope $scope, Node\Expr\Closure $closure): array
+    {
+        $nodes = (new NodeFinder)->find($closure->getStmts(), function (Node $node): bool {
+            return $node instanceof Node\Expr\PropertyFetch &&
+                $node->var instanceof Node\Expr\Variable &&
+                $node->var->name === 'this' &&
+                $node->name instanceof Node\Identifier &&
+                $node->name->name === 'app';
+        });
+
+        if (count($nodes) > 0) {
+            $errors = [];
+
+            foreach ($nodes as $node) {
+                $errors[] = RuleErrorBuilder::message('Consider using bind method instead or pass a closure.')
+                    ->identifier('rules.octane')->tip('See: https://github.com/laravel/octane#dependency-injection--octane')->line($node->getAttribute('startLine'))->build();
+            }
+
+            return $errors;
+        }
+
+        return [];
+    }
+}

--- a/tests/Rules/Data/ContainerInjection.php
+++ b/tests/Rules/Data/ContainerInjection.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Foundation\Application;
+
+class FooServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(Service::class, function () {
+            return new Service($this->app);
+        });
+
+        $this->app->bind(Service::class, function () {
+            return new Service($this->app);
+        });
+
+        // This is fine
+        $this->app->bind(Service::class, function ($app) {
+            return new Service($app);
+        });
+
+        $this->app->singleton(Service::class, function ($app) {
+            return new Service($app);
+        });
+
+        $this->app->singleton(Service::class, function ($app) {
+            return new Service($app['request']);
+        });
+
+        $this->app->singleton(Service::class, function ($app) {
+            return new Service($app['config']);
+        });
+
+        // This is fine
+        $this->app->singleton(Service::class, function ($app) {
+            return new Service($app['session']);
+        });
+    }
+}
+
+function foo(Application $app): void
+{
+    $app->singleton(Service::class, function ($app) {
+        return new Service($app);
+    });
+}
+
+(new \Illuminate\Foundation\Application())->singleton(Service::class, function ($app) {
+    return new Service($app);
+});
+
+class Service
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+}

--- a/tests/Rules/Data/octane.neon
+++ b/tests/Rules/Data/octane.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    checkOctaneCompatibility: true

--- a/tests/Rules/OctaneCompatibilityRuleTest.php
+++ b/tests/Rules/OctaneCompatibilityRuleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Tests\RulesTest;
+
+class OctaneCompatibilityRuleTest extends RulesTest
+{
+    public function testNoContainerInjection(): void
+    {
+        $errors = $this->setConfigPath(__DIR__.'/Data/octane.neon')->findErrorsByLine(__DIR__.'/Data/ContainerInjection.php');
+
+        $this->assertEquals([
+            12 => 'Consider using bind method instead or pass a closure.',
+            16 => 'Consider using bind method instead or pass a closure.',
+            25 => 'Consider using bind method instead or pass a closure.',
+            29 => 'Consider using bind method instead or pass a closure.',
+            33 => 'Consider using bind method instead or pass a closure.',
+            46 => 'Consider using bind method instead or pass a closure.',
+            51 => 'Consider using bind method instead or pass a closure.',
+        ], $errors);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #802

**Changes**

This PR adds an optional rule that can check for [Octane](https://github.com/laravel/octane) compatibility.

It's an optional rule. You need to add `checkOctaneCompatibility: true` to your `parameters` array in the config file.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
none
