### PR TITLE
fix bootstrap path

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ use NunoMaduro\Larastan\ApplicationResolver;
 
 define('LARAVEL_START', microtime(true));
 
-if (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applications and Local Dev
+if (file_exists($applicationPath = __DIR__.'/../../../bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
 } else { // Packages
     $app = ApplicationResolver::resolve();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ use NunoMaduro\Larastan\ApplicationResolver;
 
 define('LARAVEL_START', microtime(true));
 
-if (file_exists($applicationPath = __DIR__.'/../../../bootstrap/app.php')) { // Applications and Local Dev
+if (file_exists($applicationPath = dirname(__DIR__, 3).'/bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
 } else { // Packages
     $app = ApplicationResolver::resolve();

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -22,6 +22,9 @@ echo "Test Laravel"
 vendor/bin/phpstan analyse app --level=5 -c vendor/nunomaduro/larastan/extension.neon
 cd -
 
+echo "Test Laravel from other working directories"
+../laravel/vendor/bin/phpstan analyse ../laravel/app --level=5 -c ../laravel/vendor/nunomaduro/larastan/extension.neon
+
 echo "Install Lumen"
 composer create-project --quiet --prefer-dist "laravel/lumen" ../lumen
 cd ../lumen/
@@ -60,3 +63,7 @@ EOF
 
 echo "Test Lumen"
 vendor/bin/phpstan analyse app --level=5 -c vendor/nunomaduro/larastan/extension.neon
+cd -
+
+echo "Test Lumen from other working directories"
+../lumen/vendor/bin/phpstan analyse ../lumen/app --level=5 -c ../lumen/vendor/nunomaduro/larastan/extension.neon

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -7,7 +7,7 @@ composer create-project --quiet --prefer-dist "laravel/laravel" ../laravel
 cd ../laravel/
 
 echo "Add package from source"
-sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan" } ],|' -i composer.json
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan", "options": { "symlink": false }} ],|' -i composer.json
 composer require --dev "nunomaduro/larastan:*"
 
 echo "Fix https://github.com/laravel/framework/pull/23825"
@@ -27,7 +27,7 @@ composer create-project --quiet --prefer-dist "laravel/lumen" ../lumen
 cd ../lumen/
 
 echo "Add package from source"
-sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan" } ],|' -i composer.json
+sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan", "options": { "symlink": false }} ],|' -i composer.json
 composer require --dev "nunomaduro/larastan:*"
 
 echo "Fix Handler::render return type"


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
I want to re-open this PR https://github.com/nunomaduro/larastan/pull/851.
This PR would enable running larastan without caring about the working directory.
As I mentioned in https://github.com/nunomaduro/larastan/pull/851, Laravel's bootstrap and vendor path are hardcoded, and should always be a relative path `__DIR__.'/../../../bootstrap/app.php'` from `vendor/nunomaduro/larastan`.

I modified the test a little, and added a test to confirm the changes.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

I think there are no breaking changes.
