### PR TITLE
feat: adds support for detecting nested trait usage for SoftDeletes trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "ext-json": "^8.0",
+        "ext-json": "*",
         "composer/composer": "^1.0 || ^2.0",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/container": "^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "ext-json": "^8.0",
         "composer/composer": "^1.0 || ^2.0",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/container": "^6.0 || ^7.0 || ^8.0 || ^9.0",
@@ -21,9 +22,8 @@
         "illuminate/pipeline": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "mockery/mockery": "^0.9 || ^1.0",
-        "phpstan/phpstan": "^0.12.83",
-        "symfony/process": "^4.3 || ^5.0",
-        "ext-json": "*"
+        "phpstan/phpstan": "^0.12.90",
+        "symfony/process": "^4.3 || ^5.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -103,7 +103,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             // Special case for `SoftDeletes` trait
             if (
                 in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed'], true) &&
-                in_array(SoftDeletes::class, $this->collectTraitNames($modelReflection->getNativeReflection()))
+                in_array(SoftDeletes::class, array_keys($modelReflection->getTraits(true)))
             ) {
                 $ref = $this->reflectionProvider->getClass(SoftDeletes::class)->getMethod($methodName, new OutOfClassScope());
 
@@ -143,33 +143,5 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             new GenericObjectType($classReflection->getName(), [$modelType]),
             $parametersAcceptor->isVariadic()
         );
-    }
-
-    /**
-     * @param ReflectionClass<object> $class
-     *
-     * @return string[]
-     */
-    private function collectTraitNames(ReflectionClass $class): array
-    {
-        $traits = [];
-        $traitsLeftToAnalyze = $class->getTraits();
-
-        while (count($traitsLeftToAnalyze) !== 0) {
-            $trait = reset($traitsLeftToAnalyze);
-            $traits[] = $trait->getName();
-
-            foreach ($trait->getTraits() as $subTrait) {
-                if (in_array($subTrait->getName(), $traits, \true)) {
-                    continue;
-                }
-
-                $traitsLeftToAnalyze[] = $subTrait;
-            }
-
-            array_shift($traitsLeftToAnalyze);
-        }
-
-        return $traits;
     }
 }

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -169,6 +169,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
             array_shift($traitsLeftToAnalyze);
         }
+
         return $traits;
     }
 }

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -22,7 +22,6 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
-use ReflectionClass;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {

--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -2,16 +2,16 @@
 
 namespace App;
 
+use App\Traits\NestedSoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property string $name
  */
 class Group extends Model
 {
-    use SoftDeletes;
+    use NestedSoftDeletes;
 
     /** @phpstan-return HasMany<Account> */
     public function accounts(): HasMany

--- a/tests/Application/app/Traits/NestedSoftDeletes.php
+++ b/tests/Application/app/Traits/NestedSoftDeletes.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+trait NestedSoftDeletes
+{
+    use SoftDeletes;
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -63,7 +63,7 @@ class User extends Authenticatable
     /** @phpstan-return BelongsTo<Group, User> */
     public function group(): BelongsTo
     {
-        return $this->belongsTo(Group::class);
+        return $this->belongsTo(Group::class)->withTrashed();
     }
 
     /** @phpstan-return HasMany<Account> */


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

Related to #837 

**Changes**

- Use recursive `$modelReflection->getTraits(true)` instead of `$modelReflection->hasTraitUse()`

Tests:
- Added `NestedSoftDeletes` trait
- Groups model now uses `NestedSoftDeletes` instead of `SoftDeletes`
- Added `->withThrashed` to the Users Group relation to add a test case

**Breaking changes**

None
