### PR TITLE
feat: support for `orWhere` HigherOrderBuilderProxy property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for `orWhere` HigherOrderBuilderProxy property ([#884](https://github.com/nunomaduro/larastan/pull/884))
+
 ## [0.7.10] - 2021-07-07
 
 ### Fixed
 
 - Fixed an issue when using `return null` in PHPDocs forced the `return` keyword on the code. ([1e85de7](https://github.com/nunomaduro/larastan/commit/1e85de7b2632bab4db09154389d309bece973c2e))
-
 
 ## [0.7.9] - 2021-07-05
 

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 /**
  * @template TModelClass of Model
+ * @property-read static<TModelClass> $orWhere
  */
 class Builder
 {

--- a/tests/Features/Methods/ModelExtension.php
+++ b/tests/Features/Methods/ModelExtension.php
@@ -149,6 +149,12 @@ class ModelExtension
         return Thread::valid();
     }
 
+    /** @phpstan-return Builder<Thread> */
+    public function testScopeWithOrWhereHigherOrderBuilderProxyProperty(): Builder
+    {
+        return Thread::valid()->orWhere->valid();
+    }
+
     /** @phpstan-return Builder<User> */
     public function testWithAcceptsArrayOfClosures(): Builder
     {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes: not relevant
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

HigherOrderBuilderProxy property `orWhere` is not supported by Larastan yet.

Closes #885