### PR TITLE
feat: enable Testbench package discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+* Automatically discover packages via `Orchestra\Testbench`
+
 ## [1.0.2] - 2021-11-23
 
 ### Added

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -19,7 +19,7 @@ final class ApplicationResolver
 
     /** @var mixed */
     public static $composer;
-    
+
     /** @var bool */
     protected $enablesPackageDiscoveries = true;
 

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -20,7 +20,7 @@ final class ApplicationResolver
     /** @var mixed */
     public static $composer;
     
-    /** $var bool */
+    /** @var bool */
     protected $enablesPackageDiscoveries = true;
 
     /**

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -20,7 +20,8 @@ final class ApplicationResolver
     /** @var mixed */
     public static $composer;
     
-    protected bool $enablesPackageDiscoveries = true;
+    /** $var bool */
+    protected $enablesPackageDiscoveries = true;
 
     /**
      * Creates an application and registers service providers found.

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -19,6 +19,8 @@ final class ApplicationResolver
 
     /** @var mixed */
     public static $composer;
+    
+    protected bool $enablesPackageDiscoveries = true;
 
     /**
      * Creates an application and registers service providers found.


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**
I was having problems with Laravel being able to resolve an interface which was bound to the container in a service provider from another package (which the package I am testing depends on). Tests with Testbench worked fine, but not via PHPStan. Turns out Testbench was not discovering packages when ran via Larastan.

I'm opening this as a draft PR, as I'm not sure how it can be tested yet, or if it should be presented as a configuration option instead of on by default. Open to criticism and discussion.

**Breaking changes**

The change didn't cause any tests to fail. There were two failing before which are still failing now (locally on 8.0 & 8.1):

####  `Tests\Rules\CheckDispatchArgumentTypesCompatibleWithClassConstructorRuleTest::testJobDispatch`
```
TypeError: PHPStan\Rules\FunctionCallParametersCheck::__construct(): Argument #5 ($propertyReflectionFinder) must be of type PHPStan\Rules\Properties\PropertyReflectionFinder, bool given
```

#### `Tests\Rules\CheckDispatchArgumentTypesCompatibleWithClassConstructorRuleTest::testEventDispatch`
```
TypeError: PHPStan\Rules\FunctionCallParametersCheck::__construct(): Argument #5 ($propertyReflectionFinder) must be of type PHPStan\Rules\Properties\PropertyReflectionFinder, bool given
```

**PS**
Thanks for your hard work on this!