### PR TITLE
fix: leave getcwd() way of finding bootstrap file

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,8 +8,6 @@ define('LARAVEL_START', microtime(true));
 
 if (file_exists($applicationPath = dirname(__DIR__, 3).'/bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
-} elseif (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) {
-    $app = require $applicationPath;
 } else { // Packages
     $app = ApplicationResolver::resolve();
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,6 +8,8 @@ define('LARAVEL_START', microtime(true));
 
 if (file_exists($applicationPath = dirname(__DIR__, 3).'/bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
+} elseif (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) {
+    $app = require $applicationPath;
 } else { // Packages
     $app = ApplicationResolver::resolve();
 }

--- a/extension.neon
+++ b/extension.neon
@@ -42,7 +42,7 @@ parameters:
     mixinExcludeClasses:
         - Eloquent
     bootstrapFiles:
-        - bootstrap.php
+        - %laravelBootstrapFile%
     checkGenericClassInNonGenericObjectType: false
     checkOctaneCompatibility: false
     noUnnecessaryCollectionCall: true
@@ -50,6 +50,7 @@ parameters:
     noUnnecessaryCollectionCallExcept: []
     databaseMigrationsPath: []
     checkModelProperties: false
+    laravelBootstrapFile: bootstrap.php
 
 parametersSchema:
     checkOctaneCompatibility: bool()
@@ -58,6 +59,7 @@ parametersSchema:
     noUnnecessaryCollectionCallExcept: listOf(string())
     databaseMigrationsPath: listOf(string())
     checkModelProperties: bool()
+    laravelBootstrapFile: string()
 
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

fixes https://github.com/nunomaduro/larastan/issues/856
Sorry, I wasn't aware of symlink usages.
I think it is better to restore 
```php
file_exists($applicationPath = getcwd().'/bootstrap/app.php')
```
than adding a new relative path
```php
file_exists($applicationPath = dirname(__DIR__, 5).'/bootstrap/app.php')
```
because there might be other symlink usages.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

This PR would fix the breaking changes from https://github.com/nunomaduro/larastan/pull/852.
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
