### PR TITLE
feat: use `checkExplicitMixed` PHPStan option when running tests

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -165,8 +165,8 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
      */
     private function getReadableAndWritableTypes(SchemaColumn $column, Model $modelInstance): array
     {
-        $readableType = 'mixed';
-        $writableType = 'mixed';
+        $readableType = $column->readableType;
+        $writableType = $column->writeableType;
 
         if (in_array($column->name, $modelInstance->getDates(), true)) {
             return [$this->getDateClass().($column->nullable ? '|null' : ''), $this->getDateClass().'|string'.($column->nullable ? '|null' : '')];

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -206,7 +206,8 @@ class Builder
             ->firstWhere(\Illuminate\Support\Facades\DB::raw('name'), 'like', '%john%');
     }
 
-    public function testValueWithQueryExpression(): ?string
+    /** @phpstan-return mixed */
+    public function testValueWithQueryExpression()
     {
         return User::with('foo')
             ->value(\Illuminate\Support\Facades\DB::raw('name'));

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -251,7 +251,8 @@ class ModelExtension
         return Thread::methodReturningUnionWithCollectionOfAnotherModel();
     }
 
-    public function testMin(User $user): int
+    /** @phpstan-return mixed */
+    public function testMin(User $user)
     {
         return $user->min('id');
     }

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -74,7 +74,8 @@ class ModelPropertyExtension
         return $this->user->meta;
     }
 
-    public function testKnownColumnNameWithUnknownType(): string
+    /** @return mixed */
+    public function testKnownColumnNameWithUnknownType()
     {
         $this->user->unknown_column = 5;
         $this->user->unknown_column = 'foo';

--- a/tests/Features/ReturnTypes/BuilderExtension.php
+++ b/tests/Features/ReturnTypes/BuilderExtension.php
@@ -72,11 +72,12 @@ class BuilderExtension
         return $builder->whereNotNull('test');
     }
 
-    public function testMax(): int
+    /** @phpstan-return mixed */
+    public function testMax()
     {
         $user = new User;
 
-        return (int) $user->where('email', 1)->max('email');
+        return $user->where('email', 1)->max('email');
     }
 
     public function testExists(): bool

--- a/tests/Features/ReturnTypes/CollectionStub.php
+++ b/tests/Features/ReturnTypes/CollectionStub.php
@@ -56,9 +56,9 @@ class CollectionStub
 
     /**
      * @param EloquentCollection<User> $collection
-     * @return int|null
+     * @return mixed
      */
-    public function testPluck(EloquentCollection $collection): ?int
+    public function testPluck(EloquentCollection $collection)
     {
         return $collection->pluck('id')->first();
     }

--- a/tests/Features/ReturnTypes/ModelExtension.php
+++ b/tests/Features/ReturnTypes/ModelExtension.php
@@ -81,6 +81,7 @@ class ModelExtension
     /** @phpstan-return Collection<User>|null */
     public function testFindWithCastingToArray(FormRequest $request): ?Collection
     {
+        /** @var array<string, string> $requestData */
         $requestData = $request->validated();
 
         return User::find((array) $requestData['user_ids']);

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -45,19 +45,16 @@ class CorrectCollectionCalls
         return User::firstOrFail()->accounts()->first();
     }
 
-    public function maxQuery(): int
+    /** @phpstan-return mixed */
+    public function maxQuery()
     {
         return DB::table('users')->max('id');
     }
 
-    public function collectionCalls(): int
+    /** @phpstan-return mixed */
+    public function collectionCalls()
     {
         return collect([1, 2, 3])->flip()->reverse()->sum();
-    }
-
-    public function mixedReturn(): ?Foo
-    {
-        return Foo::query()->returnMixed()->first();
     }
 
     /**
@@ -82,7 +79,8 @@ class CorrectCollectionCalls
         });
     }
 
-    public function testAggregateNoArgs(): int
+    /** @phpstan-return mixed */
+    public function testAggregateNoArgs()
     {
         return User::query()
             ->select([DB::raw('COUNT(*) as temp')])
@@ -90,7 +88,8 @@ class CorrectCollectionCalls
             ->sum();
     }
 
-    public function testRelationAggregate(User $user): int
+    /** @phpstan-return mixed */
+    public function testRelationAggregate(User $user)
     {
         return $user->group()
             ->withCount(['accounts' => function ($query) {

--- a/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
@@ -90,7 +90,8 @@ class UnnecessaryCollectionCallsEloquent
         return User::query()->get()->containsStrict('id', 1);
     }
 
-    public function testSum(): int
+    /** @phpstan-return mixed */
+    public function testSum()
     {
         return User::pluck('id')->sum();
     }

--- a/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsQuery.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Facades\DB;
 
 class UnnecessaryCollectionCallsQuery
 {
-    public function queryMax(): int
+    /** @phpstan-return mixed */
+    public function queryMax()
     {
         return DB::table('users')->get()->max('id');
     }

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -34,7 +34,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
             77 => 'Called \'diff\' on Laravel collection, but could have been retrieved as a query.',
             85 => 'Called \'modelKeys\' on Laravel collection, but could have been retrieved as a query.',
             90 => 'Called \'containsStrict\' on Laravel collection, but could have been retrieved as a query.',
-            95 => 'Called \'sum\' on Laravel collection, but could have been retrieved as a query.',
+            96 => 'Called \'sum\' on Laravel collection, but could have been retrieved as a query.',
         ], $errors);
     }
 

--- a/tests/phpstan-tests.neon
+++ b/tests/phpstan-tests.neon
@@ -1,6 +1,7 @@
 includes:
     - ../extension.neon
 parameters:
+    checkExplicitMixed: true
     ignoreErrors:
         - '#Return typehint of method Tests\\Features\\ReturnTypes\\Facades::testHttpBaseUrl\(\) has invalid type Illuminate\\Http\\Client\\PendingRequest\.#'
         - '#Call to static method baseUrl\(\) on an unknown class Illuminate\\Support\\Facades\\Http\.#'


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md



**Changes**
This PR uses `checkExplicitMixed` PHPStan option when running tests. This can help us catch some false positives. Already caught a bug regarding model property type casting.

**Breaking changes**

n/a
