### PR TITLE
Precise return type for `Enumerable::partition()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Ensure the model extensions considers PHPDoc `@property` tags from ancestors, not just the model class itself
 
 ### Changed
-* Improved return type for Collection::first, last, get, pull when giving a  default value.
+* Improved return type for Collection::first, last, get, pull when giving a default value.
+* Precise return type for `Enumerable::partition()`
 
 ## [1.0.1] - 2021-11-06
 

--- a/stubs/Enumerable.stub
+++ b/stubs/Enumerable.stub
@@ -14,7 +14,7 @@ interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable
      * @param string|callable(TValue, TKey): bool $key
      * @param mixed $operator
      * @param mixed $value
-     * @return static<static>
+     * @return static<int<0, 1>, static<TKey, TValue>>
      */
     public function partition($key, $operator = null, $value = null);
 

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -104,3 +104,11 @@ assertType('App\User', $collection->get(1, new User()));
 
 assertType('App\User|null', $collection->pull(1));
 assertType('App\User', $collection->pull(1, new User()));
+
+$partitions = collect(['foo' => 1])->partition(function ($item, $key): bool {
+    assertType('int', $item);
+    assertType('string', $key);
+
+    return true;
+});
+assertType('Illuminate\Support\Enumerable<int<0, 1>, Illuminate\Support\Enumerable<string, int>>', $partitions);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~Documented user facing changes~
- [x] Updated CHANGELOG.md

**Changes**

Fixes the false-positive error reported in this example:

![image](https://user-images.githubusercontent.com/12158000/142652761-81c484c7-8379-434a-bcc5-24ca47d2114b.png)

**Breaking changes**

None, analysis will be more precise.