### PR TITLE
feat adds `rescue` helper stub

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -2,6 +2,19 @@
 
 /**
  * @template TValue
+ * @template TDefault
+ *
+ * @param callable(): TValue $callback
+ * @param TDefault|(callable(): TDefault) $rescue
+ * @param bool $report
+ * @return TValue|TDefault
+ */
+function rescue(callable $callback, $rescue = null, $report = true)
+{
+}
+
+/**
+ * @template TValue
  * @param int $times
  * @param callable(int): TValue $callback
  * @param int $sleep

--- a/tests/Features/ReturnTypes/Helpers/RescueStub.php
+++ b/tests/Features/ReturnTypes/Helpers/RescueStub.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes\Helpers;
+
+use Exception;
+use function PHPStan\Testing\assertType;
+
+class RescueStub
+{
+    public function testRescueWithNullDefault(): void
+    {
+        $rescued = rescue(function () {
+            if (mt_rand(0, 1)) {
+                throw new Exception();
+            }
+
+            return 'ok';
+        });
+
+        assertType('string|null', $rescued);
+    }
+
+    public function testRescueWithScalarDefault(): void
+    {
+        $rescued = rescue(function () {
+            if (mt_rand(0, 1)) {
+                throw new Exception();
+            }
+
+            return 'ok';
+        }, 'failed');
+
+        assertType('string', $rescued);
+    }
+
+    public function testRescueWithClosureDefault(): void
+    {
+        $rescued = rescue(function () {
+            if (mt_rand(0, 1)) {
+                throw new Exception();
+            }
+
+            return 'ok';
+        }, function () {
+            return 0;
+        });
+
+        assertType('int|string', $rescued);
+    }
+
+    public function testRetryWithoutReporting(): void
+    {
+        $rescued = rescue(function () {
+            if (mt_rand(0, 1)) {
+                throw new Exception();
+            }
+
+            return 'ok';
+        }, 'failed', false);
+
+        assertType('string', $rescued);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR adds `rescue()` helper stub to specify the return type.

**Breaking changes**

I don't know whether you consider specifying a return type a breaking change.
