### PR TITLE
fix: return correct types from model factories

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -283,6 +283,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\FactoryDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\CollectionGenericStaticMethodDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/FactoryDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/FactoryDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use NunoMaduro\Larastan\Types\Factory\ModelFactoryType;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class FactoryDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Factory::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return true;
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $calledOnType = $scope->getType($methodCall->var);
+        $originalReturnType = ParametersAcceptorSelector::selectFromArgs($scope, $methodCall->getArgs(), $methodReflection->getVariants())->getReturnType();
+
+        if (! $calledOnType instanceof ModelFactoryType) {
+            return null;
+        }
+
+        if ($methodReflection->getName() === 'count') {
+            if ($methodCall->getArgs() === []) {
+                return new ErrorType();
+            }
+
+            $argType = $scope->getType($methodCall->getArgs()[0]->value);
+
+            if ((new IntegerType())->isSuperTypeOf($argType)->yes()) {
+                return new ModelFactoryType($calledOnType->getClassName(), null, null, TrinaryLogic::createNo());
+            }
+
+            if ((new NullType())->isSuperTypeOf($argType)->yes()) {
+                return new ModelFactoryType($calledOnType->getClassName(), null, null, TrinaryLogic::createYes());
+            }
+
+            return new ModelFactoryType($calledOnType->getClassName(), null, null, TrinaryLogic::createMaybe());
+        }
+
+        if (in_array($methodReflection->getName(), ['create', 'createQuietly', 'make'], true)) {
+            if ($calledOnType->isSingleModel()->yes()) {
+                return TypeCombinator::remove($originalReturnType, new ObjectType(Collection::class));
+            } elseif ($calledOnType->isSingleModel()->no()) {
+                return TypeCombinator::remove($originalReturnType, new ObjectType(Model::class));
+            }
+        }
+
+        if (! $originalReturnType->isSuperTypeOf($calledOnType)->yes()) {
+            return null;
+        }
+
+        return $calledOnType;
+    }
+}

--- a/src/Types/Factory/ModelFactoryType.php
+++ b/src/Types/Factory/ModelFactoryType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types\Factory;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ModelFactoryType extends ObjectType
+{
+    private TrinaryLogic $isSingleModel;
+
+    public function __construct(
+        string $className,
+        ?Type $subtractedType = null,
+        ?ClassReflection $classReflection = null,
+        ?TrinaryLogic $isSingleModel = null,
+    ) {
+        parent::__construct($className, $subtractedType, $classReflection);
+
+        $this->isSingleModel = $isSingleModel ?? TrinaryLogic::createMaybe();
+    }
+
+    public function isSingleModel(): TrinaryLogic
+    {
+        return $this->isSingleModel;
+    }
+}

--- a/stubs/Factory.stub
+++ b/stubs/Factory.stub
@@ -48,6 +48,15 @@ class Factory
     public function create($attributes = [], ?\Illuminate\Database\Eloquent\Model $parent = null) {}
 
     /**
+     * Create a collection of models and persist them to the database without dispatching any model events.
+     *
+     * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|TModel
+     */
+    public function createQuietly($attributes = [], ?\Illuminate\Database\Eloquent\Model $parent = null) {}
+
+    /**
      * Make a single instance of the model.
      *
      * @param  callable|array<model-property<TModel>, mixed>  $attributes

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -13,14 +13,15 @@ class GeneralTypeTest extends TypeInferenceTestCase
      */
     public function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__.'/data/request-object.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/route.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/conditionable.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/translate.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/request-object.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/route.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/conditionable.php');
+//        yield from $this->gatherAssertTypes(__DIR__.'/data/translate.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/model-factories.php');
     }
 
     /**

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ModelFactories;
+
+use App\User;
+use function PHPStan\Testing\assertType;
+
+assertType('Database\Factories\UserFactory', User::factory());
+assertType('Database\Factories\UserFactory', User::factory()->new());
+assertType('App\User', User::factory()->createOne());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->createMany([]));
+assertType('App\User', User::factory()->makeOne());
+
+assertType('App\User', User::factory()->create());
+assertType('App\User', User::factory()->createQuietly());
+assertType('App\User', User::factory()->make());
+
+assertType('App\User', User::factory()->configure()->create());
+assertType('App\User', User::factory()->configure()->createQuietly());
+assertType('App\User', User::factory()->configure()->make());
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->create());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->createQuietly());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->make());
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->create());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->createQuietly());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->make());
+
+assertType('App\User', User::factory(2)->count(null)->create());
+assertType('App\User', User::factory(2)->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->count(null)->make());
+
+assertType('App\User', User::factory(2)->count(null)->create());
+assertType('App\User', User::factory(2)->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->count(null)->make());
+
+assertType('App\User', User::factory(2)->state(['foo'])->count(null)->create());
+assertType('App\User', User::factory(2)->state(['foo'])->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->state(['foo'])->count(null)->make());
+
+function foo(?int $foo): void
+{
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count($foo)->create());
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count($foo)->createQuietly());
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count($foo)->make());
+
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory($foo)->create());
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory($foo)->createQuietly());
+    assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory($foo)->make());
+}

--- a/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
+++ b/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Unit;
+
+use NunoMaduro\Larastan\ReturnTypes\ModelFactoryDynamicStaticMethodReturnTypeExtension;
+use NunoMaduro\Larastan\Types\Factory\ModelFactoryType;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantFloatType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class ModelFactoryDynamicStaticMethodReturnTypeExtensionTest extends PHPStanTestCase
+{
+    /**
+     * @test
+     */
+    public function it_sets_the_is_single_model_flag_to_true_if_no_args_given(): void
+    {
+        $scope = $this->createMock(Scope::class);
+        $extension = new ModelFactoryDynamicStaticMethodReturnTypeExtension;
+
+        $type = $extension->getTypeFromStaticMethodCall(
+            new DummyMethodReflection('factory'), // @phpstan-ignore-line
+            new StaticCall(new Name('App\\User'), 'factory', []),
+            $scope
+        );
+
+        $this->assertInstanceOf(ModelFactoryType::class, $type);
+        $this->assertTrue((TrinaryLogic::createYes())->equals($type->isSingleModel()));
+    }
+
+    /**
+     * @test
+     * @dataProvider argumentProvider
+     */
+    public function it_sets_the_is_single_model_flag_correctly(Type $phpstanType, TrinaryLogic $expected): void
+    {
+        $scope = $this->createMock(Scope::class);
+        $extension = new ModelFactoryDynamicStaticMethodReturnTypeExtension;
+
+        $scope->method('getType')->willReturn($phpstanType);
+
+        $type = $extension->getTypeFromStaticMethodCall(
+            new DummyMethodReflection('factory'), // @phpstan-ignore-line
+            new StaticCall(new Name('App\\User'), 'factory', [new Arg(new LNumber(1))]), // args doesn't matter
+            $scope
+        );
+
+        $this->assertInstanceOf(ModelFactoryType::class, $type);
+        $this->assertSame($expected->describe(), $type->isSingleModel()->describe());
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__.'/../phpstan-tests.neon'];
+    }
+
+    public function argumentProvider(): \Generator
+    {
+        yield [new ConstantIntegerType(1), TrinaryLogic::createNo()];
+        yield [new ConstantIntegerType(0), TrinaryLogic::createNo()];
+        yield [new ConstantIntegerType(2), TrinaryLogic::createNo()];
+        yield [new ConstantIntegerType(-1), TrinaryLogic::createNo()];
+        yield [new ConstantFloatType(1.2), TrinaryLogic::createNo()];
+        yield [new IntegerType(), TrinaryLogic::createNo()];
+        yield [new FloatType(), TrinaryLogic::createNo()];
+        yield [new IntersectionType([
+            new ConstantStringType('1'),
+            new AccessoryNumericStringType(),
+        ]), TrinaryLogic::createNo()];
+        yield [new UnionType([new FloatType(), new ConstantIntegerType(1)]), TrinaryLogic::createNo()];
+
+        yield [new NullType(), TrinaryLogic::createYes()];
+        yield [new ObjectType('App\\User'), TrinaryLogic::createYes()];
+        yield [new ConstantStringType('foo'), TrinaryLogic::createYes()];
+
+        yield [new MixedType(), TrinaryLogic::createMaybe()];
+        yield [new UnionType([new NullType(), new ConstantIntegerType(1)]), TrinaryLogic::createMaybe()];
+        yield [new UnionType([new ArrayType(new IntegerType(), new IntegerType()), new IntegerType()]), TrinaryLogic::createMaybe()];
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Better return type inference for model factories. Now Larastan understands that `User::factory()->create()` returns a single model, whereas `User:factory(2)->create()` or `User::factory()->count(2)->create()` returns a collection.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
