### PR TITLE
Update joinSub docblock

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -135,7 +135,7 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -135,7 +135,8 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @template TModelClass of \Illuminate\Database\Eloquent\Model
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModelClass>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -236,7 +236,7 @@ class Builder
     public function testJoinSubAllowsEloquentBuilder(): void
     {
         User::query()->joinSub(
-            User::query()->whereIn('id', [1, 2, 3])->from('users'),
+            User::query()->whereIn('id', [1, 2, 3]),
             'users',
             'users.id',
             'users.id'

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -233,6 +233,16 @@ class Builder
         return User::query()->restore();
     }
 
+    public function testJoinSubAllowsEloquentBuilder(): void
+    {
+        User::query()->joinSub(
+            User::query()->whereIn('id', [1, 2, 3])->from('users'),
+            'users',
+            'users.id',
+            'users.id'
+        );
+    }
+
     public function testRelationMethods(): void
     {
         User::query()->has('accounts', '=', 1, 'and', function (EloquentBuilder $query) {


### PR DESCRIPTION
**Changes**

The `joinSub` docblock in the `QueryBuilder.stub` file is not (no longer) aligned with [Laravel 9](https://github.com/laravel/framework/blob/v9.7.0/src/Illuminate/Database/Query/Builder.php#L526).
The stub version actually accepts a narrower range of types than Laravel itself. 
In particular, `\Illuminate\Database\Eloquent\Builder` was not accepted, but is accepted according to Laravel.

This change fixes the docblock and thereby removes a PHPStan false negative.

**Breaking changes**

None.
