### PR TITLE
feat: add parsing of foreignId in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 * Fix: the `deleted_at` column created with `SoftDeletes` is now treated as a `Carbon` instance
+* Add support for the `foreignId` column in migrations
 
 ## [2.0.1] - 2022-02-09
 

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -263,6 +263,7 @@ final class SchemaAggregator
                         case 'unsignedsmallinteger':
                         case 'unsignedtinyinteger':
                         case 'bigincrements':
+                        case 'foreignid':
                             $table->setColumn(new SchemaColumn($columnName, 'int', $nullable));
                             break;
 

--- a/tests/Application/database/migrations/2021_09_10_000000_create_addresses_table.php
+++ b/tests/Application/database/migrations/2021_09_10_000000_create_addresses_table.php
@@ -23,6 +23,8 @@ class CreateAddressesTable extends Migration
             $table->foreignIdFor(User::class, 'custom_foreign_id_for_name');
             $table->foreignIdFor(Address::class);
             $table->foreignIdFor(Address::class, 'nullable_address_id')->nullable();
+            $table->foreignId('foreign_id_constrained')->constrained('users');
+            $table->foreignId('nullable_foreign_id_constrained')->nullable()->constrained('users');
         });
     }
 }

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -216,4 +216,14 @@ class ModelPropertyExtension
     {
         return $address->nullable_address_id;
     }
+
+    public function testForeignIdConstrained(Address $address): int
+    {
+        return $address->foreign_id_constrained;
+    }
+
+    public function testForeignIdConstrainedNullable(Address $address): ?int
+    {
+        return $address->nullable_foreign_id_constrained;
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Add support for `$table->foreignId('column')` when parsing migrations. This increases the type specificity from mixed to int
[Relevant laravel docs](https://laravel.com/docs/9.x/migrations#foreign-key-constraints)
**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
