### PR TITLE
feat: add support for vendor-dir

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -35,7 +35,8 @@ final class ApplicationResolver
         if (file_exists($composerFile)) {
             self::$composer = json_decode((string) file_get_contents($composerFile), true);
             $namespace = (string) key(self::$composer['autoload']['psr-4']);
-            $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace, dirname($composerFile)), function (string $class) use (
+            $vendorDir = self::$composer['config']['vendor-dir'] ?? dirname($composerFile).DIRECTORY_SEPARATOR.'vendor';
+            $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace, $vendorDir), function (string $class) use (
                 $namespace
             ) {
                 /** @var class-string $class */
@@ -86,9 +87,9 @@ final class ApplicationResolver
      * @return string[]
      * @throws \ReflectionException
      */
-    private static function getProjectClasses(string $namespace, string $rootDir): array
+    private static function getProjectClasses(string $namespace, string $vendorDir): array
     {
-        $projectDirs = self::getProjectSearchDirs($namespace, $rootDir);
+        $projectDirs = self::getProjectSearchDirs($namespace, $vendorDir);
         /** @var string[] $maps */
         $maps = [];
         // Use composer's ClassMapGenerator to pull the class list out of each project search directory
@@ -121,14 +122,14 @@ final class ApplicationResolver
 
     /**
      * @param string $namespace
-     * @param string $rootDir
+     * @param string $vendorDir
      *
      * @return string[]
      * @throws \ReflectionException
      */
-    private static function getProjectSearchDirs(string $namespace, string $rootDir): array
+    private static function getProjectSearchDirs(string $namespace, string $vendorDir): array
     {
-        $composerDir = $rootDir.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer';
+        $composerDir = $vendorDir.DIRECTORY_SEPARATOR.'composer';
 
         $file = $composerDir.DIRECTORY_SEPARATOR.'autoload_psr4.php';
         $raw = include $file;


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Changed `$rootDir` to `$vendorDir` and use `self::$composer['config']['vendor-dir']` if exists in `ApplicationResolver.php`.
This PR adds support for https://getcomposer.org/doc/06-config.md#vendor-dir.

Without this PR I encountered an error, because we have our app files in laravel/app and the vendor dir is laravel/vendor.
Our Laravel project has a bootstrap file, but couldn't read it for the same reason. (I know it's a rare case, but I believe this PR helps other people using "vendor-dir")
```
ErrorException thrown in /var/source/app/laravel/vendor/nunomaduro/larastan/src/ApplicationResolver.php on line 134 while loading bootstrap file /var/source/app/laravel/vendor/nunomaduro/larastan/bootstrap.php: include(/var/source/app/vendor/composer/autoload_psr4.php): failed to open stream: No such file or directory
```

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

This won't break any existing features, because it would fallback to the general behaviour if the `self::$composer['config']['vendor-dir']` doesn't exist.
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
