### PR TITLE
Sync QueryBuilder.stub: Eloquent Builder in `Builder::joinSub()`, `Builder::leftJoinSub` and `Builder::rightJoinSub()`

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -3,6 +3,9 @@ namespace Illuminate\Database\Query;
 
 class Expression {}
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ */
 class Builder
 {
     /**
@@ -39,7 +42,7 @@ class Builder
     /**
      * Makes "from" fetch from a subquery.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|string  $query
      * @param  string  $as
      * @return $this
      *
@@ -61,7 +64,7 @@ class Builder
     /**
      * Creates a subquery and parse it.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|string  $query
      * @return array<mixed>
      */
     protected function createSub($query)
@@ -98,7 +101,7 @@ class Builder
     /**
      * Set the table which the query is targeting.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|string  $table
      * @param  string|null  $as
      * @return $this
      */
@@ -135,9 +138,7 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|\Illuminate\Database\Eloquent\Builder<TModelClass>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -178,9 +179,7 @@ class Builder
     /**
      * Add a subquery left join to the query.
      *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|\Illuminate\Database\Eloquent\Builder<TModelClass>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -217,9 +216,7 @@ class Builder
     /**
      * Add a subquery right join to the query.
      *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|\Illuminate\Database\Eloquent\Builder<TModelClass>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -732,7 +729,7 @@ class Builder
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Query\Builder<TModelClass>  $query
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -931,7 +928,7 @@ class Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|\Illuminate\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -1076,7 +1073,7 @@ class Builder
     /**
      * Add a union statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder<TModelClass>|\Closure  $query
      * @param  bool  $all
      * @return $this
      */
@@ -1086,7 +1083,7 @@ class Builder
     /**
      * Add a union all statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder<TModelClass>|\Closure  $query
      * @return $this
      */
     public function unionAll($query)
@@ -1319,7 +1316,7 @@ class Builder
      * Insert new records into the table using a subquery.
      *
      * @param  array<string>  $columns
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder<TModelClass>|string  $query
      * @return int
      */
     public function insertUsing(array $columns, $query)
@@ -1438,7 +1435,7 @@ class Builder
     /**
      * Merge an array of bindings into our bindings.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Query\Builder<TModelClass>  $query
      * @return $this
      */
     public function mergeBindings(self $query)

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -135,7 +135,9 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -176,7 +178,9 @@ class Builder
     /**
      * Add a subquery left join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -213,7 +217,9 @@ class Builder
     /**
      * Add a subquery right join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -135,7 +135,7 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -176,7 +176,7 @@ class Builder
     /**
      * Add a subquery left join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
@@ -213,7 +213,7 @@ class Builder
     /**
      * Add a subquery right join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -213,19 +213,22 @@ class Builder
             ->value(\Illuminate\Support\Facades\DB::raw('name'));
     }
 
-    public function testQueryBuilderJoinSubAcceptEloquentBuilder(): ?User {
+    public function testQueryBuilderJoinSubAcceptEloquentBuilder(): ?User
+    {
         return User::query()->toBase()
             ->joinSub(User::query(), 'user', 'users.id')
             ->first();
     }
 
-    public function testQueryBuilderLeftJoinSubAcceptEloquentBuilder(): ?User {
+    public function testQueryBuilderLeftJoinSubAcceptEloquentBuilder(): ?User
+    {
         return User::query()->toBase()
             ->leftJoinSub(User::query(), 'user', 'users.id')
             ->first();
     }
 
-    public function testQueryBuilderRightJoinSubAcceptEloquentBuilder(): ?User {
+    public function testQueryBuilderRightJoinSubAcceptEloquentBuilder(): ?User
+    {
         return User::query()->toBase()
             ->rightJoinSub(User::query(), 'user', 'users.id')
             ->first();

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -212,4 +212,22 @@ class Builder
         return User::with('foo')
             ->value(\Illuminate\Support\Facades\DB::raw('name'));
     }
+
+    public function testQueryBuilderJoinSubAcceptEloquentBuilder(): ?User {
+        return User::query()->toBase()
+            ->joinSub(User::query(), 'user', 'users.id')
+            ->first();
+    }
+
+    public function testQueryBuilderLeftJoinSubAcceptEloquentBuilder(): ?User {
+        return User::query()->toBase()
+            ->leftJoinSub(User::query(), 'user', 'users.id')
+            ->first();
+    }
+
+    public function testQueryBuilderRightJoinSubAcceptEloquentBuilder(): ?User {
+        return User::query()->toBase()
+            ->rightJoinSub(User::query(), 'user', 'users.id')
+            ->first();
+    }
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

After https://github.com/laravel/framework/pull/35993 the following methods
- `Builder::joinSub()`
- `Builder::leftJoinSub`
- `Builder::rightJoinSub()`

also accepts Eloquent Builder. This PR adds Eloquent Builder into `QueryBuilder.stab`.

Actually, as I see [`Relation` class is also supported](https://github.com/laravel/framework/blob/ac268af97a7c16d1d86a466d9127e90dc4a1e645/src/Illuminate/Database/Query/Builder.php#L349). So, maybe it should be added too?

![image](https://user-images.githubusercontent.com/1329824/128611164-a0694536-ac52-46f9-b46a-1c6c14fb568d.png)

**Breaking changes**

Not sure.