### PR TITLE
feat: add dynamic return type extension for `App::make`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 * feat: add cursorPaginate() support by @BramVanBerkel in https://github.com/nunomaduro/larastan/pull/1198
+* feat: add App::make() support by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1222
 
 ### Fixes
 * fix: inverted check in the ModelRuleHelper by @mad-briller in https://github.com/nunomaduro/larastan/pull/1207

--- a/extension.neon
+++ b/extension.neon
@@ -190,6 +190,11 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\AppMakeDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\AuthExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Support\Facades\App;
+use NunoMaduro\Larastan\Concerns\HasContainer;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Throwable;
+
+final class AppMakeDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    use HasContainer;
+
+    public function getClass(): string
+    {
+        return App::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'make' || $methodReflection->getName() === 'makeWith';
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+    {
+        if (count($methodCall->getArgs()) === 0) {
+            return new ErrorType();
+        }
+
+        $expr = $methodCall->getArgs()[0]->value;
+        if ($expr instanceof String_) {
+            try {
+                /** @var object|null $resolved */
+                $resolved = $this->resolve($expr->value);
+
+                if ($resolved === null) {
+                    return new ErrorType();
+                }
+
+                return new ObjectType(get_class($resolved));
+            } catch (Throwable $exception) {
+                return new ErrorType();
+            }
+        }
+
+        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
+            return new ObjectType($expr->class->toString());
+        }
+
+        return new NeverType();
+    }
+}

--- a/tests/Features/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
+++ b/tests/Features/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Features\ReturnTypes;
+
+use Illuminate\Support\Facades\App;
+use NunoMaduro\Larastan\ApplicationResolver;
+
+class AppMakeDynamicReturnTypeExtension
+{
+    public function testResolvesAppMakeStaticCall(): ApplicationResolver
+    {
+        return App::make(ApplicationResolver::class);
+    }
+
+    public function testResolvesAppMakeWithStaticCall(): ApplicationResolver
+    {
+        return App::makeWith(ApplicationResolver::class);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Add dynamic return type extension for App::make the same way resolve() and app() are supported.

**Breaking changes**

None
