### PR TITLE
feat: adds CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,11 @@
             "App\\": "tests/Application/app/",
             "Laravel8\\": "tests/Laravel8Application/app/",
             "Database\\Factories\\": "tests/Laravel8Application/database/factories/",
-            "Database\\Migrations\\": "tests/Laravel8Application/database/migrations/",
-            "Tests\\": "tests/"
-        }
+            "Database\\Migrations\\": "tests/Laravel8Application/database/migrations/"
+        },
+      "classmap": [
+        "tests/"
+      ]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/extension.neon
+++ b/extension.neon
@@ -421,3 +421,4 @@ services:
             - phpstan.rule
 rules:
     - NunoMaduro\Larastan\Rules\RelationExistenceRule
+    - NunoMaduro\Larastan\Rules\CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule

--- a/src/Rules/CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule.php
+++ b/src/Rules/CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+use PhpParser\BuilderFactory;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\BooleanType;
+
+/** @implements Rule<StaticCall> */
+class CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule implements Rule
+{
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
+    /** @var FunctionCallParametersCheck */
+    private $check;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        FunctionCallParametersCheck $check
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->check = $check;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+
+        if (! in_array($methodName, [
+            'dispatch',
+            'dispatchIf',
+            'dispatchUnless',
+            'dispatchSync',
+            'dispatchNow',
+            'dispatchAfterResponse',
+        ],
+            true)
+        ) {
+            return [];
+        }
+
+        if (! $node->class instanceof Node\Name) {
+            return [];
+        }
+
+        $jobClassReflection = $this->reflectionProvider->getClass($scope->resolveName($node->class));
+
+        if (! $jobClassReflection->hasTraitUse(Dispatchable::class)) {
+            return [];
+        }
+
+        if (! $jobClassReflection->hasConstructor()) {
+            $requiredArgCount = 0;
+
+            if (in_array($methodName, ['dispatchIf', 'dispatchUnless'], true)) {
+                $requiredArgCount = 1;
+            }
+
+            if (count($node->getArgs()) > $requiredArgCount) {
+                return [
+                    RuleErrorBuilder::message(sprintf(
+                        'Job class %s does not have a constructor and must be dispatched without any parameters.',
+                        $jobClassReflection->getDisplayName()
+                    ))->build(),
+                ];
+            }
+
+            return [];
+        }
+
+        if (in_array($methodName, ['dispatchIf', 'dispatchUnless'], true)) {
+            if ($node->getArgs() === []) {
+                return []; // Handled by other rules
+            }
+
+            $firstArgType = $scope->getType($node->getArgs()[0]->value);
+            if (! (new BooleanType())->isSuperTypeOf($firstArgType)->yes()) {
+                return []; // Handled by other rules
+            }
+        }
+
+        $constructorReflection = $jobClassReflection->getConstructor();
+
+        $classDisplayName = str_replace('%', '%%', $jobClassReflection->getDisplayName());
+
+        // Special case because these methods have another parameter as first argument.
+        if (in_array($methodName, ['dispatchIf', 'dispatchUnless'], true)) {
+            $args = $node->getArgs();
+            array_shift($args);
+            $node = (new BuilderFactory)->staticCall($node->class, $node->name, $args);
+        }
+
+        // @phpstan-ignore-next-line
+        return $this->check->check(
+            ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $node->getArgs(),
+                $constructorReflection->getVariants()
+            ),
+            $scope,
+            $constructorReflection->getDeclaringClass()->isBuiltin(),
+            $node,
+            [
+                'Job class '.$classDisplayName.' constructor invoked with %d parameter in '.$classDisplayName.'::'.$methodName.'(), %d required.',
+                'Job class '.$classDisplayName.' constructor invoked with %d parameters in '.$classDisplayName.'::'.$methodName.'(), %d required.',
+                'Job class '.$classDisplayName.' constructor invoked with %d parameter in '.$classDisplayName.'::'.$methodName.'(), at least %d required.',
+                'Job class '.$classDisplayName.' constructor invoked with %d parameters in '.$classDisplayName.'::'.$methodName.'(), at least %d required.',
+                'Job class '.$classDisplayName.' constructor invoked with %d parameter in '.$classDisplayName.'::'.$methodName.'(), %d-%d required.',
+                'Job class '.$classDisplayName.' constructor invoked with %d parameters in '.$classDisplayName.'::'.$methodName.'(), %d-%d required.',
+                'Parameter %s of job class '.$classDisplayName.' constructor expects %s in '.$classDisplayName.'::'.$methodName.'(), %s given.',
+                '', // constructor does not have a return type
+                'Parameter %s of job class '.$classDisplayName.' constructor is passed by reference, so it expects variables only',
+                'Unable to resolve the template type %s in instantiation of job class '.$classDisplayName,
+                'Missing parameter $%s in call to '.$classDisplayName.' constructor.',
+                'Unknown parameter $%s in call to '.$classDisplayName.' constructor.',
+                'Return type of call to '.$classDisplayName.' constructor contains unresolvable type.',
+            ]
+        );
+    }
+}

--- a/tests/Rules/CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRuleTest.php
+++ b/tests/Rules/CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRuleTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use NunoMaduro\Larastan\Rules\CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\NullsafeCheck;
+use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule> */
+class CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRuleTest extends RuleTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getRule(): Rule
+    {
+        $broker = $this->createReflectionProvider();
+
+        return new CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule(
+            $broker,
+            new FunctionCallParametersCheck(new RuleLevelHelper($broker, true, false, true, false), new NullsafeCheck(), new PhpVersion(80000), new UnresolvableTypeHelper(), true, true, true, true)
+        );
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Data/job-dispatch.php'], [
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 0 parameters in Tests\Rules\Data\LaravelJob::dispatch(), 2 required.', 5],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 0 parameters in Tests\Rules\Data\LaravelJob::dispatchSync(), 2 required.', 6],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 0 parameters in Tests\Rules\Data\LaravelJob::dispatchNow(), 2 required.', 7],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 0 parameters in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), 2 required.', 8],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 1 parameter in Tests\Rules\Data\LaravelJob::dispatch(), 2 required.', 10],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatch(), int given.', 11],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatch(), string given.', 11],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatch(), true given.', 12],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatch(), false given.', 12],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 1 parameter in Tests\Rules\Data\LaravelJob::dispatchSync(), 2 required.', 14],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchSync(), int given.', 15],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchSync(), string given.', 15],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchSync(), true given.', 16],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchSync(), false given.', 16],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 1 parameter in Tests\Rules\Data\LaravelJob::dispatchNow(), 2 required.', 18],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchNow(), int given.', 19],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchNow(), string given.', 19],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchNow(), true given.', 20],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchNow(), false given.', 20],
+            ['Job class Tests\Rules\Data\LaravelJob constructor invoked with 1 parameter in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), 2 required.', 22],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), int given.', 23],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), string given.', 23],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), true given.', 24],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchAfterResponse(), false given.', 24],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchIf(), int given.', 26],
+            ['Parameter #2 $bar of job class Tests\Rules\Data\LaravelJob constructor expects int in Tests\Rules\Data\LaravelJob::dispatchIf(), string given.', 26],
+            ['Parameter #1 $foo of job class Tests\Rules\Data\LaravelJob constructor expects string in Tests\Rules\Data\LaravelJob::dispatchUnless(), int given.', 27],
+            ['Job class Tests\Rules\Data\LaravelJobWithoutConstructor does not have a constructor and must be dispatched without any parameters.', 30],
+            ['Job class Tests\Rules\Data\LaravelJobWithoutConstructor does not have a constructor and must be dispatched without any parameters.', 32],
+            ['Job class Tests\Rules\Data\LaravelJobWithoutConstructor does not have a constructor and must be dispatched without any parameters.', 34],
+            ['Job class Tests\Rules\Data\LaravelJobWithoutConstructor does not have a constructor and must be dispatched without any parameters.', 36],
+            ['Job class Tests\Rules\Data\LaravelJobWithoutConstructor does not have a constructor and must be dispatched without any parameters.', 39],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/phpstan-rules.neon',
+        ];
+    }
+}

--- a/tests/Rules/Data/job-dispatch-classes.php
+++ b/tests/Rules/Data/job-dispatch-classes.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class LaravelJob
+{
+    use Dispatchable;
+
+    /** @var string */
+    private $foo;
+
+    /** @var int */
+    private $bar;
+
+    public function __construct(string $foo, int $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+}
+
+class LaravelJobWithoutConstructor
+{
+    use Dispatchable;
+}

--- a/tests/Rules/Data/job-dispatch.php
+++ b/tests/Rules/Data/job-dispatch.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+LaravelJob::dispatch();
+LaravelJob::dispatchSync();
+LaravelJob::dispatchNow();
+LaravelJob::dispatchAfterResponse();
+
+LaravelJob::dispatch('foo');
+LaravelJob::dispatch(1, 'foo');
+LaravelJob::dispatch(true, false);
+
+LaravelJob::dispatchSync('foo');
+LaravelJob::dispatchSync(1, 'foo');
+LaravelJob::dispatchSync(true, false);
+
+LaravelJob::dispatchNow('foo');
+LaravelJob::dispatchNow(1, 'foo');
+LaravelJob::dispatchNow(true, false);
+
+LaravelJob::dispatchAfterResponse('foo');
+LaravelJob::dispatchAfterResponse(1, 'foo');
+LaravelJob::dispatchAfterResponse(true, false);
+
+LaravelJob::dispatchIf(true, 1, 'foo');
+LaravelJob::dispatchUnless(true, 1, 1);
+
+LaravelJobWithoutConstructor::dispatch();
+LaravelJobWithoutConstructor::dispatch('foo');
+LaravelJobWithoutConstructor::dispatchSync();
+LaravelJobWithoutConstructor::dispatchSync('foo');
+LaravelJobWithoutConstructor::dispatchNow();
+LaravelJobWithoutConstructor::dispatchNow('foo');
+LaravelJobWithoutConstructor::dispatchAfterResponse();
+LaravelJobWithoutConstructor::dispatchAfterResponse('foo');
+
+LaravelJobWithoutConstructor::dispatchIf(true);
+LaravelJobWithoutConstructor::dispatchUnless(true, 'foo');


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Implements #927 

**Changes**

This PR adds a rule that can check arguments given in `dispatch` (and other variants) method against the job class constructor.

