### PR TITLE
fix: the tap helper should not enforce any return type for the callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+* No return type should be enforced for closure of tap helper 
+
 ### Changed
 * Improved return type for Collection::first, last, get, pull when giving a  default value.
 

--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -30,7 +30,7 @@ function retry($times, callable $callback, $sleep = 0, $when = null)
 /**
  * @template TValue
  * @param TValue $value
- * @param null|callable(TValue): void $callback
+ * @param null|callable(TValue): mixed $callback
  * @return mixed
  */
 function tap($value, $callback = null)


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1030

**Changes**

The tap helper declared a void return type for the closure. But as the return value is never used, there should not be a restricting type.