### PR TITLE
fix: remove when and unless from EloquentBuilder stub

### DIFF
--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -434,26 +434,6 @@ class Builder
     public function value($column);
 
     /**
-     * Apply the callback's query changes if the given "value" is true.
-     *
-     * @param mixed  $value
-     * @param callable($this, mixed): (void|Builder<TModelClass>) $callback
-     * @param (callable($this, mixed): Builder<TModelClass>)|(callable($this, mixed): void)  $default
-     * @return mixed|$this
-     */
-    public function when($value, $callback, $default = null);
-
-    /**
-     * Apply the callback's query changes if the given "value" is false.
-     *
-     * @param  mixed  $value
-     * @param  callable($this, mixed): (void|Builder<TModelClass>)  $callback
-     * @param  (callable($this, mixed): Builder<TModelClass>)|(callable($this, mixed): void)  $default
-     * @return mixed|$this
-     */
-    public function unless($value, $callback, $default = null);
-
-    /**
      * Paginate the given query.
      *
      * @param  int|null  $perPage

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -120,62 +120,6 @@ class Builder
         return User::query()->decrement(\Illuminate\Support\Facades\DB::raw('counter'));
     }
 
-    /** @phpstan-return null|EloquentBuilder<User> */
-    public function testWhen(bool $foo): ?EloquentBuilder
-    {
-        $innerQuery = null;
-        User::query()->when($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
-            /** @phpstan-var EloquentBuilder<User> $query */
-            $innerQuery = $query;
-
-            return $query->whereNull('name');
-        });
-
-        return $innerQuery;
-    }
-
-    public function testWhenVoid(bool $foo): void
-    {
-        User::query()->when($foo, static function (EloquentBuilder $query) {
-            $query->whereNull('name');
-        });
-    }
-
-    public function testWhenDefaultVoid(bool $foo): void
-    {
-        User::query()->when($foo, null, static function (EloquentBuilder $query) {
-            $query->whereNull('name');
-        });
-    }
-
-    /** @phpstan-return null|EloquentBuilder<User> */
-    public function testUnless(bool $foo): ?EloquentBuilder
-    {
-        $innerQuery = null;
-        User::query()->unless($foo, static function (EloquentBuilder $query) use (&$innerQuery) {
-            /** @phpstan-var EloquentBuilder<User> $query */
-            $innerQuery = $query;
-
-            return $query->whereNull('name');
-        });
-
-        return $innerQuery;
-    }
-
-    public function testUnlessVoid(bool $foo): void
-    {
-        User::query()->unless($foo, static function (EloquentBuilder $query) {
-            $query->whereNull('name');
-        });
-    }
-
-    public function testUnlessDefaultVoid(bool $foo): void
-    {
-        User::query()->unless($foo, null, static function (EloquentBuilder $query) {
-            $query->whereNull('name');
-        });
-    }
-
     /** @param EloquentBuilder<User> $query */
     public function testMacro(EloquentBuilder $query): void
     {

--- a/tests/Type/data/conditionable.php
+++ b/tests/Type/data/conditionable.php
@@ -2,6 +2,8 @@
 
 namespace ConditionableStubs;
 
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Traits\Conditionable;
 use function PHPStan\Testing\assertType;
 
@@ -33,3 +35,13 @@ assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $fo
 assertType('int', (new Foo())->unless(true, function (Foo $foo): int {
     return rand();
 }));
+
+/** @param Builder<User> $query */
+function doFoo(Builder $query): void
+{
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query->when(true, static function (Builder $query): Builder {
+        /** @phpstan-var Builder<User> $query */
+
+        return $query->whereNull('name');
+    }));
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Fixes https://github.com/nunomaduro/larastan/issues/915

**Changes**

This PR removes `when` and `unless` from EloquentBuilder stub. These methods are coming from the Conditionable trait, and we don't need to duplicate them in this stub.

**Breaking changes**

none
