### PR TITLE
fix: Call to an undefined method Eloquent\Builder::restore

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -22,6 +22,7 @@ use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\IntegerType;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension
 {
@@ -107,10 +108,21 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         if ($ref === null) {
             // Special case for `SoftDeletes` trait
             if (
-                in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed'], true) &&
+                in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed', 'restore'], true) &&
                 in_array(SoftDeletes::class, array_keys($modelReflection->getTraits(true)))
             ) {
                 $ref = $this->reflectionProvider->getClass(SoftDeletes::class)->getMethod($methodName, new OutOfClassScope());
+
+                if ($methodName === 'restore') {
+                    return new EloquentBuilderMethodReflection(
+                        $methodName,
+                        $classReflection,
+                        $ref,
+                        ParametersAcceptorSelector::selectSingle($ref->getVariants())->getParameters(),
+                        new IntegerType(),
+                        ParametersAcceptorSelector::selectSingle($ref->getVariants())->isVariadic()
+                    );
+                }
 
                 return new EloquentBuilderMethodReflection(
                     $methodName,

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -19,10 +19,10 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateObjectType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
-use PHPStan\Type\IntegerType;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension
 {

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -220,4 +220,10 @@ class Builder
         return User::with('foo')
             ->value(\Illuminate\Support\Facades\DB::raw('name'));
     }
+
+    /** @phpstan-return integer */
+    public function testRestore()
+    {
+        return User::query()->restore();
+    }
 }

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -221,7 +221,7 @@ class Builder
             ->value(\Illuminate\Support\Facades\DB::raw('name'));
     }
 
-    /** @phpstan-return integer */
+    /** @phpstan-return int */
     public function testRestore()
     {
         return User::query()->restore();


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Fix #1040

**Changes**

Make sure Larastan find `Illuminate\Database\Eloquent\Builder::restore()`, and proper returnType.
