### PR TITLE
Update link to Octane dependency injection docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Update link to Octane dependency injection docs ([#829](https://github.com/nunomaduro/larastan/pull/829))
+
 ## [0.7.5] - 2021-04-29
 
 ### Added

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -111,7 +111,8 @@ takesOnlyUserModelProperties('emaiil');
 
 ## OctaneCompatibilityRule
 
-This is an optional rule that can check your application for Laravel Octane compatibility. You can read more about why in the official [Octane docs](https://github.com/laravel/octane#dependency-injection--octane).
+This is an optional rule that can check your application for Laravel Octane compatibility.
+You can read more about why in [the official Octane docs](https://laravel.com/docs/octane#dependency-injection-and-octane).
 
 ### Configuration
 

--- a/src/Rules/OctaneCompatibilityRule.php
+++ b/src/Rules/OctaneCompatibilityRule.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 
@@ -120,14 +121,7 @@ class OctaneCompatibilityRule implements Rule
         });
 
         if (count($nodes) > 0) {
-            $errors = [];
-
-            foreach ($nodes as $node) {
-                $errors[] = RuleErrorBuilder::message('Consider using bind method instead or pass a closure.')
-                    ->identifier('rules.octane')->tip('See: https://github.com/laravel/octane#dependency-injection--octane')->line($node->getAttribute('startLine'))->build();
-            }
-
-            return $errors;
+            return array_map([$this, 'dependencyInjectionError'], $nodes);
         }
 
         return [];
@@ -145,16 +139,18 @@ class OctaneCompatibilityRule implements Rule
         });
 
         if (count($nodes) > 0) {
-            $errors = [];
-
-            foreach ($nodes as $node) {
-                $errors[] = RuleErrorBuilder::message('Consider using bind method instead or pass a closure.')
-                    ->identifier('rules.octane')->tip('See: https://github.com/laravel/octane#dependency-injection--octane')->line($node->getAttribute('startLine'))->build();
-            }
-
-            return $errors;
+            return array_map([$this, 'dependencyInjectionError'], $nodes);
         }
 
         return [];
+    }
+
+    private function dependencyInjectionError(Node $node): RuleError
+    {
+        return RuleErrorBuilder::message('Consider using bind method instead or pass a closure.')
+            ->identifier('rules.octane')
+            ->tip('See: https://laravel.com/docs/octane#dependency-injection-and-octane')
+            ->line($node->getAttribute('startLine'))
+            ->build();
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

I was trying to use https://github.com/nunomaduro/larastan/blob/master/docs/rules.md?rgh-link-date=2021-05-07T06%3A38%3A08Z#octanecompatibilityrule in a project, found some errors and followed the link. I then found that the docs has since been moved from the projects `README.md` to the Laravel docs website.

**Breaking changes**

No.
