### PR TITLE
See phpstan-strict-rules in action

### DIFF
--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -21,7 +21,7 @@ sed -e 's/string/string|void/' -i app/Http/Middleware/Authenticate.php
 sed '0,/}/s/}/}\nreturn;/' -i app/Http/Middleware/Authenticate.php
 
 echo "Test Laravel"
-vendor/bin/phpstan analyse app --level=5 -c vendor/nunomaduro/larastan/extension.neon
+vendor/bin/phpstan analyse app --level=5
 cd -
 
 echo "Test Laravel from other working directories"
@@ -69,7 +69,7 @@ cat <<"EOF" | patch -p 0
 EOF
 
 echo "Test Lumen"
-vendor/bin/phpstan analyse app --level=5 -c vendor/nunomaduro/larastan/extension.neon
+vendor/bin/phpstan analyse app --level=5
 cd -
 
 echo "Test Lumen from other working directories"

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -9,7 +9,7 @@ cd ../laravel/
 echo "Add package from source"
 sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan", "options": { "symlink": false }} ],|' -i composer.json
 # Work-around for conflicting psr/log versions
-composer require --dev --no-update "nunomaduro/larastan:*"
+composer require --dev --no-update "nunomaduro/larastan:*" "phpstan/extension-installer" "phpstan/phpstan-strict-rules"
 composer update
 
 echo "Fix https://github.com/laravel/framework/pull/23825"
@@ -38,7 +38,7 @@ fi
 
 echo "Add package from source"
 sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../larastan", "options": { "symlink": false }} ],|' -i composer.json
-composer require --dev "nunomaduro/larastan:*"
+composer require --dev "nunomaduro/larastan:*" "phpstan/extension-installer" "phpstan/phpstan-strict-rules"
 
 echo "Fix Handler::render return type"
 sed -e 's/@return \\Illuminate\\Http\\Response|\\Illuminate\\Http\\JsonResponse$/@return \\Symfony\\Component\\HttpFoundation\\Response/' \


### PR DESCRIPTION
in Laravel:
```
 ------ -------------------------------------------------------------------- 
  Line   Http/Middleware/Authenticate.php                                    
 ------ -------------------------------------------------------------------- 
  15     Return type (string|void|null) of method                            
         App\Http\Middleware\Authenticate::redirectTo() should be covariant  
         with return type (string|null) of method                            
         Illuminate\Auth\Middleware\Authenticate::redirectTo()               
 ------ -------------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   Http/Middleware/RedirectIfAuthenticated.php                    
 ------ --------------------------------------------------------------- 
  22     Construct empty() is not allowed. Use more strict comparison.  
 ------ --------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Providers/RouteServiceProvider.php                                    
 ------ ---------------------------------------------------------------------- 
  60     Short ternary operator is not allowed. Use null coalesce operator if  
         applicable or consider using long ternary.                            
 ------ ---------------------------------------------------------------------- 
```