### PR TITLE
fix: false positive for local model query scopes that starts with where

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -20,6 +20,8 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
+use PHPStan\Type\Generic\TemplateObjectType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 
@@ -84,6 +86,14 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         // Generic type is not specified
         if ($modelType === null) {
             return null;
+        }
+
+        if ($modelType instanceof TemplateObjectType) {
+            $modelType = $modelType->getBound();
+
+            if ($modelType->equals(new ObjectType(Model::class))) {
+                return null;
+            }
         }
 
         if ($modelType instanceof TypeWithClassName) {

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -60,6 +60,16 @@ class User extends Authenticatable
         return $query->where('active', 1);
     }
 
+    /**
+     * @param Builder<User> $query
+     *
+     * @return Builder<User>
+     */
+    public function scopeWhereActive(Builder $query): Builder
+    {
+        return $query->where('active', 1);
+    }
+
     /** @phpstan-return BelongsTo<Group, User> */
     public function group(): BelongsTo
     {

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -64,4 +64,10 @@ class Scopes extends Model
     {
         $query->where('whyuse', 'void');
     }
+
+    /** @phpstan-return Builder<User> */
+    public function testScopeThatStartsWithWordWhere(): Builder
+    {
+        return User::query()->whereActive();
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR fixes a false positive when a local model query scope that starts with word `where` used.

**Breaking changes**

n/a
