### PR TITLE
Allows checking global macros on the Eloquent Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.13] - 2021-08-10
+
+### Fixed
+
+- Support global macros on the eloquent query builder.
+
 ## [0.7.12] - 2021-07-26
 
 ### Added

--- a/src/Methods/Pipes/Macros.php
+++ b/src/Methods/Pipes/Macros.php
@@ -73,11 +73,9 @@ final class Macros implements PipeContract
 
             $className = (string) $className;
 
-            if ($className === Builder::class) {
-                $found = $className::hasGlobalMacro($passable->getMethodName());
-            } else {
-                $found = $className::hasMacro($passable->getMethodName());
-            }
+            $found = $className === Builder::class
+                ? $className::hasGlobalMacro($passable->getMethodName())
+                : $className::hasMacro($passable->getMethodName());
 
             if ($found) {
                 $reflectionFunction = new \ReflectionFunction($refProperty->getValue()[$passable->getMethodName()]);

--- a/src/Methods/Pipes/Macros.php
+++ b/src/Methods/Pipes/Macros.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\Larastan\Methods\Pipes;
 
 use Carbon\Traits\Macro as CarbonMacro;
 use Closure;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use NunoMaduro\Larastan\Concerns;
@@ -57,7 +58,7 @@ final class Macros implements PipeContract
                     $macroTraitProperty = 'macros';
                 }
             }
-        } elseif ($classReflection->hasTraitUse(Macroable::class)) {
+        } elseif ($classReflection->hasTraitUse(Macroable::class) || $classReflection->getName() === Builder::class) {
             $className = $classReflection->getName();
             $macroTraitProperty = 'macros';
         } elseif ($this->hasIndirectTraitUse($classReflection, CarbonMacro::class)) {
@@ -72,7 +73,13 @@ final class Macros implements PipeContract
 
             $className = (string) $className;
 
-            if ($found = $className::hasMacro($passable->getMethodName())) {
+            if ($className === Builder::class) {
+                $found = $className::hasGlobalMacro($passable->getMethodName());
+            } else {
+                $found = $className::hasMacro($passable->getMethodName());
+            }
+
+            if ($found) {
                 $reflectionFunction = new \ReflectionFunction($refProperty->getValue()[$passable->getMethodName()]);
                 /** @var \PHPStan\Type\Type[] $parameters */
                 $parameters = $reflectionFunction->getParameters();

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use stdClass;
 
-\Illuminate\Database\Eloquent\Builder::macro('globalCustomMacro', function () {
-
+\Illuminate\Database\Eloquent\Builder::macro('globalCustomMacro', function (string $arg): string {
+    return $arg;
 });
 
 /**
@@ -169,9 +169,9 @@ class Builder
         });
     }
 
-    public function testGlobalMacro(\Illuminate\Database\Eloquent\Builder $query): void
+    public function testGlobalMacro(\Illuminate\Database\Eloquent\Builder $query): string
     {
-        $query->globalCustomMacro();
+        return $query->globalCustomMacro('foo');
     }
 
     public function testFirstOrFailWithChain(): User

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -10,6 +10,10 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use stdClass;
 
+\Illuminate\Database\Eloquent\Builder::macro('globalCustomMacro', function () {
+
+});
+
 /**
  * This class tests `EloquentBuilder::__call` method.
  *
@@ -163,6 +167,11 @@ class Builder
     {
         $query->macro('customMacro', function () {
         });
+    }
+
+    public function testGlobalMacro(\Illuminate\Database\Eloquent\Builder $query): void
+    {
+        $query->globalCustomMacro();
     }
 
     public function testFirstOrFailWithChain(): User


### PR DESCRIPTION
The Eloquent builder allows passing methods through to the wrapped query
builder which means it has support for macros, however it also has local
macros so the API is slightly different when checking for macros.

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

I came across this problem when trying to use [lampager](https://github.com/lampager/lampager-laravel) which adds a [macro](https://github.com/lampager/lampager-laravel/blob/master/src/MacroServiceProvider.php#L20-L27) to the query builder as well as the eloquent builder. Larastan successfully checks the macro on the query builder but not for eloquent. This is because the eloquent builder doesn't use the `Macroable` trait, instead it wraps around the query builder and uses that trait as well as adding custom logic for local macros.

This pull request expands the `Macros` pipe to check if the class is the eloquent builder and calls the appropriate method to check for macros.

I haven't added any test cases yet because I'm still quite new to Larastan and PHPStan and I couldn't see how to do it well. The test would need to add a macro as it's building the application, possible in a service provider but I wasn't sure the best way to do that.