### PR TITLE
fix: respect ancestor property tags in model extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * No return type should be enforced for closure of tap helper 
+* Ensure the model extensions considers PHPDoc `@property` tags from ancestors, not just the model class itself
 
 ### Changed
 * Improved return type for Collection::first, last, get, pull when giving a  default value.

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -7,6 +7,7 @@ namespace NunoMaduro\Larastan\Properties;
 use ArrayObject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use NunoMaduro\Larastan\Reflection\ReflectionHelper;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
@@ -19,7 +20,7 @@ use PHPStan\Type\IntegerType;
  */
 final class ModelPropertyExtension implements PropertiesClassReflectionExtension
 {
-    /** @var SchemaTable[] */
+    /** @var array<string, SchemaTable> */
     private $tables = [];
 
     /** @var TypeStringResolver */
@@ -51,7 +52,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
             return false;
         }
 
-        if (array_key_exists($propertyName, $classReflection->getPropertyTags())) {
+        if (array_key_exists($propertyName, ReflectionHelper::collectPropertyTags($classReflection))) {
             return false;
         }
 

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -52,7 +52,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
             return false;
         }
 
-        if (array_key_exists($propertyName, ReflectionHelper::collectPropertyTags($classReflection))) {
+        if (ReflectionHelper::hasPropertyTag($classReflection, $propertyName)) {
             return false;
         }
 

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use NunoMaduro\Larastan\Concerns;
 use NunoMaduro\Larastan\Methods\BuilderHelper;
+use NunoMaduro\Larastan\Reflection\ReflectionHelper;
 use NunoMaduro\Larastan\Types\RelationParserHelper;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
@@ -49,7 +50,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
             return false;
         }
 
-        if (array_key_exists($propertyName, $classReflection->getPropertyTags())) {
+        if (array_key_exists($propertyName, ReflectionHelper::collectPropertyTags($classReflection))) {
             return false;
         }
 

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -50,7 +50,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
             return false;
         }
 
-        if (array_key_exists($propertyName, ReflectionHelper::collectPropertyTags($classReflection))) {
+        if (ReflectionHelper::hasPropertyTag($classReflection, $propertyName)) {
             return false;
         }
 

--- a/src/Reflection/ReflectionHelper.php
+++ b/src/Reflection/ReflectionHelper.php
@@ -4,27 +4,25 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Reflection;
 
-use PHPStan\PhpDoc\Tag\PropertyTag;
 use PHPStan\Reflection\ClassReflection;
 
 final class ReflectionHelper
 {
     /**
-     * Returns all property tags of the given class and its ancestors.
-     *
-     * In case of duplicates, the tags of the class itself have precedence.
-     * TODO consider the hierarchy to ensure correct precedence between ancestors
-     *
-     * @return array<string, PropertyTag>
+     * Does the given class or any of its ancestors have an `@property*` annotation with the given name?
      */
-    public static function collectPropertyTags(ClassReflection $classReflection): array
+    public static function hasPropertyTag(ClassReflection $classReflection, string $propertyName): bool
     {
-        $allPropertyTags = $classReflection->getPropertyTags();
-
-        foreach ($classReflection->getAncestors() as $ancestor) {
-            $allPropertyTags += $ancestor->getPropertyTags();
+        if (array_key_exists($propertyName, $classReflection->getPropertyTags())) {
+            return true;
         }
 
-        return $allPropertyTags;
+        foreach ($classReflection->getAncestors() as $ancestor) {
+            if (array_key_exists($propertyName, $ancestor->getPropertyTags())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Reflection/ReflectionHelper.php
+++ b/src/Reflection/ReflectionHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Reflection;
+
+use PHPStan\PhpDoc\Tag\PropertyTag;
+use PHPStan\Reflection\ClassReflection;
+
+final class ReflectionHelper
+{
+    /**
+     * Returns all property tags of the given class and its ancestors.
+     *
+     * In case of duplicates, the tags of the class itself have precedence.
+     * TODO consider the hierarchy to ensure correct precedence between ancestors
+     *
+     * @return array<string, PropertyTag>
+     */
+    public static function collectPropertyTags(ClassReflection $classReflection): array
+    {
+        $allPropertyTags = $classReflection->getPropertyTags();
+
+        foreach ($classReflection->getAncestors() as $ancestor) {
+            $allPropertyTags += $ancestor->getPropertyTags();
+        }
+
+        return $allPropertyTags;
+    }
+}

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use function PHPStan\Testing\assertType;
@@ -232,6 +233,26 @@ class Relations
 
         return $user->posts()->create();
     }
+
+    public function testNullableUser(ExtendsModelWithPropertyAnnotations $model): bool
+    {
+        return $model->nullableUser === null;
+    }
+
+    public function testNonNullableUser(ExtendsModelWithPropertyAnnotations $model): User
+    {
+        return $model->nonNullableUser;
+    }
+
+    public function testNullableFoo(ExtendsModelWithPropertyAnnotations $model): bool
+    {
+        return $model->nullableFoo === null;
+    }
+
+    public function testNonNullableFoo(ExtendsModelWithPropertyAnnotations $model): string
+    {
+        return $model->nonNullableFoo;
+    }
 }
 
 /**
@@ -256,6 +277,39 @@ class ModelWithoutPropertyAnnotation extends Model
     {
         return $this->hasMany(User::class);
     }
+}
+
+/**
+ * @property-read User|null $nullableUser
+ * @property-read User $nonNullableUser
+ * @property-read string|null $nullableFoo
+ * @property-read string $nonNullableFoo
+ */
+class ModelWithPropertyAnnotations extends Model
+{
+    public function nullableUser(): HasOne
+    {
+        return $this->hasOne(User::class);
+    }
+
+    public function nonNullableUser(): HasOne
+    {
+        return $this->hasOne(User::class);
+    }
+
+    public function getNullableFooAttribute(): ?string
+    {
+        return rand() ? 'foo' : null;
+    }
+
+    public function getNonNullableFooAttribute(): string
+    {
+        return 'foo';
+    }
+}
+
+class ExtendsModelWithPropertyAnnotations extends ModelWithPropertyAnnotations
+{
 }
 
 class Tag extends Model


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~Documented user facing changes~
- [x] Updated CHANGELOG.md

**Changes**

Ensure the model extensions considers PHPDoc `@property` tags from ancestors, not just the model class itself.

**Breaking changes**

None.