### PR TITLE
Resolve types for app()->make(), Container::make (and the extending Application::make) and App::make facade

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -162,6 +162,16 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\AppExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ContainerExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\AuthExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/AppExtension.php
+++ b/src/ReturnTypes/AppExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Support\Facades\App;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class AppExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    use Concerns\HasContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return App::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'make';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var Expr $expr */
+        $expr = $methodCall->args[0]->value;
+
+        if ($expr instanceof String_) {
+            try {
+                $resolved = $this->resolve($expr->value);
+
+                if (is_null($resolved)) {
+                    return new ErrorType();
+                }
+
+                return new ObjectType(get_class($resolved));
+            } catch (Throwable $exception) {
+                return new ErrorType();
+            }
+        }
+
+        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
+            return new ObjectType($expr->class->toString());
+        }
+
+        return new NeverType();
+    }
+}

--- a/src/ReturnTypes/ContainerExtension.php
+++ b/src/ReturnTypes/ContainerExtension.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Container\Container;
+use NunoMaduro\Larastan\Concerns;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class ContainerExtension implements DynamicMethodReturnTypeExtension
+{
+    use Concerns\HasContainer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return Container::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'make';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        Expr\MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        /** @var Expr $expr */
+        $expr = $methodCall->args[0]->value;
+
+        if ($expr instanceof String_) {
+            try {
+                $resolved = $this->resolve($expr->value);
+
+                if (is_null($resolved)) {
+                    return new ErrorType();
+                }
+
+                return new ObjectType(get_class($resolved));
+            } catch (Throwable $exception) {
+                return new ErrorType();
+            }
+        }
+
+        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
+            return new ObjectType($expr->class->toString());
+        }
+
+        return new NeverType();
+    }
+}

--- a/tests/Features/ReturnTypes/AppExtension.php
+++ b/tests/Features/ReturnTypes/AppExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Support\Facades\App;
+use NunoMaduro\Larastan\ApplicationResolver;
+
+class AppExtension
+{
+    public function testAppObjectType(): ApplicationResolver
+    {
+        return App::make(ApplicationResolver::class);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testAppMixedType()
+    {
+        return App::make('sentry');
+    }
+
+    public function testAppAuthString(): AuthManager
+    {
+        return App::make('auth');
+    }
+
+    /**
+     * @return null
+     */
+    public function testAppNull()
+    {
+        app()->bind('null', function () {
+        });
+
+        return App::make('null');
+    }
+}

--- a/tests/Features/ReturnTypes/ContainerExtension.php
+++ b/tests/Features/ReturnTypes/ContainerExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Container\Container;
+use NunoMaduro\Larastan\ApplicationResolver;
+
+class ContainerExtension
+{
+    public function testContainerMakeObjectType(): ApplicationResolver
+    {
+        return Container::getInstance()->make(ApplicationResolver::class);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testContainerMakeMixedType()
+    {
+        return Container::getInstance()->make('sentry');
+    }
+
+    public function testContainerMakeAuthString(): AuthManager
+    {
+        return Container::getInstance()->make('auth');
+    }
+
+    /**
+     * @return null
+     */
+    public function testContainerMakeNull()
+    {
+        app()->bind('null', function () {
+        });
+
+        return Container::getInstance()->make('null');
+    }
+
+    public function testAppMakeObjectType(): ApplicationResolver
+    {
+        return app()->make(ApplicationResolver::class);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function testAppMakeMixedType()
+    {
+        return app()->make('sentry');
+    }
+
+    public function testAppMakeAuthString(): AuthManager
+    {
+        return app()->make('auth');
+    }
+
+    /**
+     * @return null
+     */
+    public function testAppMakeNull()
+    {
+        app()->bind('null', function () {
+        });
+
+        return app()->make('null');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes -> no such changes
- [x] Updated CHANGELOG.md

Resolves #941 

Resolves the return types (if possible) from the Container::make method and thus Application::make. Added support for a call through the App facade: App::make.

**Breaking changes**
No breaking changes