### PR TITLE
feat: support Laravel 9 style attribute accessors and mutators

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,5 +1,6 @@
 parameters:
     stubFiles:
+        - stubs/Attribute.stub
         - stubs/Enumerable.stub
         - stubs/EloquentBuilder.stub
         - stubs/Collection.stub

--- a/src/Properties/ModelAccessorExtension.php
+++ b/src/Properties/ModelAccessorExtension.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Properties;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
 
 /**
  * @internal
@@ -21,6 +25,28 @@ final class ModelAccessorExtension implements PropertiesClassReflectionExtension
             return false;
         }
 
+        $camelCase = Str::camel($propertyName);
+
+        if ($classReflection->hasNativeMethod($camelCase)) {
+            $methodReflection = $classReflection->getNativeMethod($camelCase);
+
+            if ($methodReflection->isPublic() || $methodReflection->isPrivate()) {
+                return false;
+            }
+
+            $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+            if (! $returnType instanceof GenericObjectType) {
+                return false;
+            }
+
+            if (! (new ObjectType(Attribute::class))->isSuperTypeOf($returnType)->yes()) {
+                return false;
+            }
+
+            return true;
+        }
+
         return $classReflection->hasNativeMethod('get'.Str::studly($propertyName).'Attribute');
     }
 
@@ -28,6 +54,21 @@ final class ModelAccessorExtension implements PropertiesClassReflectionExtension
         ClassReflection $classReflection,
         string $propertyName
     ): PropertyReflection {
+        $studlyName = Str::studly($propertyName);
+
+        if ($classReflection->hasNativeMethod($studlyName)) {
+            $methodReflection = $classReflection->getNativeMethod($studlyName);
+
+            /** @var GenericObjectType $returnType */
+            $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+            return new ModelProperty(
+                $classReflection,
+                $returnType->getTypes()[0],
+                $returnType->getTypes()[1]
+            );
+        }
+
         $method = $classReflection->getNativeMethod('get'.Str::studly($propertyName).'Attribute');
 
         return new ModelProperty(

--- a/stubs/Attribute.stub
+++ b/stubs/Attribute.stub
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+/**
+ * @template TGet
+ * @template TSet
+ */
+class Attribute
+{
+    /**
+     * The attribute accessor.
+     *
+     * @var callable(): TGet
+     */
+    public $get;
+
+    /**
+     * The attribute mutator.
+     *
+     * @var callable(TSet): mixed
+     */
+    public $set;
+
+    /**
+     * Create a new attribute accessor / mutator.
+     *
+     * @template TMakeGet
+     * @template TMakeSet
+     * @param  (callable(mixed, mixed=): TMakeGet)|null  $get
+     * @param  (callable(TMakeSet, mixed=): mixed)|null  $set
+     * @return Attribute<TMakeGet, TMakeSet>
+     */
+    public static function make(callable $get = null, callable $set = null)
+    {}
+
+    /**
+     * Create a new attribute accessor.
+     *
+     * @template T
+     * @param  callable(mixed, mixed=): T  $get
+     * @return Attribute<T, never>
+     */
+    public static function get(callable $get)
+    {}
+
+    /**
+     * Create a new attribute mutator.
+     *
+     * @template T
+      * @param  callable(T, mixed=): mixed $set
+      * @return Attribute<never, T>
+     */
+    public static function set(callable $set)
+    {}
+}

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -6,6 +6,7 @@ use function get_class;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -157,5 +158,35 @@ class User extends Authenticatable
     public function setActive(): void
     {
         $this->active = 1;
+    }
+
+    /**
+     * @return Attribute<int, never>
+     */
+    protected function newStyleAttribute(): Attribute
+    {
+        return Attribute::make(
+            fn ($value) => 5,
+        );
+    }
+
+    /**
+     * @return Attribute<int, string>
+     */
+    protected function stringButInt(): Attribute
+    {
+        return Attribute::make(
+            fn ($value) => 5,
+            fn (string $value) => strtolower($value)
+        );
+    }
+
+    /** This will not take any effect because it's public and does not specify generic types at return type. */
+    public function email(): Attribute
+    {
+        return Attribute::make(
+            fn ($value) => 5,
+            fn (string $value) => strtolower($value)
+        );
     }
 }

--- a/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('stringButInt');
             $table->json('meta');
             $table->json('options');
             $table->json('properties');

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -16,6 +16,7 @@ use ArrayObject;
 use Carbon\Carbon as BaseCarbon;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use function PHPStan\Testing\assertType;
 
 class ModelPropertyExtension
 {
@@ -146,6 +147,7 @@ class ModelPropertyExtension
 
     public function testDateCast(User $user): ?BaseCarbon
     {
+        assertType('string', $user->email);
         $user->email_verified_at = now();
 
         return $user->email_verified_at;

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -16,6 +16,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/request-object.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
     }
 
     /**
@@ -31,6 +32,6 @@ class GeneralTypeTest extends TypeInferenceTestCase
 
     public static function getAdditionalConfigFiles(): array
     {
-        return [__DIR__.'/../phpstan-tests.neon'];
+        return [__DIR__.'/data/config-with-migrations.neon'];
     }
 }

--- a/tests/Type/data/config-with-migrations.neon
+++ b/tests/Type/data/config-with-migrations.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../phpstan-tests.neon
+parameters:
+    databaseMigrationsPath:
+        - %rootDir%/../../../tests/Application/database/migrations

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ModelProperties;
+
+use App\User;
+use function PHPStan\Testing\assertType;
+
+/** @var User $user */
+assertType('int', $user->newStyleAttribute);
+assertType('int', $user->stringButInt);
+assertType('string', $user->email);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #1153 

**Changes**

This PR adds support for Laravel 9 style attribute accessors and mutators.

Does this by making the `Attribute` class generic, and then reading those generic types when the property is accessed.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
