### PR TITLE
feat: add exact typehints for `Model` `casts`, `hidden` and `visible` properties

### DIFF
--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -8,6 +8,21 @@ namespace Illuminate\Database\Eloquent;
 abstract class Model implements \JsonSerializable, \ArrayAccess
 {
     /**
+     * @var array<string, string|class-string>
+     */
+    protected $casts = [];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $hidden = [];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $visible = [];
+
+    /**
      * Update the model in the database.
      *
      * @param  array<model-property<static>, mixed>  $attributes

--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -8,7 +8,7 @@ namespace Illuminate\Database\Eloquent;
 abstract class Model implements \JsonSerializable, \ArrayAccess
 {
     /**
-     * @var array<string, string|class-string>
+     * @var array<string, string>
      */
     protected $casts = [];
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Hi! When using larastan inside project in which rector is present and model classes are heavily using `$casts`  or `$hidden` attributes there is a problem with exact typehints for those properties.
First solution is to ignore rector rule that adds typehints, the second is to create stub file for Model class.

Since I've been using the stub for some time now I've decided to make this PR.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
