### PR TITLE
Fix SchemaAggregation when renaming tables through non-static method call

### DIFF
--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -120,7 +120,6 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertArrayHasKey('accounts', $tables);
     }
 
-
     /**
      * @param  array<string, SchemaTable>  $tables
      */

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -106,6 +106,21 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
     }
 
+    /** @test */
+    public function it_can_handle_alter_table_rename()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [
+            __DIR__.'/data/rename_migrations',
+        ], $this->fileHelper);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayNotHasKey('users', $tables);
+        self::assertArrayHasKey('accounts', $tables);
+    }
+
+
     /**
      * @param  array<string, SchemaTable>  $tables
      */

--- a/tests/Unit/data/rename_migrations/2021_12_08_000000_rename_users_table.php
+++ b/tests/Unit/data/rename_migrations/2021_12_08_000000_rename_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\RenameMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->rename('accounts');
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

In Laravel migrations we can rename a table by getting a reference to the table through Schema::table and renaming the table via the rename method. 
Larastan analyzes those cases incorrectly, but rather treats them the same as a "renameColumn" call, resulting in "trying to access undefined property x" errors on models whose tables were renamed through that method.
This PR aims at changing that.

The method does not seem to be well documented but when you already have migrations using the method, it's hard to change them afterwards.

**Breaking changes**

I'm not aware of any.
