### PR TITLE
fix: use TypeTraverser to handle Union and Intersection types in `ModelRelationsExtension`

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -221,6 +221,7 @@ class BuilderHelper
             if ($returnType instanceof ObjectType) {
                 return $returnType->getClassName();
             }
+
             return $returnType->describe(VerbosityLevel::value());
         } catch (MissingMethodFromReflectionException|ShouldNotHappenException $e) {
             return Collection::class;

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Str;
 use NunoMaduro\Larastan\Reflection\AnnotationScopeMethodParameterReflection;
@@ -212,20 +213,17 @@ class BuilderHelper
         return $returnType->describe(VerbosityLevel::value());
     }
 
-    /**
-     * @throws MissingMethodFromReflectionException
-     * @throws ShouldNotHappenException
-     */
     public function determineCollectionClassName(string $modelClassName): string
     {
-        $newCollectionMethod = $this->reflectionProvider->getClass($modelClassName)->getNativeMethod('newCollection');
-
-        $returnType = ParametersAcceptorSelector::selectSingle($newCollectionMethod->getVariants())->getReturnType();
-
-        if ($returnType instanceof ObjectType) {
-            return $returnType->getClassName();
+        try {
+            $newCollectionMethod = $this->reflectionProvider->getClass($modelClassName)->getNativeMethod('newCollection');
+            $returnType = ParametersAcceptorSelector::selectSingle($newCollectionMethod->getVariants())->getReturnType();
+            if ($returnType instanceof ObjectType) {
+                return $returnType->getClassName();
+            }
+            return $returnType->describe(VerbosityLevel::value());
+        } catch (MissingMethodFromReflectionException|ShouldNotHappenException $e) {
+            return Collection::class;
         }
-
-        return $returnType->describe(VerbosityLevel::value());
     }
 }

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -92,9 +92,10 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         $relatedModel = new ObjectType($relatedModelClassName);
-        $collectionClass = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
 
         if (Str::contains($returnType->getClassName(), 'Many')) {
+            $collectionClass = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
+
             return new ModelProperty(
                 $classReflection,
                 new GenericObjectType($collectionClass, [new IntegerType(), $relatedModel]),
@@ -103,10 +104,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         if (Str::endsWith($returnType->getClassName(), 'MorphTo')) {
-            return new ModelProperty($classReflection, new UnionType([
-                new ObjectType(Model::class),
-                new MixedType(),
-            ]), new NeverType(), false);
+            return new ModelProperty($classReflection, new MixedType(), new NeverType(), false);
         }
 
         return new ModelProperty($classReflection, new UnionType([

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -18,10 +18,14 @@ use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 
 /**
@@ -74,7 +78,6 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
     {
         $method = $classReflection->getMethod($propertyName, new OutOfClassScope());
 
-        /** @var ObjectType $returnType */
         $returnType = ParametersAcceptorSelector::selectSingle($method->getVariants())->getReturnType();
 
         if ($returnType instanceof GenericObjectType) {
@@ -93,23 +96,37 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
 
         $relatedModel = new ObjectType($relatedModelClassName);
 
-        if (Str::contains($returnType->getClassName(), 'Many')) {
-            $collectionClass = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
+        $relationType = TypeTraverser::map($returnType, function (Type $type, callable $traverse) use ($relatedModelClassName, $relatedModel) {
+            if ($type instanceof UnionType || $type instanceof IntersectionType) {
+                return $traverse($type);
+            }
 
-            return new ModelProperty(
-                $classReflection,
-                new GenericObjectType($collectionClass, [new IntegerType(), $relatedModel]),
-                new NeverType(), false
-            );
-        }
+            if ($type instanceof TypeWithClassName) {
+                if ($type instanceof GenericObjectType) {
+                    /** @var ObjectType $relatedModel */
+                    $relatedModel = $type->getTypes()[0];
+                    $relatedModelClassName = $relatedModel->getClassName();
+                }
 
-        if (Str::endsWith($returnType->getClassName(), 'MorphTo')) {
-            return new ModelProperty($classReflection, new MixedType(), new NeverType(), false);
-        }
+                if (Str::contains($type->getClassName(), 'Many')) {
+                    $collectionClass = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
 
-        return new ModelProperty($classReflection, new UnionType([
-            $relatedModel,
-            new NullType(),
-        ]), new NeverType(), false);
+                    return new GenericObjectType($collectionClass, [new IntegerType(), $relatedModel]);
+                }
+
+                if (Str::endsWith($type->getClassName(), 'MorphTo')) {
+                    return new MixedType();
+                }
+
+                return new UnionType([
+                    $relatedModel,
+                    new NullType(),
+                ]);
+            }
+
+            return $traverse($type);
+        });
+
+        return new ModelProperty($classReflection, $relationType, new NeverType(), false);
     }
 }

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features\Properties;
 
-use App\Account;
 use App\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -15,15 +13,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ModelRelationsExtension
 {
-    /** @return Collection<int, OtherDummyModel> */
-    public function testHasMany()
-    {
-        /** @var DummyModel $dummyModel */
-        $dummyModel = DummyModel::firstOrFail();
-
-        return $dummyModel->hasManyRelation;
-    }
-
     public function testHasManyForEach(): OtherDummyModel
     {
         /** @var DummyModel $dummyModel */
@@ -38,33 +27,6 @@ class ModelRelationsExtension
         return new OtherDummyModel;
     }
 
-    /** @return Collection<int, OtherDummyModel> */
-    public function testHasManyThroughRelation(DummyModel $dummyModel)
-    {
-        return $dummyModel->hasManyThroughRelation;
-    }
-
-    public function testBelongsTo(OtherDummyModel $otherDummyModel): ?DummyModel
-    {
-        return $otherDummyModel->belongsToRelation;
-    }
-
-    /** @return mixed */
-    public function testMorphTo(OtherDummyModel $otherDummyModel)
-    {
-        return $otherDummyModel->morphToRelation;
-    }
-
-    public function testCollectionMethodFirstOnRelation(DummyModel $dummyModel): ?OtherDummyModel
-    {
-        return $dummyModel->hasManyRelation->first();
-    }
-
-    public function testCollectionMethodFindOnRelation(DummyModel $dummyModel): ?OtherDummyModel
-    {
-        return $dummyModel->hasManyRelation()->find(1);
-    }
-
     public function testModelRelationForeach(DummyModel $dummyModel): ?OtherDummyModel
     {
         foreach ($dummyModel->hasManyRelation as $item) {
@@ -74,16 +36,6 @@ class ModelRelationsExtension
         }
 
         return null;
-    }
-
-    public function testModelWithRelationDefinedInTrait(Account $account): ?User
-    {
-        return $account->ownerRelation;
-    }
-
-    public function testRelationCanbeOverridenWithAnnotation(OtherDummyModel $dummyModel): DummyModel
-    {
-        return $dummyModel->belongsToRelation;
     }
 }
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -17,6 +17,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');
     }
 
     /**

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -11,16 +11,20 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use function PHPStan\Testing\assertType;
 
-function foo(Foo $dummyModel, Bar $otherFoo, Account $account): void {
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $dummyModel->hasManyRelation);
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $dummyModel->hasManyThroughRelation);
-    assertType('ModelPropertiesRelations\Foo', $otherFoo->belongsToRelation);
-    assertType('mixed', $otherFoo->morphToRelation);
-    assertType('ModelPropertiesRelations\Bar|null', $dummyModel->hasManyRelation->first());
-    assertType('ModelPropertiesRelations\Bar|null', $dummyModel->hasManyRelation()->find(1));
+function foo(Foo $foo, Bar $bar, Account $account): void
+{
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyRelation);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyThroughRelation);
+    assertType('ModelPropertiesRelations\Foo', $bar->belongsToRelation);
+    assertType('mixed', $bar->morphToRelation);
+    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation->first());
+    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation()->find(1));
     assertType('App\User|null', $account->ownerRelation);
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model|null', $foo->relationReturningUnion);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>|ModelPropertiesRelations\Baz|null', $foo->relationReturningUnion2);
 }
 
+/** @property string $name */
 class Foo extends Model
 {
     /** @return HasMany<Bar> */
@@ -33,6 +37,17 @@ class Foo extends Model
     public function hasManyThroughRelation(): HasManyThrough
     {
         return $this->hasManyThrough(Bar::class, User::class);
+    }
+
+    public function relationReturningUnion(): HasMany|BelongsTo
+    {
+        return $this->name === 'foo' ? $this->hasMany(Bar::class) : $this->belongsTo(Baz::class);
+    }
+
+    /** @return HasMany<Bar>|BelongsTo<Baz, Foo> */
+    public function relationReturningUnion2(): HasMany|BelongsTo
+    {
+        return $this->name === 'foo' ? $this->hasMany(Bar::class) : $this->belongsTo(Baz::class);
     }
 }
 
@@ -52,4 +67,8 @@ class Bar extends Model
     {
         return $this->morphTo('foo');
     }
+}
+
+class Baz extends Model
+{
 }

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ModelPropertiesRelations;
+
+use App\Account;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use function PHPStan\Testing\assertType;
+
+function foo(Foo $dummyModel, Bar $otherFoo, Account $account): void {
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $dummyModel->hasManyRelation);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $dummyModel->hasManyThroughRelation);
+    assertType('ModelPropertiesRelations\Foo', $otherFoo->belongsToRelation);
+    assertType('mixed', $otherFoo->morphToRelation);
+    assertType('ModelPropertiesRelations\Bar|null', $dummyModel->hasManyRelation->first());
+    assertType('ModelPropertiesRelations\Bar|null', $dummyModel->hasManyRelation()->find(1));
+    assertType('App\User|null', $account->ownerRelation);
+}
+
+class Foo extends Model
+{
+    /** @return HasMany<Bar> */
+    public function hasManyRelation(): HasMany
+    {
+        return $this->hasMany(Bar::class);
+    }
+
+    /** @return HasManyThrough<Bar> */
+    public function hasManyThroughRelation(): HasManyThrough
+    {
+        return $this->hasManyThrough(Bar::class, User::class);
+    }
+}
+
+/**
+ * @property Foo $belongsToRelation
+ */
+class Bar extends Model
+{
+    /** @return BelongsTo<Foo, Bar> */
+    public function belongsToRelation(): BelongsTo
+    {
+        return $this->belongsTo(Foo::class);
+    }
+
+    /** @return MorphTo<Model, Bar> */
+    public function morphToRelation(): MorphTo
+    {
+        return $this->morphTo('foo');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes #1181 

**Changes**

This PR refactors `ModelRelationsExtension` to use TypeTraverser to handle `Union` and `Intersection` types.

**Breaking changes**
none