### PR TITLE
fix: `deleted_at` column has date type rather than `string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Fix: the `deleted_at` column created with `SoftDeletes` is now treated as a `Carbon` instance
+
 ## [2.0.1] - 2022-02-09
 
 ### Added

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -154,6 +154,22 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
     }
 
     /**
+     * @param Model $modelInstance
+     * @return string[]
+     * @phpstan-return array<int, string>
+     */
+    private function getModelDateColumns(Model $modelInstance): array
+    {
+        $dateColumns = $modelInstance->getDates();
+
+        if(! method_exists($modelInstance, 'getDeletedAtColumn')) {
+            return $dateColumns;
+        }
+
+        return [...$dateColumns, $modelInstance->getDeletedAtColumn()];
+    }
+
+    /**
      * @param  SchemaColumn  $column
      * @param  Model  $modelInstance
      * @return string[]
@@ -164,7 +180,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
         $readableType = $column->readableType;
         $writableType = $column->writeableType;
 
-        if (in_array($column->name, $modelInstance->getDates(), true)) {
+        if (in_array($column->name, $this->getModelDateColumns($modelInstance), true)) {
             return [$this->getDateClass().($column->nullable ? '|null' : ''), $this->getDateClass().'|string'.($column->nullable ? '|null' : '')];
         }
 

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -154,7 +154,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
     }
 
     /**
-     * @param Model $modelInstance
+     * @param  Model  $modelInstance
      * @return string[]
      * @phpstan-return array<int, string>
      */
@@ -162,7 +162,7 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
     {
         $dateColumns = $modelInstance->getDates();
 
-        if(! method_exists($modelInstance, 'getDeletedAtColumn')) {
+        if (! method_exists($modelInstance, 'getDeletedAtColumn')) {
             return $dateColumns;
         }
 

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -162,11 +162,11 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
     {
         $dateColumns = $modelInstance->getDates();
 
-        if (! method_exists($modelInstance, 'getDeletedAtColumn')) {
-            return $dateColumns;
+        if (method_exists($modelInstance, 'getDeletedAtColumn')) {
+            $dateColumns[] = $modelInstance->getDeletedAtColumn();
         }
 
-        return [...$dateColumns, $modelInstance->getDeletedAtColumn()];
+        return $dateColumns;
     }
 
     /**

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -7,6 +7,7 @@ namespace NunoMaduro\Larastan\Properties;
 use Illuminate\Support\Str;
 use PhpParser;
 use PhpParser\NodeFinder;
+use Carbon\Carbon;
 
 /**
  * @see https://github.com/psalm/laravel-psalm-plugin/blob/master/src/SchemaAggregator.php
@@ -372,12 +373,15 @@ final class SchemaAggregator
                             $table->setColumn(new SchemaColumn($columnName, 'set', $nullable, $secondArgArray));
                             break;
 
-                        case 'softdeletestz':
                         case 'timestamptz':
                         case 'timetz':
                         case 'year':
-                        case 'softdeletes':
                             $table->setColumn(new SchemaColumn($columnName, 'string', true));
+                            break;
+
+                        case 'softdeletestz':
+                        case 'softdeletes':
+                            $table->setColumn(new SchemaColumn($columnName, Carbon::class, true));
                             break;
 
                         case 'uuidmorphs':

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -381,7 +381,7 @@ final class SchemaAggregator
 
                         case 'softdeletestz':
                         case 'softdeletes':
-                            $table->setColumn(new SchemaColumn($columnName, get_class(Date::now()), true));
+                            $table->setColumn(new SchemaColumn($columnName, '?'.get_class(Date::now()), true));
                             break;
 
                         case 'uuidmorphs':

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Properties;
 
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use PhpParser;
 use PhpParser\NodeFinder;
-use Carbon\Carbon;
 
 /**
  * @see https://github.com/psalm/laravel-psalm-plugin/blob/master/src/SchemaAggregator.php
@@ -381,7 +381,7 @@ final class SchemaAggregator
 
                         case 'softdeletestz':
                         case 'softdeletes':
-                            $table->setColumn(new SchemaColumn($columnName, Carbon::class, true));
+                            $table->setColumn(new SchemaColumn($columnName, get_class(Date::now()), true));
                             break;
 
                         case 'uuidmorphs':

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Properties;
 
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use PhpParser;
 use PhpParser\NodeFinder;
@@ -373,15 +372,12 @@ final class SchemaAggregator
                             $table->setColumn(new SchemaColumn($columnName, 'set', $nullable, $secondArgArray));
                             break;
 
+                        case 'softdeletestz':
                         case 'timestamptz':
                         case 'timetz':
                         case 'year':
-                            $table->setColumn(new SchemaColumn($columnName, 'string', true));
-                            break;
-
-                        case 'softdeletestz':
                         case 'softdeletes':
-                            $table->setColumn(new SchemaColumn($columnName, '?'.get_class(Date::now()), true));
+                            $table->setColumn(new SchemaColumn($columnName, 'string', true));
                             break;
 
                         case 'uuidmorphs':

--- a/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
@@ -28,6 +28,7 @@ class CreateUsersTable extends Migration
             $table->unknownColumnType('unknown_column');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 }

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -186,7 +186,7 @@ class ModelPropertyExtension
 
     public function testSoftDeletesCastDateTimeAndNullable(User $user): ?string
     {
-        return $user->deleted_at->format('d/m/Y');
+        return $user->deleted_at?->format('d/m/Y');
     }
 
     public function testForeignIdFor(Address $address): int

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -184,6 +184,11 @@ class ModelPropertyExtension
         return $user->properties->first();
     }
 
+    public function testSoftDeletesCastDateTimeAndNullable(User $user): ?string
+    {
+        return $user->deleted_at->format('d/m/Y');
+    }
+
     public function testForeignIdFor(Address $address): int
     {
         return $address->user_id;

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -189,6 +189,14 @@ class ModelPropertyExtension
         return $user->deleted_at?->format('d/m/Y');
     }
 
+    public function testWriteToSoftDeletesColumn(): void
+    {
+        $this->user->deleted_at = 'test';
+        $this->user->deleted_at = now();
+        $this->user->deleted_at = null;
+        $this->user->deleted_at = BaseCarbon::now();
+    }
+
     public function testForeignIdFor(Address $address): int
     {
         return $address->user_id;

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -140,7 +140,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes'], $this->fileHelper);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -153,7 +153,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes_tz()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes_tz'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes_tz'], $this->fileHelper);
 
         $tables = $migrationHelper->initializeTables();
 

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use Illuminate\Support\Facades\Date;
 use NunoMaduro\Larastan\Properties\MigrationHelper;
 use NunoMaduro\Larastan\Properties\SchemaTable;
 use PHPStan\File\FileHelper;

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -147,7 +147,7 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame(get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame('?'.get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
     }
 
     /** @test */
@@ -160,6 +160,6 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame(get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame('?'.get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
     }
 }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -147,7 +147,7 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame('?'.get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['deleted_at']->readableType);
     }
 
     /** @test */
@@ -160,6 +160,6 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame('?'.get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['deleted_at']->readableType);
     }
 }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Date;
 use NunoMaduro\Larastan\Properties\MigrationHelper;
 use NunoMaduro\Larastan\Properties\SchemaTable;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
 use PHPStan\Testing\PHPStanTestCase;
-use Carbon\Carbon;
 
 class MigrationHelperTest extends PHPStanTestCase
 {
@@ -147,7 +147,7 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame(Carbon::class, $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame(get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
     }
 
     /** @test */
@@ -160,6 +160,6 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
-        self::assertSame(Carbon::class, $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame(get_class(Date::now()), $tables['users']->columns['deleted_at']->readableType);
     }
 }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -9,6 +9,7 @@ use NunoMaduro\Larastan\Properties\SchemaTable;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
 use PHPStan\Testing\PHPStanTestCase;
+use Carbon\Carbon;
 
 class MigrationHelperTest extends PHPStanTestCase
 {
@@ -134,5 +135,31 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertSame('string', $tables['users']->columns['email']->readableType);
         self::assertSame('string', $tables['users']->columns['created_at']->readableType);
         self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
+    }
+
+    /** @test */
+    public function it_can_handle_migrations_with_soft_deletes()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes'], $this->fileHelper);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(6, $tables['users']->columns);
+        self::assertSame(Carbon::class, $tables['users']->columns['deleted_at']->readableType);
+    }
+
+    /** @test */
+    public function it_can_handle_migrations_with_soft_deletes_tz()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes_tz'], $this->fileHelper);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(6, $tables['users']->columns);
+        self::assertSame(Carbon::class, $tables['users']->columns['deleted_at']->readableType);
     }
 }

--- a/tests/Unit/data/migrations_using_soft_deletes/2020_01_30_000000_create_users_table_with_soft_deletes.php
+++ b/tests/Unit/data/migrations_using_soft_deletes/2020_01_30_000000_create_users_table_with_soft_deletes.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingSoftDeletes;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+}

--- a/tests/Unit/data/migrations_using_soft_deletes_tz/2020_01_31_000000_alter_users_table_to_use_soft_deletes_tz.php
+++ b/tests/Unit/data/migrations_using_soft_deletes_tz/2020_01_31_000000_alter_users_table_to_use_soft_deletes_tz.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingSoftDeletesTz;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+            $table->softDeletesTz();
+        });
+    }
+}


### PR DESCRIPTION

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nunomaduro/larastan/issues/1051

**Changes**

This updates the `SchemaAggregator` to read `SoftDeletes` and `SoftDeletesTz` columns as `Carbon` instances instead of strings.
