### PR TITLE
Avoid need for explicit `@extends` in factories

### DIFF
--- a/stubs/Factory.stub
+++ b/stubs/Factory.stub
@@ -3,10 +3,17 @@
 namespace Illuminate\Database\Eloquent\Factories;
 
 /**
- * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @template TModel extends \Illuminate\Database\Eloquent\Model
  */
 class Factory
 {
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model;
+
     /**
      * Get a new factory instance for the given attributes.
      *
@@ -64,4 +71,11 @@ class Factory
      * @return TModel
      */
     protected function makeInstance(?\Illuminate\Database\Eloquent\Model $parent) {}
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<model-property<TModel>, mixed>
+     */
+    abstract public function definition();
 }

--- a/tests/Laravel8Application/database/factories/UserFactory.php
+++ b/tests/Laravel8Application/database/factories/UserFactory.php
@@ -8,23 +8,10 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Laravel8\Models\User;
 
-/**
- * @extends Factory<User>
- */
 class UserFactory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
     protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition()
     {
         return [


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Follow up to https://github.com/nunomaduro/larastan/pull/861

**Changes**

The type of the used model in a factory can be inferred from the `$model` attribute.
This eliminates the need for a

**Breaking changes**

One test seems to be failing: `Tests\Rules\ModelPropertyRuleTest::testModelPropertyRuleOnModelFactory`

```
Internal error: Call to undefined method PHPStan\Type\MixedType::getClassReflection()\n
Run PHPStan with --debug option and post the stack trace to:\n
https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md
```