### PR TITLE
Correct package suggestion description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^7.3 || ^8.2 || ^9.3"
     },
     "suggest": {
-        "orchestra/testbench": "^4.0 || ^5.0"
+        "orchestra/testbench": "For analysing Laravel packages"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Resolves: https://github.com/nunomaduro/larastan/issues/845

**Changes**

Correct package suggestion description, second parameter does not indicate version: https://getcomposer.org/doc/04-schema.md#suggest 

```
$ composer require --dev nunomaduro/larastan
1 package suggestions were added by new dependencies, use `composer suggest` to see details.
```

Before:
```
$ composer suggest
nunomaduro/larastan suggests:
 - orchestra/testbench: ^4.0 || ^5.0
```
After:
```
$ composer suggest
nunomaduro/larastan suggests:
 - orchestra/testbench: For analysing Laravel packages
```