### PR TITLE
feat: adds throw types for macros

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -25,3 +25,5 @@ if ($app instanceof Application) {
 } elseif ($app instanceof LumenApplication) {
     $app->boot();
 }
+
+define('LARAVEL_VERSION', $app->version());

--- a/tests/Reflection/MacroMethodsClassReflectionExtensionTest.php
+++ b/tests/Reflection/MacroMethodsClassReflectionExtensionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Reflection;
+
+use Generator;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use NunoMaduro\Larastan\Methods\Extension;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\ObjectType;
+
+class MacroMethodsClassReflectionExtensionTest extends PHPStanTestCase
+{
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
+    /**
+     * @var Extension
+     */
+    private $reflectionExtension;
+
+    /** @var string */
+    private $laravelVersion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reflectionProvider = $this->createReflectionProvider();
+        $this->reflectionExtension = new Extension(
+            self::getContainer()->getByType(PhpMethodReflectionFactory::class),
+            $this->reflectionProvider
+        );
+        $this->laravelVersion = LARAVEL_VERSION;
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider methodAndClassProvider
+     */
+    public function it_can_find_macros_on_a_class(string $class, string $methodName, string $laravelVersion)
+    {
+        if ($laravelVersion !== '' && version_compare($this->laravelVersion, $laravelVersion, '<')) {
+            $this->markTestSkipped('This test requires Laravel 8.0 or higher.');
+        }
+
+        $requestClass = $this->reflectionProvider->getClass($class);
+
+        $this->assertTrue($this->reflectionExtension->hasMethod($requestClass, $methodName));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider methodAndThrowTypeProvider
+     */
+    public function it_can_set_throw_type_for_macros(string $class, string $methodName, string $exceptionClass)
+    {
+        $requestClass = $this->reflectionProvider->getClass($class);
+
+        $this->assertTrue($this->reflectionExtension->hasMethod($requestClass, $methodName));
+
+        $method = $this->reflectionExtension->getMethod($requestClass, $methodName);
+
+        $this->assertNotNull($method->getThrowType());
+        $this->assertInstanceOf(ObjectType::class, $method->getThrowType());
+        $this->assertSame($exceptionClass, $method->getThrowType()->getClassName());
+    }
+
+    public function methodAndClassProvider(): Generator
+    {
+        yield [Request::class, 'validate', ''];
+        yield [Request::class, 'validateWithBag', ''];
+        yield [Request::class, 'hasValidSignature', ''];
+        yield [Request::class, 'hasValidRelativeSignature', '8.0'];
+    }
+
+    public function methodAndThrowTypeProvider(): Generator
+    {
+        yield [Request::class, 'validate', ValidationException::class];
+        yield [Request::class, 'validateWithBag', ValidationException::class];
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__.'/../../extension.neon'];
+    }
+}

--- a/tests/Type/MethodsClassReflectionExtensionTest.php
+++ b/tests/Type/MethodsClassReflectionExtensionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Type;
+
+class MethodsClassReflectionExtensionTest extends \PHPStan\Testing\TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public function dataFileAsserts(): iterable
+    {
+        yield from $this->gatherAssertTypes(__DIR__.'/data/macros.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__.'/../../extension.neon'];
+    }
+}

--- a/tests/Type/data/macros.php
+++ b/tests/Type/data/macros.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Macros;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use function PHPStan\Testing\assertVariableCertainty;
+use PHPStan\TrinaryLogic;
+
+try {
+    Request::validate([]);
+} catch (ValidationException $e) {
+    $foo = 'foo';
+}
+
+assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes https://github.com/nunomaduro/larastan/issues/1004

**Changes**

This PR adds support to define throw types for macro methods. Since macros are magic methods, a map of method names and exception classes is used. So in future this map should be updated if we want to add more method and exception combinations.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
