### PR TITLE
fix: `Query::whereBetween` typehint

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -466,7 +466,7 @@ class Builder
     /**
      * Add a where between statement to the query.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  array<string|int, mixed>  $values
      * @param  string  $boolean
      * @param  bool  $not


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

`Query::whereBetween` can accept `\Illuminate\Database\Query\Expression`.

ref. https://github.com/laravel/framework/blob/171f65d2bf43fb82b7a4fe2ec769f94e962d912c/src/Illuminate/Database/Query/Builder.php#L1126
**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
