### PR TITLE
Allow users to boot other ServiceProviders by adding them to composer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support global macros on the eloquent query builder.
 - Partial support for defining columns with `foreignIdFor` in migrations. ([#932](https://github.com/nunomaduro/larastan/pull/932)) Thanks @Josh-G
+- Allow users to boot other ServiceProviders by adding them to composer.autoload
 
 ## [0.7.12] - 2021-07-26
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,50 @@ If you are getting the error `Allowed memory size exhausted`, then you can use t
 ./vendor/bin/phpstan analyse --memory-limit=2G
 ```
 
+## Loading other Service Providers (for package development)
+
+When facing errors like, it's possible that even Testbench is not able to load the Service Provider you need, and you may an error like:
+
+```
+Target
+    [Spatie\ResponseCache\Serializers\Serializer]
+is not instantiable while building
+    [Spatie\ResponseCache\ResponseCacheRepository]
+```
+
+To load them you have to
+
+#### Configure Composer "type" to "library"
+
+This is the name Composer uses for packages:
+
+``` json
+{
+    "name": "area17/edge-flush",
+    "type": "library",
+    "description": "Package description",
+    ...
+}
+```
+
+#### Add the Service Provider to be autoloaded to `composer.json`'s autoload-dev:
+
+This will tell larastan to force booting those service providers during testing: 
+
+``` json
+{
+    ...
+
+    "autoload-dev": {
+        "psr-4": {
+            "Spatie\\ResponseCache\\": "vendor/spatie/laravel-responsecache/src"
+        }
+    }
+
+    ...
+}
+```
+
 ## Ignoring errors
 
 Ignoring a specific error can be done either with a php comment or in the configuration file: 


### PR DESCRIPTION
- [ ] Added or updated tests
- [X] Documented user facing changes
- [X] Updated CHANGELOG.md

Resolves https://github.com/nunomaduro/larastan/issues/831

**Changes**

Currently larastan supports registering Service Providers only from the **first** namespace you put in your `composer.json` autoload object. So if you define: 

``` json
{
    ...
    "autoload": {
        "psr-4": {
            "A17\\EdgeFlush\\": "src",
            "A17\\EdgeFlush\\Database\\Factories\\": "database/factories"
        }
    },
    "autoload-dev": {
        "psr-4": {
            "Spatie\\ResponseCache\\": "vendor/spatie/laravel-responsecache/src"
        }
    },
    ...
}
```

It will only register Service Providers from the `A17\EdgeFlush` namespace. And if you define namespaces on your `autoload-dev` it will, by design, completely ignore them too. But while developing packages, we usually need all third party Service Providers, we are using, to be registered.

This PR changes it by booting those defined in `composer.json`. And, if it's running on a package it will also register Service Providers defined in `autoload-dev`. To enable it developers have to set the Composer type to "library".