### PR TITLE
Fix Dynamic call to static method Illuminate\Foundation\Application::configurationIsCached()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["7.2", "7.3", "7.4", "8.0"]
-        laravel: ["^6.0", "^7.0", "^8.0"]
+        laravel: ["^6.0", "^7.0", "^8.0", "^9.0"]
         exclude:
           - php: "7.2"
             laravel: "^8.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["7.2", "7.3", "7.4", "8.0"]
-        laravel: ["^6.0", "^7.0", "^8.0", "^9.0"]
+        laravel: ["^6.0", "^7.0", "^8.0"]
         exclude:
           - php: "7.2"
             laravel: "^8.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed Dynamic call to static method error for regular methods to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
+- Fixed `Dynamic call to static method` error for regular methods to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed "Dynamic call to static method `xxx()`." error for regular methods (!= macro) to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
+- Fixed "Dynamic call to static method `xxx()`." error for regular methods (!= `Macroable`) to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed "Dynamic call to static method `xxx()`." error for regular methods (!= macro) to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
+
 ### Added
 
 - Support global macros on the eloquent query builder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed "Dynamic call to static method `xxx()`." error for regular methods (!= `Macroable`) to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
+- Fixed Dynamic call to static method error for regular methods to work with [`phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules). ([#483](https://github.com/nunomaduro/larastan/issues/483), [#917](https://github.com/nunomaduro/larastan/pull/917))
 
 ### Added
 

--- a/src/Methods/Passable.php
+++ b/src/Methods/Passable.php
@@ -193,7 +193,7 @@ final class Passable implements PassableContract
             if (get_class($methodReflection) === PhpMethodReflection::class) {
                 $methodReflection = Mockery::mock($methodReflection);
                 $methodReflection->shouldReceive('isStatic')
-                    ->andReturn(true);
+                    ->andReturn($this->isStaticAllowed());
             }
 
             $this->setMethodReflection($methodReflection);


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md


**Changes**

larastan + phpstan-strict generates false positives (related to #483):

```
Dynamic call to static method  Illuminate\Foundation\Application::configurationIsCached().
```

this PR seems to fix it.

**Breaking changes**

Not sure.

_PS: If needed I can provide link to reproduce._
