### PR TITLE
Infer type of model `id` without migrations

### DIFF
--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -119,15 +119,16 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
         }
 
         if (
-            (! array_key_exists($tableName, $this->tables)
-                || ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
+            (
+                ! array_key_exists($tableName, $this->tables) ||
+                ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
             )
             && $propertyName === 'id'
         ) {
             return new ModelProperty(
                 $classReflection,
-                new IntegerType(),
-                new IntegerType()
+                $this->stringResolver->resolve($modelInstance->getKeyType()),
+                $this->stringResolver->resolve($modelInstance->getKeyType()),
             );
         }
 

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -128,7 +128,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
             return new ModelProperty(
                 $classReflection,
                 $this->stringResolver->resolve($modelInstance->getKeyType()),
-                $this->stringResolver->resolve($modelInstance->getKeyType()),
+                $this->stringResolver->resolve($modelInstance->getKeyType())
             );
         }
 

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -120,8 +120,8 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
 
         if (
             (
-                ! array_key_exists($tableName, $this->tables) ||
-                ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
+                ! array_key_exists($tableName, $this->tables)
+                || ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
             )
             && $propertyName === 'id'
         ) {

--- a/tests/Application/app/Team.php
+++ b/tests/Application/app/Team.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+}

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -8,6 +8,7 @@ use App\Account;
 use App\Group;
 use App\GuardedModel;
 use App\Role;
+use App\Team;
 use App\Thread;
 use App\User;
 use Carbon\Carbon as BaseCarbon;
@@ -26,6 +27,9 @@ class ModelPropertyExtension
 
     /** @var Group */
     private $group; // @phpstan-ignore-line
+
+    /** @var Team */
+    private $team; // @phpstan-ignore-line
 
     public function testPropertyReturnType(): int
     {
@@ -112,6 +116,19 @@ class ModelPropertyExtension
         $group->id = 5;
 
         return $group->save();
+    }
+
+    public function testReadIdPropertyWhenMigrationsCouldntBeReadAndKeyTypeIsString(): string
+    {
+        return $this->team->id;
+    }
+
+    public function testWriteIdPropertyWhenMigrationsCouldntBeReadAndKeyTypeIsString(): bool
+    {
+        $team = new Team();
+        $team->id = 'five';
+
+        return $team->save();
     }
 
     public function testModelWithGuardedProperties(GuardedModel $guardedModel): string


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

#499 #536 #1029

**Changes**

Ths PR allows infering the `$id` property from a model when there are no migrations.
This assumes that the `$keyType` property or the `getKeyType()` method has been modified accordingly.

**Breaking changes**

Probably not, but I'm not sure.
