### PR TITLE
fix: improve return types for Collection `first`, `firstWhere`, `last`

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -12,20 +12,27 @@ class Collection implements \ArrayAccess, Enumerable
 {
     /**
      * @template TDefault
-     * @param    callable|null  $callback
-     * @param    TDefault  $default
+     * @param    null|callable(TValue, TKey): bool  $callback
+     * @param    TDefault|callable(): TDefault  $default
      * @return   TValue|TDefault
      */
     public function first(callable $callback = null, $default = null){}
 
     /**
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return TValue|null
+     */
+    public function firstWhere($key, $operator = null, $value = null){}
+
+    /**
      * @template TDefault
-     * @param    callable|null  $callback
-     * @param    TDefault  $default
-     * @return   TValue|TDefault
+     * @param  null|callable(TValue, TKey): bool  $callback
+     * @param  TDefault|callable(): TDefault  $default
+     * @return TValue|TDefault
      */
     public function last(callable $callback = null, $default = null){}
-
 
     /**
      * @template TDefault

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -70,10 +70,32 @@ $foo
     });
 
 assertType('App\User|null', $collection->first());
-assertType('App\User', $collection->first(null, new User()));
+assertType('App\User|bool', $collection->first(null, false));
+assertType('App\User|null', $collection->first(function ($user) {
+    assertType('App\User', $user);
+    return $user->id > 1;
+}));
+assertType('App\User|bool', $collection->first(function (User $user) {
+    assertType('App\User', $user);
+    return $user->id > 1;
+}, function () {
+    return false;
+}));
+
+assertType('App\User|null', $collection->firstWhere('blocked'));
+assertType('App\User|null', $collection->firstWhere('blocked', true));
+assertType('App\User|null', $collection->firstWhere('blocked', '=', true));
 
 assertType('App\User|null', $collection->last());
-assertType('App\User', $collection->last(null, new User()));
+assertType('App\User|bool', $collection->last(null, false));
+assertType('App\User|null', $collection->last(function (User $user) {
+    return $user->id > 1;
+}));
+assertType('App\User|bool', $collection->last(function (User $user) {
+    return $user->id > 1;
+}, function () {
+    return false;
+}));
 
 assertType('App\User|null', $collection->get(1));
 assertType('App\User', $collection->get(1, new User()));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Improves #1010

**Changes**

Adds return types for callable `$default` parameters in `first()` and `last()` methods:
```php
User::all()->first(default: fn () => false); // User|bool
User::all()->last(default: fn () => false); // User|bool
```

Adds `firstWhere` to the collection stubs:
```php
User::all()->firstWhere('blocked'); // User|null
User::all()->firstWhere('blocked', true); // User|null
User::all()->firstWhere('blocked', '=', true); // User|null
```

**Breaking changes**

None.
