### PR TITLE
feat: add support for migrations using Schema::connection

### DIFF
--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -39,7 +39,7 @@ class MigrationHelper
      */
     public function initializeTables(array $tables = []): array
     {
-        if (empty($this->databaseMigrationPath)) {
+        if (count($this->databaseMigrationPath) === 0) {
             $this->databaseMigrationPath = [database_path('migrations')];
         }
 

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -120,22 +120,6 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertArrayHasKey('accounts', $tables);
     }
 
-    /**
-     * @param  array<string, SchemaTable>  $tables
-     */
-    private function assertUsersTableSchema(array $tables): void
-    {
-        self::assertCount(1, $tables);
-        self::assertArrayHasKey('users', $tables);
-        self::assertCount(5, $tables['users']->columns);
-        self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
-        self::assertSame('int', $tables['users']->columns['id']->readableType);
-        self::assertSame('string', $tables['users']->columns['name']->readableType);
-        self::assertSame('string', $tables['users']->columns['email']->readableType);
-        self::assertSame('string', $tables['users']->columns['created_at']->readableType);
-        self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
-    }
-
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes()
     {
@@ -160,5 +144,31 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertArrayHasKey('users', $tables);
         self::assertCount(6, $tables['users']->columns);
         self::assertSame('string', $tables['users']->columns['deleted_at']->readableType);
+    }
+
+    /** @test */
+    public function it_can_handle_connection_before_schema_create()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migration_with_schema_connection'], $this->fileHelper);
+
+        $tables = $migrationHelper->initializeTables();
+
+        $this->assertUsersTableSchema($tables);
+    }
+
+    /**
+     * @param  array<string, SchemaTable>  $tables
+     */
+    private function assertUsersTableSchema(array $tables): void
+    {
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(5, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+        self::assertSame('int', $tables['users']->columns['id']->readableType);
+        self::assertSame('string', $tables['users']->columns['name']->readableType);
+        self::assertSame('string', $tables['users']->columns['email']->readableType);
+        self::assertSame('string', $tables['users']->columns['created_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
     }
 }

--- a/tests/Unit/data/migration_with_schema_connection/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migration_with_schema_connection/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationWithSchemaConnection;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection('foo')->create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #1058 

**Changes**

This PR adds the ability to recognize `Schema::connection(...)->create(...)` or `Schema::setConnection(...)->create(...)` calls in migration files.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
