### PR TITLE
Recommend usage of composer update in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We have [StyleCI](https://styleci.io/) setup to automatically fix any code style
 
 Clone your fork, then install the dev dependencies:
 
-    composer install
+    composer update
 
 ## Tests
 


### PR DESCRIPTION
Given there is no composer.lock file and the pipeline also runs the latest
dependencies, it seems better to have the local dependencies up to date.
