### PR TITLE
fix: Eloquent collection has array-key for the key type

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -3,7 +3,7 @@
 namespace Illuminate\Support;
 
 /**
- * @template TKey
+ * @template TKey of array-key
  * @template TValue
  * @implements \ArrayAccess<TKey, TValue>
  * @implements Enumerable<TKey, TValue>

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Traits\EnumeratesValues;
 
 /**
  * @template TValue
- * @extends \Illuminate\Support\Collection<int, TValue>
+ * @extends \Illuminate\Support\Collection<array-key, TValue>
  */
 class Collection extends \Illuminate\Support\Collection
 {
@@ -30,7 +30,7 @@ class Collection extends \Illuminate\Support\Collection
 
     /**
      * @param callable(TValue, int): mixed $callback
-     * @return \Illuminate\Support\Collection<mixed, mixed>
+     * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function flatMap(callable $callback) {}
 

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -27,13 +27,13 @@ assertType('Illuminate\Database\Eloquent\Collection<App\User>', $collection->key
 assertType('Illuminate\Support\Collection<string, Illuminate\Support\Collection<int, int>>', $collection->mapToGroups(function (User $user, int $key): array {
     return ['foo' => $user->id];
 }));
-assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<int, App\User>>', $collection->groupBy('id'));
+assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), App\User>>', $collection->groupBy('id'));
 assertType('Illuminate\Support\Collection<int, App\User>', User::all()->mapInto(User::class));
-assertType('Illuminate\Support\Collection<int, App\User>', $collection->flatMap(function (User $user, int $id): array {
+assertType('Illuminate\Support\Collection<(int|string), App\User>', $collection->flatMap(function (User $user, int $id): array {
     return [$user];
 }));
 assertType(
-    'Illuminate\Support\Collection<int, App\Account>',
+    'Illuminate\Support\Collection<(int|string), App\Account>',
     $collection->flatMap(function (User $user, int $id) {
         return $user->accounts;
     })


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes #1026 

**Changes**

Eloquent collection can have `array-key` as the `Collection` key type.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
