### PR TITLE
Add support for Storage::drive besides Storage::disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Improvements
+* feat: add Storage::drive() support by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1241
+
 ### Fixes
 
 * fix: Change QueryBuilder::newQuery() @return from `$this` to `static`

--- a/src/ReturnTypes/StorageDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/StorageDynamicStaticMethodReturnTypeExtension.php
@@ -25,7 +25,7 @@ class StorageDynamicStaticMethodReturnTypeExtension implements DynamicStaticMeth
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {
-        return $methodReflection->getName() === 'disk';
+        return $methodReflection->getName() === 'disk' || $methodReflection->getName() === 'drive';
     }
 
     public function getTypeFromStaticMethodCall(

--- a/tests/Features/Methods/StorageFacade.php
+++ b/tests/Features/Methods/StorageFacade.php
@@ -14,9 +14,19 @@ class StorageFacade
         return Storage::disk();
     }
 
+    public function testDrive(): Filesystem
+    {
+        return Storage::drive();
+    }
+
     public function testDiskGetDriver(): bool
     {
         return Storage::disk()->deleteDirectory('foo');
+    }
+
+    public function testDriveGetDriver(): bool
+    {
+        return Storage::drive()->deleteDirectory('foo');
     }
 
     /** @return string|false */


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Storage::drive is an alias for Storage::disk so can be supported by just checking for it in the StorageDynamicStaticMethodReturntypeExtension

**Breaking changes**
None
