### PR TITLE
fix: add missing relation builder method stubs for custom builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Changed EloquentBuilder stub to fix several relation builder methods return types when custom builder is used ([#XXX](https://github.com/nunomaduro/larastan/pull/XXX)) Thanks @fragkp
 - Changed EloquentBuilder stub to fix `whereHas` return type when custom builder is used ([#896](https://github.com/nunomaduro/larastan/pull/896)) Thanks @fragkp
 
 ## [0.7.11] - 2021-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Changed EloquentBuilder stub to fix several relation builder methods return types when custom builder is used ([#XXX](https://github.com/nunomaduro/larastan/pull/XXX)) Thanks @fragkp
+- Changed EloquentBuilder stub to fix several relation builder methods return types when custom builder is used ([#899](https://github.com/nunomaduro/larastan/pull/899)) Thanks @fragkp
 - Changed EloquentBuilder stub to fix `whereHas` return type when custom builder is used ([#896](https://github.com/nunomaduro/larastan/pull/896)) Thanks @fragkp
 
 ## [0.7.11] - 2021-07-22

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -185,6 +185,49 @@ class Builder
     public function orWhere($column, $operator = null, $value = null);
 
     /**
+     * Add a relationship count / exists condition to the query.
+     *
+     * @template TRelatedModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel>|string  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return static
+     *
+     * @throws \RuntimeException
+     */
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', \Closure $callback = null);
+
+    /**
+     * Add a relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @return static
+     */
+    public function orHas($relation, $operator = '>=', $count = 1);
+
+    /**
+     * Add a relationship count / exists condition to the query.
+     *
+     * @param  string  $relation
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function doesntHave($relation, $boolean = 'and', \Closure $callback = null);
+
+    /**
+     * Add a relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @return static
+     */
+    public function orDoesntHave($relation);
+
+    /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  string  $relation
@@ -194,6 +237,147 @@ class Builder
      * @return static
      */
     public function whereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return static
+     */
+    public function orWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query.
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', \Closure $callback = null);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with an "or".
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  string  $operator
+     * @param  int  $count
+     * @return static
+     */
+    public function orHasMorph($relation, $types, $operator = '>=', $count = 1);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query.
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', \Closure $callback = null);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with an "or".
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @return static
+     */
+    public function orDoesntHaveMorph($relation, $types);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses.
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return static
+     */
+    public function whereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return static
+     */
+    public function orWhereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses.
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function whereDoesntHaveMorph($relation, $types, \Closure $callback = null);
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @template TRelatedModel of Model
+     * @template TChildModel of Model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  string|array<string>  $types
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function orWhereDoesntHaveMorph($relation, $types, \Closure $callback = null);
+
+    /**
+     * Merge the where constraints from another query to the current query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $from
+     * @return static
+     */
+    public function mergeConstraintsFrom(\Illuminate\Database\Eloquent\Builder $from);
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function orWhereDoesntHave($relation, \Closure $callback = null);
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @return static
+     */
+    public function whereDoesntHave($relation, \Closure $callback = null);
 
     /**
      * Add a basic where clause to the query, and return the first result.

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -104,6 +104,108 @@ class CustomEloquentBuilderTest
     }
 
     /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterHasBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->has('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrHasBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orHas('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterDoesntHaveBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->doesntHave('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrDoesntHaveBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orDoesntHave('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterWhereHasBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->whereHas('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrWhereHasBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orWhereHas('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterWhereDoesntHaveBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->whereDoesntHave('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrWhereDoesntHaveBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orWhereDoesntHave('relation');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterHasMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->hasMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrHasMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orHasMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterDoesntHaveMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->doesntHaveMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrDoesntHaveMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orDoesntHaveMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterWhereHasMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->whereHasMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrWhereHasMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orWhereHasMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterWhereDoesntHaveMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->whereDoesntHaveMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterOrWhereDoesntHaveMorphMorphBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->orWhereDoesntHaveMorph('relation', 'types');
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterMergeConstraintsFromBuilderMethod(): CustomEloquentBuilder
+    {
+        return ModelWithCustomBuilder::query()->mergeConstraintsFrom(ModelWithCustomBuilder::query());
+    }
+
+    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
     public function testModelWithCustomBuilderReturnsCustomEloquentBuilderAfterCustomBuilderMethodRelationChainedWithExplicitQueryMethod(): CustomEloquentBuilder
     {
         return ModelWithCustomBuilder::query()->whereHas('relation')->type('foo');


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

On my road to a green screen for larastan, I discovered some missing relation builder methods are missing in the stub. Errors occurs when a custom eloquent builder is used.

Similar to: https://github.com/nunomaduro/larastan/pull/896

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Added missing relation methods to stub.
