### PR TITLE
fix: ignore Model in ModelPropertyRule

### DIFF
--- a/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
+++ b/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
@@ -48,7 +48,7 @@ class ModelPropertiesRuleHelper
         /** @var Type $modelType */
         [$parameterIndex, $modelType] = $modelPropertyParameter;
 
-        if (! (new ObjectType(Model::class))->isSuperTypeOf($modelType)->yes()) {
+        if (! (new ObjectType(Model::class))->isSuperTypeOf($modelType)->yes() || $modelType->equals(new ObjectType(Model::class))) {
             return [];
         }
 

--- a/tests/Rules/Data/model-property-builder.php
+++ b/tests/Rules/Data/model-property-builder.php
@@ -32,6 +32,13 @@ function bar(\Illuminate\Database\Eloquent\Builder $builder): \Illuminate\Databa
 \App\User::query()->where('propertyDefinedOnlyInAnnotation', 'foo');
 \App\User::query()->where('only_available_with_accessor', 'foo');
 
+// Currently, there is no way to change the type of `$query` inside the callback.
+// So until we have a way to do that, we will ignore errors for `Builder<Model>`
+// @see https://github.com/phpstan/phpstan/discussions/6850
+\App\User::query()->whereHas('accounts', function (\Illuminate\Database\Eloquent\Builder $query) {
+    $query->where('foo', 'bar');
+});
+
 function getKey(): string
 {
     if (random_int(0, 1)) {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md


**Changes**

This PR ignores `Model` in `ModelPropertyRule`

It was already doing that before. But https://github.com/nunomaduro/larastan/commit/71dccc1679cfdfc122b9baa23c1ddb1cf921a9d1 changed the logic little bit. So this PR brings the old logic back.

**Breaking changes**

none
