### PR TITLE
feat: improve return types for Collection::first, last, get and pull when default value is given.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix `groupBy` Collection method signature
 * Renamed `CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule` to `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` by @canvural in https://github.com/nunomaduro/larastan/pull/1003
 * `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` now checks for argument types compatibility with the class constructor for both Event and Job classes. by @canvural in https://github.com/nunomaduro/larastan/pull/1003
+* Improved return type for Collection::first, last, get, pull when giving a  default value.
 
 ### Improvements
 * Clarified "static analysis" wording in docs and logo by @asgrim in https://github.com/nunomaduro/larastan/pull/1008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+* Improved return type for Collection::first, last, get, pull when giving a  default value.
+
 ## [1.0.1] - 2021-11-06
 
 ### Changed
 * Fix `groupBy` Collection method signature
 * Renamed `CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule` to `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` by @canvural in https://github.com/nunomaduro/larastan/pull/1003
 * `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` now checks for argument types compatibility with the class constructor for both Event and Job classes. by @canvural in https://github.com/nunomaduro/larastan/pull/1003
-* Improved return type for Collection::first, last, get, pull when giving a  default value.
 
 ### Improvements
 * Clarified "static analysis" wording in docs and logo by @asgrim in https://github.com/nunomaduro/larastan/pull/1008

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -29,7 +29,7 @@ class Collection implements \ArrayAccess, Enumerable
 
     /**
      * @template TDefault
-     * @param    mixed  $key
+     * @param    TKey  $key
      * @param    TDefault  $default
      * @return   TValue|TDefault
      */
@@ -42,7 +42,7 @@ class Collection implements \ArrayAccess, Enumerable
 
     /**
      * @template TDefault
-     * @param    mixed  $key
+     * @param    TKey  $key
      * @param    TDefault  $default
      * @return   TValue|TDefault
      */

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -11,24 +11,27 @@ namespace Illuminate\Support;
 class Collection implements \ArrayAccess, Enumerable
 {
     /**
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return TValue|null
+     * @template TDefault
+     * @param    callable|null  $callback
+     * @param    TDefault  $default
+     * @return   TValue|TDefault
      */
     public function first(callable $callback = null, $default = null){}
 
     /**
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return TValue|null
+     * @template TDefault
+     * @param    callable|null  $callback
+     * @param    TDefault  $default
+     * @return   TValue|TDefault
      */
     public function last(callable $callback = null, $default = null){}
 
 
     /**
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return TValue|null
+     * @template TDefault
+     * @param    mixed  $key
+     * @param    TDefault  $default
+     * @return   TValue|TDefault
      */
     public function get($key, $default = null) {}
 
@@ -38,9 +41,10 @@ class Collection implements \ArrayAccess, Enumerable
     public function pop() {}
 
     /**
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return TValue|null
+     * @template TDefault
+     * @param    mixed  $key
+     * @param    TDefault  $default
+     * @return   TValue|TDefault
      */
     public function pull($key, $default = null) {}
 

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -68,3 +68,15 @@ $foo
     ->map(function ($grouped, $groupKey): array {
         assertType('(int|string)', $groupKey);
     });
+
+assertType('App\User|null', $collection->first());
+assertType('App\User', $collection->first(null, new User()));
+
+assertType('App\User|null', $collection->last());
+assertType('App\User', $collection->last(null, new User()));
+
+assertType('App\User|null', $collection->get(1));
+assertType('App\User', $collection->get(1, new User()));
+
+assertType('App\User|null', $collection->pull(1));
+assertType('App\User', $collection->pull(1, new User()));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

This PR improves return type resolution for Collection::first, last, get and pull when default value is given.

Today, 
```php
User::all()->first(default: new User);
```
is typed as `User|null`, even if it actually never returns null.

With this PR, it will be typed as `User`.

Strange calls are also supported
```php
User::all()->first(default: 42); // User|int
```
(I really don't know why someone would write this but why not ?)

This PR does not add support for callable as default
```php
User::all()->first(default: fn() => new User);
```
My guess is it will be a little bit more complicated than just a stub update.


**Breaking changes**

I hope there won't be any
