### PR TITLE
Laravel 8 factory support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/",
-            "App\\": "tests/Application/app"
+            "App\\": "tests/Application/app/",
+            "Laravel8\\": "tests/Laravel8Application/app/",
+            "Database\\Factories\\": "tests/Laravel8Application/database/factories/",
+            "Tests\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/extension.neon
+++ b/extension.neon
@@ -4,6 +4,7 @@ parameters:
         - stubs/EloquentBuilder.stub
         - stubs/Collection.stub
         - stubs/EloquentCollection.stub
+        - stubs/Factory.stub
         - stubs/Model.stub
         - stubs/JsonResource.stub
         - stubs/Gate.stub
@@ -104,6 +105,10 @@ services:
         class: NunoMaduro\Larastan\Methods\Extension
         tags:
             - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: NunoMaduro\Larastan\Methods\ModelFactoryMethodsClassReflectionExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
 
     -
         class: NunoMaduro\Larastan\Properties\ModelAccessorExtension
@@ -144,6 +149,11 @@ services:
         class: NunoMaduro\Larastan\Properties\ModelRelationsExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ModelFactoryDynamicStaticMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
         class: NunoMaduro\Larastan\ReturnTypes\ModelExtension

--- a/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
+++ b/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Methods;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ModelFactoryMethodsClassReflectionExtension implements MethodsClassReflectionExtension
+{
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        // Class only available on Laravel 8
+        if (! class_exists('\Illuminate\Database\Eloquent\Factories\Factory')) {
+            return false;
+        }
+
+        if (! $classReflection->isSubclassOf(Factory::class)) {
+            return false;
+        }
+
+        if (! Str::startsWith($methodName, ['for', 'has'])) {
+            return false;
+        }
+
+        $relationship = Str::camel(Str::substr($methodName, 3));
+
+        $parent = $classReflection->getParentClass();
+
+        if ($parent === false) {
+            return false;
+        }
+
+        $modelType = $parent->getActiveTemplateTypeMap()->getType('TModel');
+
+        if ($modelType === null) {
+            return false;
+        }
+
+        return $modelType->hasMethod($relationship)->yes();
+    }
+
+    public function getMethod(
+        ClassReflection $classReflection,
+        string $methodName
+    ): MethodReflection {
+        return new class($classReflection, $methodName) implements MethodReflection
+        {
+            /** @var ClassReflection */
+            private $classReflection;
+
+            /** @var string */
+            private $methodName;
+
+            public function __construct(ClassReflection $classReflection, string $methodName)
+            {
+                $this->classReflection = $classReflection;
+                $this->methodName = $methodName;
+            }
+
+            public function getDeclaringClass(): ClassReflection
+            {
+                return $this->classReflection;
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): ?string
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->methodName;
+            }
+
+            public function getPrototype(): ClassMemberReflection
+            {
+                return $this;
+            }
+
+            public function getVariants(): array
+            {
+                $returnType = new ObjectType($this->classReflection->getName());
+                $stateParameter = ParametersAcceptorSelector::selectSingle($this->classReflection->getMethod('state', new OutOfClassScope())->getVariants())->getParameters()[0];
+                $countParameter = ParametersAcceptorSelector::selectSingle($this->classReflection->getMethod('count', new OutOfClassScope())->getVariants())->getParameters()[0];
+
+                $variants = [
+                    new FunctionVariant(TemplateTypeMap::createEmpty(), null, [], false, $returnType),
+                ];
+
+                if (Str::startsWith($this->methodName, 'for')) {
+                    $variants[] = new FunctionVariant(TemplateTypeMap::createEmpty(), null, [$stateParameter], false, $returnType);
+                } else {
+                    $variants[] = new FunctionVariant(TemplateTypeMap::createEmpty(), null, [$countParameter], false, $returnType);
+                    $variants[] = new FunctionVariant(TemplateTypeMap::createEmpty(), null, [$stateParameter], false, $returnType);
+                    $variants[] = new FunctionVariant(TemplateTypeMap::createEmpty(), null, [$countParameter, $stateParameter], false, $returnType);
+                }
+
+                return $variants;
+            }
+
+            public function isDeprecated(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): ?string
+            {
+                return null;
+            }
+
+            public function isFinal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function isInternal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getThrowType(): ?Type
+            {
+                return null;
+            }
+
+            public function hasSideEffects(): TrinaryLogic
+            {
+                return TrinaryLogic::createMaybe();
+            }
+        };
+    }
+}

--- a/src/ReturnTypes/ModelExtension.php
+++ b/src/ReturnTypes/ModelExtension.php
@@ -56,7 +56,15 @@ final class ModelExtension implements DynamicStaticMethodReturnTypeExtension
             return true;
         }
 
-        return $methodReflection->getDeclaringClass()->hasNativeMethod($name);
+        if (! $methodReflection->getDeclaringClass()->hasNativeMethod($name)) {
+            return false;
+        }
+
+        $method = $methodReflection->getDeclaringClass()->getNativeMethod($methodReflection->getName());
+
+        $returnType = ParametersAcceptorSelector::selectSingle($method->getVariants())->getReturnType();
+
+        return (count(array_intersect([EloquentBuilder::class, QueryBuilder::class, Collection::class], $returnType->getReferencedClasses()))) > 0;
     }
 
     /**

--- a/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class ModelFactoryDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        if ($methodReflection->getName() !== 'factory') {
+            return false;
+        }
+
+        // Class only available on Laravel 8
+        if (! class_exists('\Illuminate\Database\Eloquent\Factories\Factory')) {
+            return false;
+        }
+
+        $modelName = $methodReflection->getDeclaringClass()->getNativeReflection()->getShortName();
+
+        return class_exists('Database\\Factories\\'.$modelName.'Factory');
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): Type {
+        $modelName = $methodReflection->getDeclaringClass()->getNativeReflection()->getShortName();
+
+        return new ObjectType('Database\\Factories\\'.$modelName.'Factory');
+    }
+}

--- a/stubs/Factory.stub
+++ b/stubs/Factory.stub
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factories;
+
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
+class Factory
+{
+    /**
+     * Get a new factory instance for the given attributes.
+     *
+     * @param  callable|array<model-property<TModel>, mixed>  $attributes
+     * @return static
+     */
+    public static function new($attributes = []) {}
+
+    /**
+     * Create a single model and persist it to the database.
+     *
+     * @param  array<model-property<TModel>, mixed> $attributes
+     * @return TModel
+     */
+    public function createOne($attributes = []) {}
+
+    /**
+     * Create a collection of models and persist them to the database.
+     *
+     * @param  iterable<callable|array<model-property<TModel>, mixed>>  $records
+     * @return \Illuminate\Database\Eloquent\Collection<TModel>
+     */
+    public function createMany(iterable $records) {}
+
+    /**
+     * Create a collection of models and persist them to the database.
+     *
+     * @param  array<model-property<TModel>, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection<TModel>|TModel
+     */
+    public function create($attributes = [], ?\Illuminate\Database\Eloquent\Model $parent = null) {}
+
+    /**
+     * Make a single instance of the model.
+     *
+     * @param  callable|array<model-property<TModel>, mixed>  $attributes
+     * @return TModel
+     */
+    public function makeOne($attributes = []) {}
+
+    /**
+     * Create a collection of models.
+     *
+     * @param  array<model-property<TModel>, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection<TModel>|TModel
+     */
+    public function make($attributes = [], ?\Illuminate\Database\Eloquent\Model $parent = null) {}
+
+    /**
+     * Make an instance of the model with the given attributes.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return TModel
+     */
+    protected function makeInstance(?\Illuminate\Database\Eloquent\Model $parent) {}
+}

--- a/tests/Features/Laravel8/Methods/ModelFactory.php
+++ b/tests/Features/Laravel8/Methods/ModelFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Laravel8\Methods;
+
+use Database\Factories\UserFactory;
+use Laravel8\Models\User;
+
+class ModelFactory
+{
+    public function testHasRelation(): UserFactory
+    {
+        return User::factory()->hasAccounts();
+    }
+
+    public function testHasRelationWithCount(): UserFactory
+    {
+        return User::factory()->hasAccounts(3);
+    }
+
+    public function testHasRelationWithState(): UserFactory
+    {
+        return User::factory()->hasAccounts(['active' => 0]);
+    }
+
+    public function testHasRelationWithCountAndState(): User
+    {
+        return User::factory()->hasAccounts(3, ['active' => 1])->createOne();
+    }
+
+    public function testForRelation(): UserFactory
+    {
+        return User::factory()->forParent();
+    }
+
+    public function testForRelationWithState(): UserFactory
+    {
+        return User::factory()->forParent(['meta' => ['foo']]);
+    }
+}

--- a/tests/Features/Laravel8/ReturnTypes/ModelFactory.php
+++ b/tests/Features/Laravel8/ReturnTypes/ModelFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Laravel8\ReturnTypes;
+
+use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Laravel8\Models\User;
+
+class ModelFactory
+{
+    public function testFactory(): UserFactory
+    {
+        return User::factory();
+    }
+
+    public function testNew(): UserFactory
+    {
+        return User::factory()->new();
+    }
+
+    public function testCreateOne(): User
+    {
+        return User::factory()->createOne();
+    }
+
+    /** @phpstan-return Collection<User> */
+    public function testCreateMany(): Collection
+    {
+        return User::factory()->createMany([]);
+    }
+
+    /** @phpstan-return Collection<User>|User */
+    public function testCreate()
+    {
+        return User::factory()->create();
+    }
+
+    public function testMakeOne(): User
+    {
+        return User::factory()->makeOne();
+    }
+
+    /** @phpstan-return Collection<User>|User */
+    public function testMake()
+    {
+        return User::factory()->make();
+    }
+}

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class FeaturesTest extends TestCase
 {
@@ -14,11 +15,8 @@ class FeaturesTest extends TestCase
         $calls = [];
         $baseDir = __DIR__.DIRECTORY_SEPARATOR.'Features'.DIRECTORY_SEPARATOR;
 
-        /** @var \Symfony\Component\Finder\SplFileInfo $file */
-        foreach ((new Finder())->in($baseDir)->files() as $file) {
-            if ($file->getExtension() !== 'php') {
-                continue;
-            }
+        /** @var SplFileInfo $file */
+        foreach ((new Finder())->in($baseDir)->files()->name('*.php') as $file) {
             $fullPath = realpath((string) $file);
             $calls[str_replace($baseDir, '', $fullPath)] = [$fullPath];
         }

--- a/tests/Laravel8Application/app/Models/User.php
+++ b/tests/Laravel8Application/app/Models/User.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel8\Models;
+
+use App\Account;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class User extends Model
+{
+    use HasFactory;
+
+    /** @phpstan-return HasMany<Account> */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(get_class($this));
+    }
+}

--- a/tests/Laravel8Application/database/factories/UserFactory.php
+++ b/tests/Laravel8Application/database/factories/UserFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Laravel8\Models\User;
+
+/**
+ * @extends Factory<User>
+ */
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    /**
+     * Indicate that the model's email address should be unverified.
+     *
+     * @return self
+     */
+    public function unverified()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'email_verified_at' => null,
+            ];
+        });
+    }
+}

--- a/tests/Rules/Data/model-property-model-factory.php
+++ b/tests/Rules/Data/model-property-model-factory.php
@@ -1,0 +1,6 @@
+<?php
+
+function foo(): void
+{
+    \Laravel8\Models\User::factory()->createOne(['foo' => 'bar']);
+}

--- a/tests/Rules/ModelPropertyRuleTest.php
+++ b/tests/Rules/ModelPropertyRuleTest.php
@@ -47,4 +47,17 @@ class ModelPropertyRuleTest extends RulesTest
             7 => 'Property \'foo\' does not exist in ModelPropertyOnModel model.',
         ], $errors);
     }
+
+    public function testModelPropertyRuleOnModelFactory(): void
+    {
+        if (version_compare(app()->version(), '8.0.0', '<')) {
+            $this->markTestSkipped('Test required Laravel 8');
+        }
+
+        $errors = $this->setConfigPath(__DIR__.DIRECTORY_SEPARATOR.'Data/modelPropertyConfig.neon')->findErrorsByLine(__DIR__.'/Data/model-property-model-factory.php');
+
+        self::assertEquals([
+            5 => 'Property \'foo\' does not exist in Laravel8\\Models\\User model.',
+        ], $errors);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Closes #661 

This PR adds support for Laravel 8 factories.

- `User::factory()` would return `UserFactory`
- `User::factory()->createOne()` would return `User`
- Unfortunately there is no good solution to infer more precise return type for `create` method. It can either return collection of models, or single model. And this is decided by the `count()` method. This kind of fluent calls are hard to keep track with PHPStan.

I will add support for relations later (`has{Relation}` and `for{Relation}` method calls), I'm opening the PR now so if anyone wants to try over the weekend they could do so. I'd appreciate any feedback if anyone tries.
