### PR TITLE
Update default config to match new highest level

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ parameters:
     paths:
         - app
 
-    # The level 8 is the highest level
+    # The level 9 is the highest level
     level: 5
 
     ignoreErrors:


### PR DESCRIPTION
Boilerplate wasn't really applicable. The new highest level in PHPStan is 9, this change reflects that in the documentation where it was previously stated that the max level was 8.