### PR TITLE
Factory name is not correctly resolved when application namespace is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* fix: Resolve correct model factory instance when application namespace is empty
 
 ### Fixed
 

--- a/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
@@ -38,7 +38,7 @@ final class ModelFactoryDynamicStaticMethodReturnTypeExtension implements Dynami
             return new ErrorType();
         }
 
-        $factoryName = Factory::resolveFactoryName($class->toCodeString()); // @phpstan-ignore-line
+        $factoryName = Factory::resolveFactoryName(ltrim('\\', $class->toCodeString())); // @phpstan-ignore-line
 
         if (class_exists($factoryName)) {
             return new ObjectType($factoryName);


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Updated CHANGELOG.md

**Changes**

When the application namespace is empty it tries to resolve the factory with e.g. `Factory::resolveFactoryName('\App\Models\User')`. The resolved factory name will be `Database\Factories\\App\Models\UserFactory`. Now this class cannot be found and phpstan crashes with 
` Cannot declare class Database\Factories\App\Models\UserFactory, because the name is already in use`. 

This PR just removes the first `\` from the model class name. This is the same behaviour as `get_called_class` in the [HasFactory](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Factories/HasFactory.php#L16) method.

I couldn't find a way to set the application namespace easily in the tests. Let me know if you have an idea so I can fix this.