### PR TITLE
feat improve model factory `after*` methods

### DIFF
--- a/stubs/Factory.stub
+++ b/stubs/Factory.stub
@@ -78,4 +78,20 @@ class Factory
      * @return array<model-property<TModel>, mixed>
      */
     abstract public function definition();
+
+    /**
+     * Add a new "after making" callback to the model definition.
+     *
+     * @param  \Closure(TModel): mixed  $callback
+     * @return static
+     */
+    public function afterMaking(\Closure $callback) {}
+
+    /**
+     * Add a new "after creating" callback to the model definition.
+     *
+     * @param  \Closure(TModel): mixed  $callback
+     * @return static
+     */
+    public function afterCreating(\Closure $callback) {}
 }

--- a/tests/Features/ReturnTypes/ModelFactory.php
+++ b/tests/Features/ReturnTypes/ModelFactory.php
@@ -57,12 +57,12 @@ class ModelFactory
 
     public function testAfterMakingWithParentModelUsingFactory(): UserFactory
     {
-        return User::factory()->afterMaking();
+        return User::factory()->afterMaking(fn(User $user) => $user);
     }
 
     public function testAfterCreatingWithParentModelUsingFactory(): UserFactory
     {
-        return User::factory()->afterCreating();
+        return User::factory()->afterCreating(fn(User $user) => $user);
     }
 
     public function testFactory(): PostFactory
@@ -105,11 +105,11 @@ class ModelFactory
 
     public function testAfterMaking(): PostFactory
     {
-        return Post::factory()->afterMaking();
+        return Post::factory()->afterMaking(fn(Post $post) => $post);
     }
 
     public function testAfterCreating(): PostFactory
     {
-        return Post::factory()->afterCreating();
+        return Post::factory()->afterCreating(fn(Post $post) => $post);
     }
 }

--- a/tests/Features/ReturnTypes/ModelFactory.php
+++ b/tests/Features/ReturnTypes/ModelFactory.php
@@ -57,12 +57,12 @@ class ModelFactory
 
     public function testAfterMakingWithParentModelUsingFactory(): UserFactory
     {
-        return User::factory()->afterMaking(fn(User $user) => $user);
+        return User::factory()->afterMaking(fn (User $user) => $user);
     }
 
     public function testAfterCreatingWithParentModelUsingFactory(): UserFactory
     {
-        return User::factory()->afterCreating(fn(User $user) => $user);
+        return User::factory()->afterCreating(fn (User $user) => $user);
     }
 
     public function testFactory(): PostFactory
@@ -105,11 +105,11 @@ class ModelFactory
 
     public function testAfterMaking(): PostFactory
     {
-        return Post::factory()->afterMaking(fn(Post $post) => $post);
+        return Post::factory()->afterMaking(fn (Post $post) => $post);
     }
 
     public function testAfterCreating(): PostFactory
     {
-        return Post::factory()->afterCreating(fn(Post $post) => $post);
+        return Post::factory()->afterCreating(fn (Post $post) => $post);
     }
 }

--- a/tests/Features/ReturnTypes/ModelFactory.php
+++ b/tests/Features/ReturnTypes/ModelFactory.php
@@ -55,6 +55,16 @@ class ModelFactory
         return User::factory()->unverified();
     }
 
+    public function testAfterMakingWithParentModelUsingFactory(): UserFactory
+    {
+        return User::factory()->afterMaking();
+    }
+
+    public function testAfterCreatingWithParentModelUsingFactory(): UserFactory
+    {
+        return User::factory()->afterCreating();
+    }
+
     public function testFactory(): PostFactory
     {
         return Post::factory();
@@ -91,5 +101,15 @@ class ModelFactory
     public function testMake()
     {
         return Post::factory()->make();
+    }
+
+    public function testAfterMaking(): PostFactory
+    {
+        return Post::factory()->afterMaking();
+    }
+
+    public function testAfterCreating(): PostFactory
+    {
+        return Post::factory()->afterCreating();
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Resolves #1131 

**Changes**

As discussed in #1131, it looks like Laravel won't be making this change in the near future. This PR prevents errors such as this:

```
Parameter #1 $callback of method Illuminate\Database\Eloquent\Factories\Factory<Illuminate\Database\Eloquent\Model>::afterCreating() expects 
    Closure(Illuminate\Database\Eloquent\Model): mixed,
    Closure(App\Data\Models\Task): void given.
```