### PR TITLE
Allow Builder-s in Builder::union* $query parameter

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -1071,7 +1071,8 @@ class Builder
     /**
      * Add a union statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+	 * @template TModelClass of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModelClass>|\Closure  $query
      * @param  bool  $all
      * @return $this
      */
@@ -1081,7 +1082,8 @@ class Builder
     /**
      * Add a union all statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+	 * @template TModelClass of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModelClass>|\Closure  $query
      * @return $this
      */
     public function unionAll($query)


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

related: https://github.com/laravel/framework/pull/42374

The Builder::union method is supports `Illuminate\Database\Eloquent\Builder`, but an error occurs because there is no description.


**Steps to reproduce**

```php
$first = User::where('id',8);

$users = User::where('id',2)->union($first)->get();
```

**Error Report**

```
Parameter #1 $query of method Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>::union() expects Closure|Illuminate\Database\Query\Builder, Illuminate\Database\Eloquent\Builder given.
```

**Description**

**`Illuminate\Database\Eloquent\Builder` is not a subtype of `Illuminate\Database\Query\Builder`.**

Illuminate\Database\Eloquent\Builder
```php
use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
class Builder implements BuilderContract
{
```

Illuminate\Database\Query\Builder
```php
use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
class Builder implements BuilderContract
{
```

**Changes**

Added type.

**Breaking changes**

no
