### PR TITLE
support defining columns with foreignIdFor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for defining columns with `foreignIdFor` in migrations. ([#932](https://github.com/nunomaduro/larastan/pull/932)) Thanks @Josh-G
+
 ## [0.7.12] - 2021-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Support for defining columns with `foreignIdFor` in migrations. ([#932](https://github.com/nunomaduro/larastan/pull/932)) Thanks @Josh-G
+- Partial support for defining columns with `foreignIdFor` in migrations. ([#932](https://github.com/nunomaduro/larastan/pull/932)) Thanks @Josh-G
 
 ## [0.7.12] - 2021-07-26
 

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Properties;
 
+use Illuminate\Support\Str;
 use PhpParser;
 use PhpParser\NodeFinder;
 
@@ -171,28 +172,12 @@ final class SchemaAggregator
                             continue;
                         }
 
-                        if (! class_exists($modelClass)) {
-                            continue;
+                        $columnName = Str::snake(class_basename($modelClass)).'_id';
+                        if ($secondArg instanceof PhpParser\Node\Scalar\String_) {
+                            $columnName = $secondArg->value;
                         }
 
-                        try {
-                            $reflect = new \ReflectionClass($modelClass);
-
-                            /** @var \Illuminate\Database\Eloquent\Model $model */
-                            $model = $reflect->newInstanceWithoutConstructor();
-
-                            $columnName = $model->getForeignKey();
-                            $columnType = $model->getKeyType() === 'int' && $model->getIncrementing()
-                                ? 'int'
-                                : 'string';
-
-                            if ($secondArg instanceof PhpParser\Node\Scalar\String_) {
-                                $columnName = $secondArg->value;
-                            }
-
-                            $table->setColumn(new SchemaColumn($columnName, $columnType, $nullable));
-                        } catch (\ReflectionException $e) {
-                        }
+                        $table->setColumn(new SchemaColumn($columnName, 'mixed', $nullable));
 
                         continue;
                     }

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -177,7 +177,7 @@ final class SchemaAggregator
                             $columnName = $secondArg->value;
                         }
 
-                        $table->setColumn(new SchemaColumn($columnName, 'mixed', $nullable));
+                        $table->setColumn(new SchemaColumn($columnName, 'int', $nullable));
 
                         continue;
                     }

--- a/tests/Application/app/Address.php
+++ b/tests/Application/app/Address.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Address extends Model
+{
+    protected $keyType = 'uuid';
+}

--- a/tests/Application/app/Address.php
+++ b/tests/Application/app/Address.php
@@ -6,6 +6,10 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property string $address_id
+ * @property string $nullable_address_id
+ */
 class Address extends Model
 {
     protected $keyType = 'uuid';

--- a/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\Laravel8\Properties;
 
+use App\Address;
 use App\User;
 use ArrayObject;
 use Illuminate\Support\Collection;
@@ -34,5 +35,25 @@ class ModelPropertyExtension
     public function testAsCollectionCastElements(User $user)
     {
         return $user->properties->first();
+    }
+
+    public function testForeignIdFor(Address $address): int
+    {
+        return $address->user_id;
+    }
+
+    public function testForeignIdForName(Address $address): int
+    {
+        return $address->custom_foreign_id_for_name;
+    }
+
+    public function testForeignIdUUID(Address $address): string
+    {
+        return $address->address_id;
+    }
+
+    public function testForeignIdNullable(Address $address): ?string
+    {
+        return $address->nullable_address_id;
     }
 }

--- a/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
@@ -37,22 +37,26 @@ class ModelPropertyExtension
         return $user->properties->first();
     }
 
-    public function testForeignIdFor(Address $address): int
+    /** @phpstan-return mixed */
+    public function testForeignIdFor(Address $address)
     {
         return $address->user_id;
     }
 
-    public function testForeignIdForName(Address $address): int
+    /** @phpstan-return mixed */
+    public function testForeignIdForName(Address $address)
     {
         return $address->custom_foreign_id_for_name;
     }
 
-    public function testForeignIdUUID(Address $address): string
+    /** @phpstan-return mixed */
+    public function testForeignIdUUID(Address $address)
     {
         return $address->address_id;
     }
 
-    public function testForeignIdNullable(Address $address): ?string
+    /** @phpstan-return mixed */
+    public function testForeignIdNullable(Address $address)
     {
         return $address->nullable_address_id;
     }

--- a/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Laravel8/Properties/ModelPropertyExtension.php
@@ -37,26 +37,22 @@ class ModelPropertyExtension
         return $user->properties->first();
     }
 
-    /** @phpstan-return mixed */
-    public function testForeignIdFor(Address $address)
+    public function testForeignIdFor(Address $address): int
     {
         return $address->user_id;
     }
 
-    /** @phpstan-return mixed */
-    public function testForeignIdForName(Address $address)
+    public function testForeignIdForName(Address $address): int
     {
         return $address->custom_foreign_id_for_name;
     }
 
-    /** @phpstan-return mixed */
-    public function testForeignIdUUID(Address $address)
+    public function testForeignIdUUID(Address $address): string
     {
         return $address->address_id;
     }
 
-    /** @phpstan-return mixed */
-    public function testForeignIdNullable(Address $address)
+    public function testForeignIdNullable(Address $address): ?string
     {
         return $address->nullable_address_id;
     }

--- a/tests/Laravel8Application/database/migrations/2021_09_10_000000_create_addresses_table.php
+++ b/tests/Laravel8Application/database/migrations/2021_09_10_000000_create_addresses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use App\Address;
+use App\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAddressesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignIdFor(User::class);
+            $table->foreignIdFor(User::class, 'custom_foreign_id_for_name');
+            $table->foreignIdFor(Address::class);
+            $table->foreignIdFor(Address::class, 'nullable_address_id')->nullable();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**
This PR adds support for using [`->foreignIdFor(YourModel::class)` in migrations](https://laravel.com/docs/8.x/migrations#column-method-foreignIdFor).

**Breaking changes**
None
