### PR TITLE
Improve DX: specify memory limits for tests (custom composer scripts)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,8 @@
         }
     },
     "scripts": {
-        "test:types": "phpstan analyse --ansi --memory-limit 2G",
-        "test:unit": "phpunit --colors=always -d memory_limit=2048M",
+        "test:types": "phpstan analyse --ansi --memory-limit 256M",
+        "test:unit": "phpunit --colors=always -d memory_limit=512M",
         "test": [
             "@test:types",
             "@test:unit"

--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,8 @@
         }
     },
     "scripts": {
-        "test:types": "phpstan analyse --ansi",
-        "test:unit": "phpunit --colors=always",
+        "test:types": "phpstan analyse --ansi --memory-limit 2G",
+        "test:unit": "phpunit --colors=always -d memory_limit=2048M",
         "test": [
             "@test:types",
             "@test:unit"


### PR DESCRIPTION
explicitly specify (most likely increase) memory limits for tests on the project. Especially useful for dev env where PHP configured with strict memory limits (to catch memory issues locally), so developers will need to do less frictions to run tests locally.