### PR TITLE
fix: customer eloquent builder return wrong type when `whereHas` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed EloquentBuilder stub to fix `whereHas` return type when custom builder is used ([#896](https://github.com/nunomaduro/larastan/pull/896)) Thanks @fragkp
+
 ## [0.7.11] - 2021-07-22
 
 ### Added

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -191,7 +191,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static<TModelClass>
+     * @return static
      */
     public function whereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -104,24 +104,6 @@ class CustomEloquentBuilderTest
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
-    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderWithExplicitQueryMethod(): CustomEloquentBuilder
-    {
-        return ModelWithCustomBuilder::query();
-    }
-
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
-    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterBuilderMethodWithExplicitQueryMethod(): CustomEloquentBuilder
-    {
-        return ModelWithCustomBuilder::query()->where('email', 'bar');
-    }
-
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
-    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterCustomBuilderMethodChainedWithExplicitQueryMethod(): CustomEloquentBuilder
-    {
-        return ModelWithCustomBuilder::query()->where('email', 'bar')->type('foo');
-    }
-
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterCustomBuilderMethodRelationChainedWithExplicitQueryMethod(): CustomEloquentBuilder
     {
         return ModelWithCustomBuilder::query()->whereHas('relation')->type('foo');

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -102,6 +102,30 @@ class CustomEloquentBuilderTest
     {
         return ModelWithCustomBuilder::findOrFail([1, 2, 3]);
     }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderWithExplicitQueryMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query();
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterBuilderMethodWithExplicitQueryMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->where('email', 'bar');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterCustomBuilderMethodChainedWithExplicitQueryMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->where('email', 'bar')->type('foo');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterCustomBuilderMethodRelationChainedWithExplicitQueryMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->whereHas('relation')->type('foo');
+    }
 }
 
 class FooModel extends Model


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Closes #897

The return type of the `whereHas` method (EloquentBuilder stub) was previously wrong, so that when a custom builder is used, thus builder is not correct recognized.