### PR TITLE
fix: remove `fromSub` from stubs

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -37,18 +37,6 @@ class Builder
     {}
 
     /**
-     * Makes "from" fetch from a subquery.
-     *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
-     * @param  string  $as
-     * @return $this
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function fromSub($query, $as)
-    {}
-
-    /**
      * Add a raw from clause to the query.
      *
      * @param  string  $expression


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

removed fromSub from queryBuilder stub. Laravels phpdocs are more correct.

Right now fromSub will fail on an Eloquent Builder
