### PR TITLE
Interaction with phpstan/phpstan-mockery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,11 +42,13 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --with='illuminate/contracts:${{ matrix.laravel }}' --prefer-dist --no-interaction --no-progress"
 
+      - run: "composer require --dev phpstan/phpstan-mockery"
+
       - name: "Execute static analysis"
         run: "composer run-script test:types"
 
       - name: "Execute unit tests"
-        run: "composer run-script test:unit"
+        run: "composer run-script test:unit -- tests/Rules/RelationExistenceRuleTest.php"
 
       - name: "Run Larastan on Laravel and Lumen sample applications"
         run: "tests/laravel-test.sh"

--- a/extension.neon
+++ b/extension.neon
@@ -1,3 +1,5 @@
+includes:
+  - ./vendor/phpstan/phpstan-mockery/extension.neon
 parameters:
     stubFiles:
         - stubs/Attribute.stub

--- a/src/Rules/ModelRuleHelper.php
+++ b/src/Rules/ModelRuleHelper.php
@@ -18,10 +18,10 @@ final class ModelRuleHelper
 {
     public function findModelReflectionFromType(Type $type): ?ClassReflection
     {
-        if (!(new ObjectType(Builder::class))->isSuperTypeOf($type)->yes() &&
-            !(new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->yes() &&
-            !(new ObjectType(Relation::class))->isSuperTypeOf($type)->yes() &&
-            !(new ObjectType(Model::class))->isSuperTypeOf($type)->yes()
+        if (! (new ObjectType(Builder::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(Relation::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(Model::class))->isSuperTypeOf($type)->yes()
         ) {
             return null;
         }

--- a/src/Rules/ModelRuleHelper.php
+++ b/src/Rules/ModelRuleHelper.php
@@ -18,10 +18,10 @@ final class ModelRuleHelper
 {
     public function findModelReflectionFromType(Type $type): ?ClassReflection
     {
-        if ((new ObjectType(Builder::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(Relation::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(Model::class))->isSuperTypeOf($type)->no()
+        if (!(new ObjectType(Builder::class))->isSuperTypeOf($type)->yes() &&
+            !(new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->yes() &&
+            !(new ObjectType(Relation::class))->isSuperTypeOf($type)->yes() &&
+            !(new ObjectType(Model::class))->isSuperTypeOf($type)->yes()
         ) {
             return null;
         }

--- a/tests/Rules/Data/relation-existence-rule.php
+++ b/tests/Rules/Data/relation-existence-rule.php
@@ -50,3 +50,6 @@ declare(strict_types=1);
 \App\User::query()->with('foo:id,name');
 \App\User::with(['foo:id', 'accounts']);
 \App\User::query()->with(['foo:id', 'accounts']);
+
+$mock = \Mockery::mock(\StdClass::class);
+$mock->expects('foo')->with('bar');

--- a/tests/Rules/Data/relation-existence-rule.php
+++ b/tests/Rules/Data/relation-existence-rule.php
@@ -51,5 +51,5 @@ declare(strict_types=1);
 \App\User::with(['foo:id', 'accounts']);
 \App\User::query()->with(['foo:id', 'accounts']);
 
-$mock = \Mockery::mock(\StdClass::class);
+$mock = \Mockery::mock(\stdClass::class);
 $mock->expects('foo')->with('bar');


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Updated CHANGELOG.md

Resolves https://github.com/nunomaduro/larastan/issues/1204

Inverts the check in the `ModelRuleHelper` class to reduce false positives of classes that return `maybe` for all super class checks.

So i am just creating a PR based on the `mockery` branch provided by @szepeviktor but i noticed these lines added to the `extension.neon`:

```neon
includes:
  - ./vendor/phpstan/phpstan-mockery/extension.neon
```

Wont that mean that everyone who uses Larastan will now need the `phpstan/phpstan-mockery` dependency? 

Also the `.github/workflows/tests.yml` path seems to have been changed only to run this one specific test, is that correct? 
sorry you'll have to forgive my naivety with github actions, pretty new to them!