### PR TITLE
change bootstrap path

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ use NunoMaduro\Larastan\ApplicationResolver;
 
 define('LARAVEL_START', microtime(true));
 
-if (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applications and Local Dev
+if (file_exists($applicationPath = __DIR__.'/../../../bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
 } else { // Packages
     $app = ApplicationResolver::resolve();


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Changes `getcwd()` to `__DIR__.'/../../../'` in `bootstrap.php`

In Laravel, [basePath is configureable](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Application.php#L170), so `getcwd()` might not be the basePath.

[bootstrapPath](https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Foundation/Application.php#L368-L371) and [vendorPath](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/PackageManifest.php#L58) are hardcoded and cannot be changed, so I think it is better to find Laravel bootstrap file by relative path.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

I believe there are no breaking changes, but not sure enough.
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
