### PR TITLE
Use recent version of `composer/pcre`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* fix: Updated `composer/pcre` to new PHP relevant version
+
 ## [2.1.0] - 2022-03-04
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
-        "composer/pcre": "^1.0",
+        "composer/pcre": "^3.0",
         "illuminate/console": "^9",
         "illuminate/container": "^9",
         "illuminate/contracts": "^9",


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

`composer/pcre:^1.0` is not compatible with PHP7.4 and above. According to `pcre` [docs](https://github.com/composer/pcre#requirements), version `^3.0` should be used for PHP7.4 and above, which is more relevant for Larastan.

Using `^1.0` causes conflict with the latest version of other libraries like [`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/composer.json), which requires `composer/xdebug-handler:^3.0` and that required `composer/pcre:^3.0`.

**Breaking changes**

N/A
