### PR TITLE
fix: inverted check in the ModelRuleHelper

### DIFF
--- a/src/Rules/ModelRuleHelper.php
+++ b/src/Rules/ModelRuleHelper.php
@@ -18,10 +18,10 @@ final class ModelRuleHelper
 {
     public function findModelReflectionFromType(Type $type): ?ClassReflection
     {
-        if ((new ObjectType(Builder::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(Relation::class))->isSuperTypeOf($type)->no() &&
-            (new ObjectType(Model::class))->isSuperTypeOf($type)->no()
+        if (! (new ObjectType(Builder::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(EloquentBuilder::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(Relation::class))->isSuperTypeOf($type)->yes() &&
+            ! (new ObjectType(Model::class))->isSuperTypeOf($type)->yes()
         ) {
             return null;
         }


### PR DESCRIPTION
Resolves https://github.com/nunomaduro/larastan/issues/1204

Inverting this check minimizes false positives for classes that return 'maybe' for the isSuperTypeOf check, which would then go on to be treated as a queryable Laravel class.

This breaks no test cases currently present.