### PR TITLE
Eloquent Builder global macros support.

### DIFF
--- a/src/Methods/Pipes/Macros.php
+++ b/src/Methods/Pipes/Macros.php
@@ -70,7 +70,7 @@ final class Macros implements PipeContract
             $macroTraitProperty = 'macros';
         } elseif ($this->hasIndirectTraitUse($classReflection, CarbonMacro::class)) {
             $className = $classReflection->getName();
-            $macroTraitMethod   = 'hasMacro';
+            $macroTraitMethod = 'hasMacro';
             $macroTraitProperty = 'globalMacros';
         }
 

--- a/tests/Features/Methods/BuilderExtension.php
+++ b/tests/Features/Methods/BuilderExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Methods;
+
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+
+Builder::macro('foo', static function (): string {
+    return 'foo';
+});
+
+class BuilderExtension
+{
+    public function testBuilderMacroCalledStatically(): string
+    {
+        return Builder::foo();
+    }
+
+    public function testBuilderMacroCalledDynamically(): string
+    {
+        return User::query()->foo();
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Eloquent `Builder` (in v8 at least) [doesn't use the `Macroable` trait](https://github.com/laravel/framework/blob/dc393980dec1b3ee4b0f36b5b0188859a399b4e4/src/Illuminate/Database/Eloquent/Builder.php#L27-L32), it uses its own realization to mimic `Macroable`. Look like Larastan supports only local macros, but not global:

```php
Builder::macro('foo', static function (): string {
    return 'foo';
});

Builder::foo() // Call to an undefined static method Illuminate\\Database\\Eloquent\\Builder::foo().
```

This PR adds support for global macros, so

```php
Builder::foo() // = 'foo'
```

**Breaking changes**

Nope.
