### PR TITLE
feat: rescue parameter of rescue function now accepts the `Throwable`

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -5,7 +5,7 @@
  * @template TDefault
  *
  * @param callable(): TValue $callback
- * @param TDefault|(callable(): TDefault) $rescue
+ * @param TDefault|(callable(\Throwable): TDefault) $rescue
  * @param bool $report
  * @return TValue|TDefault
  */

--- a/tests/Features/ReturnTypes/Helpers/RescueStub.php
+++ b/tests/Features/ReturnTypes/Helpers/RescueStub.php
@@ -6,6 +6,7 @@ namespace Tests\Features\ReturnTypes\Helpers;
 
 use Exception;
 use function PHPStan\Testing\assertType;
+use Throwable;
 
 class RescueStub
 {
@@ -50,7 +51,22 @@ class RescueStub
         assertType('int|string', $rescued);
     }
 
-    public function testRetryWithoutReporting(): void
+    public function testRescueWithClosureDefaultThrowable(): void
+    {
+        $rescued = rescue(function () {
+            if (mt_rand(0, 1)) {
+                throw new Exception();
+            }
+
+            return 'ok';
+        }, function (Throwable $e) {
+            return 0;
+        });
+
+        assertType('int|string', $rescued);
+    }
+
+    public function testRescueWithoutReporting(): void
     {
         $rescued = rescue(function () {
             if (mt_rand(0, 1)) {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The `$rescue` parameter in the `rescue()` helper now accepts the caught `Throwable`.

**Breaking changes**

None
