### PR TITLE
Added conditional return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Improvements
+* feat: Added conditional return types
+
 ### Fixes
 
 * fix: Change QueryBuilder::newQuery() @return from `$this` to `static`

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -13,7 +13,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>|model-property<TRelatedModel>|'*'  $columns
-     * @return \Illuminate\Support\Collection<int, TRelatedModel>|TRelatedModel
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
@@ -51,7 +51,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return TRelatedModel|\Illuminate\Database\Eloquent\Collection<int, TRelatedModel>|null
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
      */
     public function find($id, $columns = ['*']);
 
@@ -69,7 +69,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return TRelatedModel|\Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -69,7 +69,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -13,7 +13,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>|model-property<TRelatedModel>|'*'  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
@@ -51,7 +51,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
      */
     public function find($id, $columns = ['*']);
 
@@ -69,7 +69,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -64,7 +64,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
-     * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<int, TModelClass>|null
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)|null
      */
     public function find($id, $columns = ['*']);
 
@@ -82,7 +82,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
-     * @phpstan-return TModelClass|\Illuminate\Database\Eloquent\Collection<int, TModelClass>
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -64,7 +64,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)|null
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)|null
      */
     public function find($id, $columns = ['*']);
 
@@ -82,7 +82,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -30,7 +30,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -30,7 +30,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -30,7 +30,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  mixed  $id
      * @param  array<int, mixed>  $columns
-     * @return \Illuminate\Support\Collection<int, TRelatedModel>|TRelatedModel
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable|array) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1218 

**Changes**

Added conditional return types.
If the $id parameter is an array or Arrayable then return type is a collection else the model found.

**Breaking changes**

Updated the return types of the following methods:
- Model::find()
- Model::findOrFail()
- BelongsToMany::findOrNew()
- BelongsToMany::find()
- BelongsToMany::findOrFail()
- HasOneOrMany::findOrNew()