### PR TITLE
feat: use correct builder return types for Model::newQuery* methods

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -151,7 +151,7 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
-        class: NunoMaduro\Larastan\ReturnTypes\ModelExtension
+        class: NunoMaduro\Larastan\ReturnTypes\ModelDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
@@ -275,6 +275,11 @@ services:
 
     -
         class: NunoMaduro\Larastan\ReturnTypes\CollectionGenericStaticMethodDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\NewModelQueryDynamicMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -22,7 +22,7 @@ use PHPStan\Type\Type;
 /**
  * @internal
  */
-final class ModelExtension implements DynamicStaticMethodReturnTypeExtension
+final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
     /** @var BuilderHelper */
     private $builderHelper;

--- a/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Larastan\Methods\BuilderHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+
+class NewModelQueryDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private BuilderHelper $builderHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), [
+            'newQuery', 'newModelQuery', 'newQueryWithoutRelationships',
+            'newQueryWithoutScopes', 'newQueryWithoutScope', 'newQueryForRestoration',
+        ], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $calledOnType = $scope->getType($methodCall->var);
+
+        if (! $calledOnType instanceof TypeWithClassName) {
+            return null;
+        }
+
+        $builderName = $this->builderHelper->determineBuilderName($calledOnType->getClassName());
+
+        return new GenericObjectType($builderName, [$calledOnType]);
+    }
+}

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -143,3 +143,20 @@ Post::query()->where(static function (PostBuilder $query) {
         ->orWhere('bar', 'LIKE', '%foo%')
         ->orWhereRelation('users', 'name', 'LIKE', '%foo%'));
 });
+
+function doFoo(User $user, Post $post): void
+{
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newQuery());
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newModelQuery());
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newQueryWithoutRelationships());
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newQueryWithoutScopes());
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newQueryWithoutScope('foo'));
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->newQueryForRestoration([1]));
+
+    assertType('App\PostBuilder<App\Post>', $post->newQuery());
+    assertType('App\PostBuilder<App\Post>', $post->newModelQuery());
+    assertType('App\PostBuilder<App\Post>', $post->newQueryWithoutRelationships());
+    assertType('App\PostBuilder<App\Post>', $post->newQueryWithoutScopes());
+    assertType('App\PostBuilder<App\Post>', $post->newQueryWithoutScope('foo'));
+    assertType('App\PostBuilder<App\Post>', $post->newQueryForRestoration([1]));
+};


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

This PR adds new NewModelQueryDynamicMethodReturnTypeExtension that returns correct types for `Model::newQuery*` method family.

**Breaking changes**
n/a
