### PR TITLE
[9.x] DOC BLOCK params fix on orderBy methods at Query Builder stub file

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -903,7 +903,7 @@ class Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -915,7 +915,7 @@ class Builder
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this
      */
     public function orderByDesc($column)


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

As per the laravel 9.18 updates, they changed the comment of the orderBy and orderByDesc method you can [check](https://github.com/laravel/framework/pull/42768) 

**Changes**

Just changed the wrong comment. 


