### PR TITLE
Fix Model property types

### DIFF
--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -13,12 +13,12 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     protected $casts = [];
 
     /**
-     * @var array<string>
+     * @var list<string>
      */
     protected $hidden = [];
 
     /**
-     * @var array<string>
+     * @var list<string>
      */
     protected $visible = [];
 

--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -13,12 +13,12 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     protected $casts = [];
 
     /**
-     * @var array<int, string>
+     * @var array<string>
      */
     protected $hidden = [];
 
     /**
-     * @var array<int, string>
+     * @var array<string>
      */
     protected $visible = [];
 


### PR DESCRIPTION
These are simple lists,
```
[
  1 => 'apple',
  3 => 'pear',
]
```
is invalid!