### PR TITLE
Allow any return type for Collection::each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Added the `mixed` return type for callables within a Collection's ->each statement to allow for short closures in PHP 8 ([#868](https://github.com/nunomaduro/larastan/pull/868))
+
 ## [0.7.9] - 2021-07-05
 
 ### Fixed

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -57,7 +57,7 @@ class Collection implements \ArrayAccess, Enumerable
     public function shift() {}
 
     /**
-     * @param callable(TValue, TKey): (void|bool) $callable
+     * @param callable(TValue, TKey): (void|mixed) $callable
      * @return static<TValue>
      */
     public function each($callable) {}


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

This allows you to have the following:

```php
User::all()->each(fn(User $user, int $key) => $user->doSomething());
```

Without getting the following error:

`Parameter #1 $callback of method Illuminate\\Support\\Collection<int,App\\User>::each() expects callable(App\\User, int): bool|void, Closure(App\\User): App\\User given.`

Can't really add a test for this as it's a PHP 7.4 only thing.
