### PR TITLE
Expand docblock of JoinSub to allow other models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
@@ -6,112 +7,121 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
+
 ## [2.2.0] - 2022-08-31
 
 ### Added
-* Install fileinfo PHP extension by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1318
-* Configure Composer properly in CI by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1329
-* feat: rules for unnecessary uses of with() and values() functions by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1226
-* feat: add rule for missing 'provides' method in Deferrable ServiceProviders by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1262
-* feat: conditional return type for Collection::random method by @canvural in https://github.com/nunomaduro/larastan/pull/1338
-* Remove all unnecessary method stubs for the Query Builder by @lupinitylabs in https://github.com/nunomaduro/larastan/pull/1343
-* feat: add ViewWithMethodsClassReflectionExtension by @canvural in https://github.com/nunomaduro/larastan/pull/1348
+
+- Install fileinfo PHP extension by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1318
+- Configure Composer properly in CI by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1329
+- feat: rules for unnecessary uses of with() and values() functions by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1226
+- feat: add rule for missing 'provides' method in Deferrable ServiceProviders by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1262
+- feat: conditional return type for Collection::random method by @canvural in https://github.com/nunomaduro/larastan/pull/1338
+- Remove all unnecessary method stubs for the Query Builder by @lupinitylabs in https://github.com/nunomaduro/larastan/pull/1343
+- feat: add ViewWithMethodsClassReflectionExtension by @canvural in https://github.com/nunomaduro/larastan/pull/1348
 
 ### Fixed
-* fix: use Composer autoloader to determine vendor-dir by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1319
-* fix: return correct types from model factories by @canvural in https://github.com/nunomaduro/larastan/pull/1339
-* fix: better return types for `App::environment` by @crissi in https://github.com/nunomaduro/larastan/pull/1303
-* fix: remove `fromSub` from stubs by @crissi in https://github.com/nunomaduro/larastan/pull/1340
 
+- fix: use Composer autoloader to determine vendor-dir by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1319
+- fix: return correct types from model factories by @canvural in https://github.com/nunomaduro/larastan/pull/1339
+- fix: better return types for `App::environment` by @crissi in https://github.com/nunomaduro/larastan/pull/1303
+- fix: remove `fromSub` from stubs by @crissi in https://github.com/nunomaduro/larastan/pull/1340
 
 ## [2.1.8] - 2022-06-04
 
 ### Fixed
-* Don't use `ReflectionClass` directly https://github.com/nunomaduro/larastan/commit/2404fa8d9e27d726bb9e42ec754b323d6727bdfd
-* Don't try to invoke methods on classes https://github.com/nunomaduro/larastan/commit/2a0b2dade387bc19bdf070650c1ba1e035c709da
+
+- Don't use `ReflectionClass` directly https://github.com/nunomaduro/larastan/commit/2404fa8d9e27d726bb9e42ec754b323d6727bdfd
+- Don't try to invoke methods on classes https://github.com/nunomaduro/larastan/commit/2a0b2dade387bc19bdf070650c1ba1e035c709da
 
 ## [2.1.7] - 2022-06-03
 
 ### Added
-* Conditional return types to some global helper functions by @canvural in https://github.com/nunomaduro/larastan/pull/1260
-* Conditional return types for `Conditionable` trait by @canvural in https://github.com/nunomaduro/larastan/pull/1261
-* Conditional return type for `Route::middleware` by @canvural in https://github.com/nunomaduro/larastan/commit/0543c454896f07079d86145afbc318a947ee72c1
+
+- Conditional return types to some global helper functions by @canvural in https://github.com/nunomaduro/larastan/pull/1260
+- Conditional return types for `Conditionable` trait by @canvural in https://github.com/nunomaduro/larastan/pull/1261
+- Conditional return type for `Route::middleware` by @canvural in https://github.com/nunomaduro/larastan/commit/0543c454896f07079d86145afbc318a947ee72c1
 
 ## [2.1.6] - 2022-05-23
 
 ### Changed
 
-* Increased minimum PHPStan version to 1.7.0
+- Increased minimum PHPStan version to 1.7.0
 
 ## [2.1.5] - 2022-05-23
 
 ### Added
 
-* feat: add dynamic return type extension for `App::make` by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1222
-* Improve DX: specify memory limits for tests (custom composer scripts) by @lptn in https://github.com/nunomaduro/larastan/pull/1220
-* Allow Builder-s in Builder::union* $query parameter by @fagai in https://github.com/nunomaduro/larastan/pull/1231
-* Added conditional return types by @ricklambrechts in https://github.com/nunomaduro/larastan/pull/1236
-* Add support for Storage::drive besides Storage::disk by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1241
-* Date type extension by @bastien-phi in https://github.com/nunomaduro/larastan/pull/1142
+- feat: add dynamic return type extension for `App::make` by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1222
+- Improve DX: specify memory limits for tests (custom composer scripts) by @lptn in https://github.com/nunomaduro/larastan/pull/1220
+- Allow Builder-s in Builder::union\* $query parameter by @fagai in https://github.com/nunomaduro/larastan/pull/1231
+- Added conditional return types by @ricklambrechts in https://github.com/nunomaduro/larastan/pull/1236
+- Add support for Storage::drive besides Storage::disk by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1241
+- Date type extension by @bastien-phi in https://github.com/nunomaduro/larastan/pull/1142
 
 ### Fixed
-* fix: typo in doc file name by @mnastalski in https://github.com/nunomaduro/larastan/pull/1208
-* fix: fix: change `QueryBuilder::newQuery()` @return from `$this` to `static` by @dotdash in https://github.com/nunomaduro/larastan/pull/1221
-* Update joinSub docblock by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1212
-* When unless void default by @BertvanHoekelen in https://github.com/nunomaduro/larastan/pull/1203
-* Fix Model property types by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1234
+
+- fix: typo in doc file name by @mnastalski in https://github.com/nunomaduro/larastan/pull/1208
+- fix: fix: change `QueryBuilder::newQuery()` @return from `$this` to `static` by @dotdash in https://github.com/nunomaduro/larastan/pull/1221
+- Update joinSub docblock by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1212
+- When unless void default by @BertvanHoekelen in https://github.com/nunomaduro/larastan/pull/1203
+- Fix Model property types by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1234
 
 ## [2.1.4] - 2022-03-30
 
 ### Improvements
-* feat: add cursorPaginate() support by @BramVanBerkel in https://github.com/nunomaduro/larastan/pull/1198
-* feat: add App::make() support by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1222
+
+- feat: add cursorPaginate() support by @BramVanBerkel in https://github.com/nunomaduro/larastan/pull/1198
+- feat: add App::make() support by @PrinsFrank in https://github.com/nunomaduro/larastan/pull/1222
 
 ### Fixes
-* fix: inverted check in the ModelRuleHelper by @mad-briller in https://github.com/nunomaduro/larastan/pull/1207
+
+- fix: inverted check in the ModelRuleHelper by @mad-briller in https://github.com/nunomaduro/larastan/pull/1207
 
 ## [2.1.3] - 2022-03-23
 
 ### Improvements
-* feat: add exact typehints for `Model` `casts`, `hidden` and `visible` properties by @Magiczne in https://github.com/nunomaduro/larastan/pull/1158
-* feat: support `with` in RelationExistenceRule  by @canvural in https://github.com/nunomaduro/larastan/pull/1175
-* feat: update Eloquent Builder stubs to be more specific by @canvural in https://github.com/nunomaduro/larastan/pull/1178
-* Break long line in transformStaticParameters by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1183
-* feat: improve model factory `after*` methods by @mdpoulter in https://github.com/nunomaduro/larastan/pull/1195
+
+- feat: add exact typehints for `Model` `casts`, `hidden` and `visible` properties by @Magiczne in https://github.com/nunomaduro/larastan/pull/1158
+- feat: support `with` in RelationExistenceRule by @canvural in https://github.com/nunomaduro/larastan/pull/1175
+- feat: update Eloquent Builder stubs to be more specific by @canvural in https://github.com/nunomaduro/larastan/pull/1178
+- Break long line in transformStaticParameters by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1183
+- feat: improve model factory `after*` methods by @mdpoulter in https://github.com/nunomaduro/larastan/pull/1195
 
 ### Fixes
-* fix: use custom collection if it does not have template types by @canvural in https://github.com/nunomaduro/larastan/pull/1170
-* fix: ignore Model in ModelPropertyRule by @canvural in https://github.com/nunomaduro/larastan/pull/1184
-* fix: use TypeTraverser to handle Union and Intersection types in `ModelRelationsExtension` by @canvural in https://github.com/nunomaduro/larastan/pull/1187
 
+- fix: use custom collection if it does not have template types by @canvural in https://github.com/nunomaduro/larastan/pull/1170
+- fix: ignore Model in ModelPropertyRule by @canvural in https://github.com/nunomaduro/larastan/pull/1184
+- fix: use TypeTraverser to handle Union and Intersection types in `ModelRelationsExtension` by @canvural in https://github.com/nunomaduro/larastan/pull/1187
 
-* fix: updated `composer/pcre` to new PHP relevant version
-* feat: add support for the `foreignId` column in migrations
+- fix: updated `composer/pcre` to new PHP relevant version
+- feat: add support for the `foreignId` column in migrations
 
 ## [2.1.0] - 2022-03-04
 
 ### Added
 
-* feat: add return type support for `$request->user()` call by @canvural in https://github.com/nunomaduro/larastan/pull/1136
-* feat: schema dump parsing by @canvural in https://github.com/nunomaduro/larastan/pull/1147
-* feat: add support for migrations using `Schema::connection` by @canvural in https://github.com/nunomaduro/larastan/pull/1151
+- feat: add return type support for `$request->user()` call by @canvural in https://github.com/nunomaduro/larastan/pull/1136
+- feat: schema dump parsing by @canvural in https://github.com/nunomaduro/larastan/pull/1147
+- feat: add support for migrations using `Schema::connection` by @canvural in https://github.com/nunomaduro/larastan/pull/1151
 
 ### Fixed
-* fix: collect() returns collection which can have array-key as key type in https://github.com/nunomaduro/larastan/commit/b0a50dfe2d21c44c9f2577aa5d7c9825b6b9d5b2
-* fix: `Query::whereBetween` typehint by @gitetsu in https://github.com/nunomaduro/larastan/pull/1123
-* fix: update PHPStan version and stubs by @canvural in https://github.com/nunomaduro/larastan/pull/1144
-* fix: `deleted_at` column has date type rather than `string` by @totov in https://github.com/nunomaduro/larastan/pull/1124
 
+- fix: collect() returns collection which can have array-key as key type in https://github.com/nunomaduro/larastan/commit/b0a50dfe2d21c44c9f2577aa5d7c9825b6b9d5b2
+- fix: `Query::whereBetween` typehint by @gitetsu in https://github.com/nunomaduro/larastan/pull/1123
+- fix: update PHPStan version and stubs by @canvural in https://github.com/nunomaduro/larastan/pull/1144
+- fix: `deleted_at` column has date type rather than `string` by @totov in https://github.com/nunomaduro/larastan/pull/1124
 
 ## [2.0.1] - 2022-02-09
 
 ### Added
 
-* Fix incorrect return type by `route` on Request class by @fragkp in https://github.com/nunomaduro/larastan/pull/1113
+- Fix incorrect return type by `route` on Request class by @fragkp in https://github.com/nunomaduro/larastan/pull/1113
 
 ### Changed
 
-* refactor: replace composer with copy of ClassMapGenerator by @canvural in https://github.com/nunomaduro/larastan/pull/1119
+- refactor: replace composer with copy of ClassMapGenerator by @canvural in https://github.com/nunomaduro/larastan/pull/1119
 
 ## [2.0.0] - 2022-01-26
 
@@ -119,58 +129,68 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Dropped support for Laravel versions older than 9.
 - Moved all Collection stubs to Laravel core.
+
 ### Added
-* Infer type of model `id` without migrations by @sebdesign in https://github.com/nunomaduro/larastan/pull/1057
-* Enable Testbench package discovery by @mewejo in https://github.com/nunomaduro/larastan/pull/1093
+
+- Infer type of model `id` without migrations by @sebdesign in https://github.com/nunomaduro/larastan/pull/1057
+- Enable Testbench package discovery by @mewejo in https://github.com/nunomaduro/larastan/pull/1093
 
 ## [1.0.3] - 2022-01-20
 
-* Avoid #1059 by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1062
-* Fix SchemaAggregation when renaming tables through non-static method call by @N-Silbernagel in https://github.com/nunomaduro/larastan/pull/1065
-* fix: Call to an undefined method Eloquent\Builder::restore by @ryo-imai-bit in https://github.com/nunomaduro/larastan/pull/1061
-* fix: check for trait with getDeclaringTrait if method is declared in a trait
-* fix: use container to get the FunctionCallParametersCheck class in test
+- Avoid #1059 by @szepeviktor in https://github.com/nunomaduro/larastan/pull/1062
+- Fix SchemaAggregation when renaming tables through non-static method call by @N-Silbernagel in https://github.com/nunomaduro/larastan/pull/1065
+- fix: Call to an undefined method Eloquent\Builder::restore by @ryo-imai-bit in https://github.com/nunomaduro/larastan/pull/1061
+- fix: check for trait with getDeclaringTrait if method is declared in a trait
+- fix: use container to get the FunctionCallParametersCheck class in test
 
 ## [1.0.2] - 2021-11-23
 
 ### Added
-* Throw types for macros by @canvural in https://github.com/nunomaduro/larastan/pull/1013
-* Improve return types for Collection::first, last, get and pull when default value is given. by @bastien-phi in https://github.com/nunomaduro/larastan/pull/1010
+
+- Throw types for macros by @canvural in https://github.com/nunomaduro/larastan/pull/1013
+- Improve return types for Collection::first, last, get and pull when default value is given. by @bastien-phi in https://github.com/nunomaduro/larastan/pull/1010
 
 ### Fixed
-* Respect ancestor property tags in model extensions by @spawnia in https://github.com/nunomaduro/larastan/pull/1037
-* Correct method reflection for magic `with*` calls on `RedirectResponse` by @canvural in https://github.com/nunomaduro/larastan/pull/1016
-* Eloquent collection has array-key for the key type by @canvural in https://github.com/nunomaduro/larastan/pull/1027
-* Laravel container can have scalar bindings by @canvural in https://github.com/nunomaduro/larastan/pull/1028
-* `tap` helper should not enforce any return type for the callback by @tpetry in https://github.com/nunomaduro/larastan/pull/1031
+
+- Respect ancestor property tags in model extensions by @spawnia in https://github.com/nunomaduro/larastan/pull/1037
+- Correct method reflection for magic `with*` calls on `RedirectResponse` by @canvural in https://github.com/nunomaduro/larastan/pull/1016
+- Eloquent collection has array-key for the key type by @canvural in https://github.com/nunomaduro/larastan/pull/1027
+- Laravel container can have scalar bindings by @canvural in https://github.com/nunomaduro/larastan/pull/1028
+- `tap` helper should not enforce any return type for the callback by @tpetry in https://github.com/nunomaduro/larastan/pull/1031
 
 ### Changed
-* Improve return types for Collection `first`, `firstWhere`, `last` by @sebdesign in https://github.com/nunomaduro/larastan/pull/1025
-* Update default config to match new highest level by @felixdorn in https://github.com/nunomaduro/larastan/pull/1014
+
+- Improve return types for Collection `first`, `firstWhere`, `last` by @sebdesign in https://github.com/nunomaduro/larastan/pull/1025
+- Update default config to match new highest level by @felixdorn in https://github.com/nunomaduro/larastan/pull/1014
 
 ## [1.0.1] - 2021-11-06
 
 ### Changed
-* Fix `groupBy` Collection method signature
-* Renamed `CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule` to `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` by @canvural in https://github.com/nunomaduro/larastan/pull/1003
-* `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` now checks for argument types compatibility with the class constructor for both Event and Job classes. by @canvural in https://github.com/nunomaduro/larastan/pull/1003
+
+- Fix `groupBy` Collection method signature
+- Renamed `CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule` to `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` by @canvural in https://github.com/nunomaduro/larastan/pull/1003
+- `CheckDispatchArgumentTypesCompatibleWithClassConstructorRule` now checks for argument types compatibility with the class constructor for both Event and Job classes. by @canvural in https://github.com/nunomaduro/larastan/pull/1003
 
 ### Improvements
-* Clarified "static analysis" wording in docs and logo by @asgrim in https://github.com/nunomaduro/larastan/pull/1008
+
+- Clarified "static analysis" wording in docs and logo by @asgrim in https://github.com/nunomaduro/larastan/pull/1008
 
 ## [1.0.0] - 2021-11-01
 
 ### Added
+
 - Dynamic method return type extension for `Enumerable::filter` in https://github.com/nunomaduro/larastan/pull/981
-- New rule to check for relation existence  in https://github.com/nunomaduro/larastan/pull/985
+- New rule to check for relation existence in https://github.com/nunomaduro/larastan/pull/985
 - `rescue` parameter of `rescue` function now accepts the `Throwable` by @sebdesign in https://github.com/nunomaduro/larastan/pull/989
 - New `CheckJobDispatchArgumentTypesCompatibleWithClassConstructorRule` rule in https://github.com/nunomaduro/larastan/pull/991
 - Added `non-empty-string` types in stubs. https://github.com/nunomaduro/larastan/commit/c5b81cfee07686e2ce0ea557f8e32f2f022d47eb
 
 ### Fixed
+
 - PHPStan 1.0 compatibility in https://github.com/nunomaduro/larastan/pull/968
 
 ### BC breaking changes
+
 - `JsonResource` class is no longer generic. You can remove `@template` tags from your resource classes and directly add `@mixin Model` tags to your resource classes. https://github.com/nunomaduro/larastan/commit/37f9ce80890a67a02b1d55bf79eb73604880c6b9
 
 ## [0.7.15] - 2021-10-26
@@ -225,11 +245,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.7.11] - 2021-07-22
 
 ### Added
+
 - Support for Laravel 8 model factories. ([#861](https://github.com/nunomaduro/larastan/pull/861), [`6a03ad7`](https://github.com/nunomaduro/larastan/commit/6a03ad7899f5b71133c459df0260e19491dc5ed4))
 - Support for `orWhere` HigherOrderBuilderProxy property. ([#884](https://github.com/nunomaduro/larastan/pull/884)) Thanks @shaffe-fr
 - Added more precise declarations to Factory stub ([#888](https://github.com/nunomaduro/larastan/pull/888)) Thanks @spawnia
 
 ### Changed
+
 - Laravel 9 tests cannot run on PHP 7.4
 
 ## [0.7.10] - 2021-07-07
@@ -259,14 +281,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for detecting nested trait usage for SoftDeletes trait ([#838](https://github.com/nunomaduro/larastan/pull/838)) Thanks @IAmRGroot
 - Added support for vendor-dir ([#850](https://github.com/nunomaduro/larastan/pull/850)) Thanks @rajyan
 
-
 ### Fixed
 
 - Correct return type for restore method
 - Nullable properties should not be overwritten when applying model casts
 - Fixed suggest in Composer config ([#846](https://github.com/nunomaduro/larastan/pull/846)) Thanks @szepeviktor
 - Fixed bootstrap path ([#852](https://github.com/nunomaduro/larastan/pull/852)) Thanks @rajyan
-
 
 ## [0.7.6] - 2021-05-18
 
@@ -359,6 +379,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for `Model::whereNotBetween()` ([#731](https://github.com/nunomaduro/larastan/pull/731))
 
 ### Fixed
+
 - Search missing method also in templated model ([#739](https://github.com/nunomaduro/larastan/pull/739))
 
 ## [0.6.11] - 2020-12-07
@@ -424,26 +445,30 @@ This release introduces a new rule that can check the arguments of methods that 
 
 **NOTE**: This rule is currently in beta! If you want to improve it's analysis, you can check out the issue [here](https://github.com/nunomaduro/larastan/issues/676) and contribute!
 
-
 ### Added
+
 - Add a new `view-string` PHPDoc type ([#654](https://github.com/nunomaduro/larastan/pull/654))
 - Stubs for Eloquent builder `value` and `orWhere` methods
 
 ### Fixed
+
 - Parameter type of the query builder's `where`, `orWhere` and `addArrayOfWheres` ([#651](https://github.com/nunomaduro/larastan/pull/651)).
 - Fix callback parameters for `retry` ([#663](https://github.com/nunomaduro/larastan/pull/663)).
 - Using Reflection to initiate a model in `ModelPropertyExtension` to avoid errors caused by using Model constructor. ([#666](https://github.com/nunomaduro/larastan/pull/666))
 
 ### Changed
+
 - Made improvements to database migrations scanning. ([#670](https://github.com/nunomaduro/larastan/pull/670))
 - Improved running test suite commands and Windows compatibility ([#682](https://github.com/nunomaduro/larastan/pull/682))
 
 ## [0.6.4] - 2020-09-02
 
 ### Changed
+
 - Update `orchestra/testbench` version to allow Laravel 8 installations ([#646](https://github.com/nunomaduro/larastan/pull/646))
 
 ### Fixed
+
 - Return type of `firstWhere` method on model, builder and relations ([#649](https://github.com/nunomaduro/larastan/pull/649))
 
 ## [0.6.3] - 2020-08-31
@@ -477,42 +502,53 @@ This release introduces a new rule that can check the arguments of methods that 
 ## [0.6.1] - 2020-06-20
 
 ### Added
+
 - Support for dynamic auth model loading from config. Thanks @0xb4lint ([#602](https://github.com/nunomaduro/larastan/pull/602))
 - Support for Laravel 8
 
 ### Fixed
+
 - Fix false positive when calling `tap($this)` ([#601](https://github.com/nunomaduro/larastan/pull/601))
 
 ## [0.6.0] - 2020-06-10
 
 ### Added
+
 - Document common errors for users to ignore ([#564](https://github.com/nunomaduro/larastan/pull/564))
 - Add `abort` to `earlyTerminatingFunctionCalls` config option ([#567](https://github.com/nunomaduro/larastan/pull/567))
 - Support for `tap` helper. ([#575](https://github.com/nunomaduro/larastan/pull/575))
 - Bumped minimum PHPStan version to 0.12.28
 
 ### Fixed
+
 - Avoid false-positive when calling static builder methods such as `::find()` on Model classes where
   the concrete subclass is not yet known ([#565](https://github.com/nunomaduro/larastan/pull/565))
 - Use correct argument order for `Str::startsWith` ([#570](https://github.com/nunomaduro/larastan/pull/570))
 
 ### Changed
+
 - Do not overwrite PHPStan's default for `reportUnmatchedIgnoredErrors` ([#564](https://github.com/nunomaduro/larastan/pull/564))
 
 ### Removed
+
 - Stop ignoring errors ([#564](https://github.com/nunomaduro/larastan/pull/564))
 
 ## [0.5.8] - 2020-05-06
 
 ### Added
+
 - Support for custom Eloquent collections. Thanks @timacdonald ([#537](https://github.com/nunomaduro/larastan/pull/537))
 - Added issue and PR templates for new contributors. Thanks @spawnia ([#560](https://github.com/nunomaduro/larastan/pull/560))
+
 ### Fixed
+
 - Fixed some of the collection methods in stub files. Thanks @Daanra ([#556](https://github.com/nunomaduro/larastan/pull/556))
 - Fixed a bug with Composer autoloading. Thanks @ondrejmirtes ([#561](https://github.com/nunomaduro/larastan/pull/561))
+
 ## [0.5.7] - 2020-04-28
 
 ### Fixed
+
 - Fixed incorrect stubs for model creation methods. ([85716a5](https://github.com/nunomaduro/larastan/commit/85716a50610740af787899709814c1053ef4acf6))
 - Fixed false positives on NoUnnecessaryCollectionCallRule rule. Thanks @Daanra ([#546](https://github.com/nunomaduro/larastan/pull/546))
 
@@ -523,12 +559,14 @@ This release introduces a new rule that can check the arguments of methods that 
 ## [0.5.6] - 2020-04-26
 
 ### Fixed
+
 - Fixed relation methods with custom builders always returning custom builder. ([#520](https://github.com/nunomaduro/larastan/pull/520))
 - Fixed reading `boolean` columns from migrations. ([#514](https://github.com/nunomaduro/larastan/pull/514), [#513](https://github.com/nunomaduro/larastan/pull/513), [692fcd1](https://github.com/nunomaduro/larastan/commit/692fcd1ddc7017a5d25a476153b3e3d0b8081624), [d1f1861](https://github.com/nunomaduro/larastan/commit/d1f1861ae0094cd8e0f24f001f2bc43e2c85c9fb))
 - Annotations for model properties have higher order than migration files. ([ec22906](https://github.com/nunomaduro/larastan/commit/ec22906dba63325b21c1ac2640879dfd55a1394f))
 - Improved support for Eloquent relationships. ([#533](https://github.com/nunomaduro/larastan/pull/533))
 
 ### Added
+
 - Eloquent relations are now also generic. ([#518](https://github.com/nunomaduro/larastan/pull/518))
 - Support for Composer 2. Thanks @GrahamCampbell ([#528](https://github.com/nunomaduro/larastan/pull/528))
 - Support for `abort_unless`, `throw_if` and `throw_unless` functions. Thanks @Daanra ([#542](https://github.com/nunomaduro/larastan/pull/542))
@@ -539,23 +577,27 @@ This release introduces a new rule that can check the arguments of methods that 
 ## [0.5.5] - 2020-03-26
 
 ### Fixed
+
 - Assume id property exists only when it is not found. ([#510](https://github.com/nunomaduro/larastan/pull/510))
 - Fixed an issue with generics in BuilderModelFindExtension. ([#511](https://github.com/nunomaduro/larastan/pull/511))
 
 ## [0.5.4] - 2020-03-22
 
 ### Added
+
 - Support for return type inference of `find*` methods on Builder class depending on passed arguments. ([#503](https://github.com/nunomaduro/larastan/pull/503))
 
 ## [0.5.3] - 2020-03-21
 
 ### Added
+
 - Support for Eloquent resources. Thanks @mr-feek ([#470](https://github.com/nunomaduro/larastan/pull/470))
 - Treat Laravel ide-helper generated relationship properties as generic Collections. Thanks @mr-feek ([#479](https://github.com/nunomaduro/larastan/pull/479))
 - Treat Laravel ide-helper generated builder typehints as generic Builders. ([#497](https://github.com/nunomaduro/larastan/pull/497))
 - `id` property on any model class will be recognized as integer type. ([#499](https://github.com/nunomaduro/larastan/pull/499))
 
 ### Fixed
+
 - Corrected parameter type of builder dynamic wheres. Thanks @mr-feek ([#482](https://github.com/nunomaduro/larastan/pull/482))
 - Added a check to see if migrations directory exists. Thanks @deleugpn ([#498](https://github.com/nunomaduro/larastan/pull/498))
 - Added `Carbon/Carbon` to possible types for a date properties in models. Thanks @arxeiss ([#500](https://github.com/nunomaduro/larastan/pull/500))
@@ -564,6 +606,7 @@ This release introduces a new rule that can check the arguments of methods that 
 ## [0.5.2] - 2020-02-10
 
 ### Fixed
+
 - Model scopes returns the builder, if return type is `void` ([#450](https://github.com/nunomaduro/larastan/pull/450))
 - Fix return type of calling query builder methods on custom builders ([#453](https://github.com/nunomaduro/larastan/pull/453))
 - Fix return type of `all` on model. Thanks @BertvanHoekelen ([#454](https://github.com/nunomaduro/larastan/pull/454))
@@ -573,6 +616,7 @@ This release introduces a new rule that can check the arguments of methods that 
 ## [0.5.1] - 2020-02-04
 
 ### Added
+
 - Support for model accessors ([#401](https://github.com/nunomaduro/larastan/pull/401))
 - Handle Builder method calls, model scope calls and dynamic where calls on relations. Thanks @BertvanHoekelen ([#410](https://github.com/nunomaduro/larastan/pull/410), [#419](https://github.com/nunomaduro/larastan/pull/419), [#423](https://github.com/nunomaduro/larastan/pull/423))
 - Support for custom Eloquent builders ([#432](https://github.com/nunomaduro/larastan/pull/432))
@@ -581,8 +625,9 @@ This release introduces a new rule that can check the arguments of methods that 
 - Add generic stubs for Eloquent collection and Support collection. ([#439](https://github.com/nunomaduro/larastan/pull/439))
 
 ### Fixed
-- Better return type support for find* methods ([#400](https://github.com/nunomaduro/larastan/pull/400))
-- Don't register abstract service providers. Thanks @CyberiaResurrection  ([#440](https://github.com/nunomaduro/larastan/pull/440))
+
+- Better return type support for find\* methods ([#400](https://github.com/nunomaduro/larastan/pull/400))
+- Don't register abstract service providers. Thanks @CyberiaResurrection ([#440](https://github.com/nunomaduro/larastan/pull/440))
 
 ## [0.5.0] - 2019-12-25
 
@@ -590,6 +635,7 @@ Blogpost: [nunomaduro.com/larastan-0-5-is-out](https://nunomaduro.com/larastan-0
 Upgrade guide: [UPGRADE.md](https://github.com/nunomaduro/larastan/blob/master/UPGRADE.md)
 
 ### Added
+
 - Support to PHPStan `0.12` [#378](https://github.com/nunomaduro/larastan/pull/378)
 - Support to Laravel 7 [#377](https://github.com/nunomaduro/larastan/pull/377)
 - Support for Facade fakes [#347](https://github.com/nunomaduro/larastan/pull/347)
@@ -598,241 +644,349 @@ Upgrade guide: [UPGRADE.md](https://github.com/nunomaduro/larastan/blob/master/U
 - Support for return types of `spy`, `mock` and `partialMock` methods of `TestCase` [#362](https://github.com/nunomaduro/larastan/pull/362)
 
 ### Fixed
+
 - Fixed a bug about handling method calls that starts with `find` on model instances [#360](https://github.com/nunomaduro/larastan/pull/360)
 
 ### Removed
+
 - The artisan `code:analyse` command. [391](https://github.com/nunomaduro/larastan/pull/391)
 
 ## [0.4.3] - 2019-10-22
+
 ### Added
+
 - Support for `abort_if`. Fixes [#116](https://github.com/nunomaduro/larastan/issues/116) ([#330](https://github.com/nunomaduro/larastan/pull/330))
 
 ### Fixed
+
 - Better return type inference in models and builders ([#325](https://github.com/nunomaduro/larastan/pull/325), [#336](https://github.com/nunomaduro/larastan/pull/336))
 
 ## [0.4.2] - 2019-10-16
+
 ### Added
+
 - Support for determining correct return type for relation create method ([#320](https://github.com/nunomaduro/larastan/pull/320), [#323](https://github.com/nunomaduro/larastan/pull/323))
 
 ### Fixed
+
 - `getProjectClasses` method to use Composer data to get the classes ([#318](https://github.com/nunomaduro/larastan/pull/318))
 - Return type of calling scope on relation ([#322](https://github.com/nunomaduro/larastan/pull/322))
 
 ## [0.4.1] - 2019-10-07
+
 ### Added
+
 - Better return type inference in relation methods ([#319](https://github.com/nunomaduro/larastan/pull/319))
 - Better return type inference for auth guard method calls on auth helper and facade ([#317](https://github.com/nunomaduro/larastan/pull/317))
-- Support to phpstan extension plugin  ([#314](https://github.com/nunomaduro/larastan/pull/314))
+- Support to phpstan extension plugin ([#314](https://github.com/nunomaduro/larastan/pull/314))
 
 ## [0.4.0] - 2019-08-28
+
 ### Added
+
 - Support to `Carbon` macros ([#301](https://github.com/nunomaduro/larastan/pull/301))
 
 ### Fixed
+
 - Support to `laravel/framework:^6.0` without `laravel/helpers` package ([#311](https://github.com/nunomaduro/larastan/pull/311))
 
 ### Removed
+
 - Dependency of `orchestra/testbench` in Laravel projects ([#305](https://github.com/nunomaduro/larastan/pull/305))
 
 ## [0.3.21] - 2019-08-17
+
 ### Fixed
+
 - Macro method detector class implements MethodReflection instead of BuiltinMethodReflection ([#299](https://github.com/nunomaduro/larastan/pull/299))
 
 ## [0.3.20] - 2019-08-17
+
 ### Fixed
+
 - Macro method detector class implements MethodReflection instead of BuiltinMethodReflection ([#298](https://github.com/nunomaduro/larastan/pull/298))
 
 ## [0.3.19] - 2019-08-16
+
 ### Added
+
 - Partial support to `auth` helper ([#254](https://github.com/nunomaduro/larastan/pull/254))
 
 ### Fixed
+
 - Compatibility with PHPStan 0.11.13 ([#294](https://github.com/nunomaduro/larastan/pull/294))
 
 ## [0.3.18] - 2019-08-04
+
 ### Added
+
 - Support to Laravel 6 ([2be403c](https://github.com/nunomaduro/larastan/commit/2be403c784d0f4b84449b1b4f91b5c6ace3585a1))
 
 ## [0.3.17] - 2019-05-29
+
 ### Fixed
+
 - Issue with PHPStan 0.11.8 because of MethodReflectionFactory signature change ([#270](https://github.com/nunomaduro/larastan/pull/270))
 
 ## [0.3.16] - 2019-03-30
+
 ### Added
+
 - Support to Lumen (Put commit here)
 
 ### Fixed
+
 - Void return type on Models (Put commit here)
 
 ## [0.3.15] - 2019-01-23
+
 ### Added
+
 - Support to Laravel 5.8 ([0949fa5](https://github.com/nunomaduro/larastan/commit/0949fa59dea711c462c2d7a3a26b4a4a6cbafbf1))
 
 ## [0.3.14] - 2019-01-22
+
 ### Changed
+
 - Bumps PHPStan version to > 0.11.1 ([#229](https://github.com/nunomaduro/larastan/pull/229))
 
 ## [0.3.13] - 2018-12-21
+
 ### Added
+
 - Support to `trans` helper ([#220](https://github.com/nunomaduro/larastan/pull/220))
 
 ## [0.3.12] - 2018-12-03
+
 ### Added
+
 - Support to paginators ([c29af44](https://github.com/nunomaduro/larastan/commit/c29af44b318d57c8625db7dab1aa6d138e2bf48b))
 
 ## [0.3.11] - 2018-11-26
+
 ### Fixed
+
 - Null return type in `Auth::user()` ([#211](https://github.com/nunomaduro/larastan/pull/211))
 
 ## [0.3.10] - 2018-11-22
+
 ### Added
+
 - Support to return type of `$this` from Eloquent builder
 
 ## [0.3.9] - 2018-11-21
+
 ### Added
+
 - Support to return type of `Auth::user()`
 
 ## [0.3.8] - 2018-11-01
+
 ### Added
+
 - Auto detects configuration `phpstan.neon` ([#194](https://github.com/nunomaduro/larastan/pull/194))
 
 ## [0.3.7] - 2018-10-31
+
 ### Fixed
+
 - Fixes while resolving application with invalid php files ([7dd69ad](https://github.com/nunomaduro/larastan/commit/7dd69ad4feb7fe58676c2e4fd8dfe8f91d9af9d9))
 
 ## [0.3.6] - 2018-10-30
+
 ### Added
+
 - Support to return type of `url` helper ([#179](https://github.com/nunomaduro/larastan/pull/179))
 
 ## [0.3.5] - 2018-10-29
+
 ### Fixed
+
 - Internal error caused by non-existing provider name ([#170](https://github.com/nunomaduro/larastan/pull/170))
 - Issue when project name have spaces ([#186](https://github.com/nunomaduro/larastan/pull/186))
 
 ## [0.3.4] - 2018-10-09
+
 ### Fixed
+
 - Issue while calling soft deletes macros staticly
 
 ## [0.3.3] - 2018-10-09
+
 ### Added
+
 - Support for Soft Deletes
 
 ## [0.3.2] - 2018-10-05
+
 ### Added
+
 - Support to return type of `redirect` & `view` helpers ([#157](https://github.com/nunomaduro/larastan/pull/157))
 
 ## [0.3.1] - 2018-10-04
+
 ### Fixed
+
 - Usage with Laravel 5.6 ([2d13d9a](https://github.com/nunomaduro/larastan/commit/2d13d9a3ae0f2a50739ecc25e3b5860199486d7e))
 
 ## [0.3.0] - 2018-10-04
+
 ### Added
+
 - Support for code analysis in Laravel Packages
 
 ## [0.2.12] - 2018-09-27
+
 ### Added
+
 - Support to return type of `request` helper ([#145](https://github.com/nunomaduro/larastan/pull/145))
 
 ## [0.2.11] - 2018-09-21
+
 ### Added
+
 - Support to return type of `response` helper
 - Support to return type of `\Illuminate\Http\Response::input` method
 
 ### Fixed
+
 - False positives when performing long Eloquent queries
 - Issue when there is recursive mixins
 - When container got used twice using the `ArrayAccess` interface
 
 ## [0.2.10] - 2018-09-12
+
 ### Fixed
+
 - Issue while using invalid mixins ([#137](https://github.com/nunomaduro/larastan/pull/137))
 
 ## [0.2.9] - 2018-09-01
+
 ### Fixed
+
 - Usage of spaces with the option `--paths`
 
 ## [0.2.8] - 2018-09-01
+
 ### Fixed
+
 - Issue while resolving implementations from container
 
 ## [0.2.7] - 2018-08-27
+
 ### Fixed
+
 - Issue on Windows with the default path param ([#128](https://github.com/nunomaduro/larastan/pull/128))
 - Issue with exit code ([#115](https://github.com/nunomaduro/larastan/pull/115))
 - While running Larastan on CI envs ([#113](https://github.com/nunomaduro/larastan/pull/113))
 
 ## [0.2.6] - 2018-08-27
+
 ### Added
+
 - Support to Laravel 5.7
 
 ## [0.2.5] - 2018-08-17
+
 ### Fixed
+
 - Issue with option `errorFormat` ([#121](https://github.com/nunomaduro/larastan/pull/121))
 
 ## [0.2.4] - 2018-07-24
+
 ### Fixed
+
 - Issue while resolving implementations that don't exist on the container
 
 ## [0.2.3] - 2018-07-23
+
 ### Fixed
+
 - Common laravel false positives on trusted proxies and app exception handler
 
 ## [0.2.2] - 2018-07-23
+
 ### Fixed
+
 - Resolved null type from container
 
 ## [0.2.1] - 2018-07-23
+
 ### Fixed
-- Error - "internal error: * product does not exist"
+
+- Error - "internal error: \* product does not exist"
 
 ## [0.2.0] - 2018-07-22
+
 ### Fixed
+
 - Issues while using Lumen
 
 ## [0.1.9] - 2018-07-22
+
 ### Added
+
 - Support to Lumen and Laravel Zero
 
 ## [0.1.8] - 2018-07-22
+
 ### Added
+
 - Support to builder dynamic wheres
 
 ## [0.1.7] - 2018-07-22
+
 ### Added
+
 - Support to "object" return type
 
 ### Fixed
+
 - Bug on macro extension
 
 ## [0.1.6] - 2018-07-22
+
 ### Added
+
 - Allows array access on objects that respects container's contract
 
 ## [0.1.5] - 2018-07-22
+
 ### Fixed
+
 - Removes unused `dd`
 
 ## [0.1.4] - 2018-07-22
+
 ### Fixed
+
 - Issue when `static` is missing was return type hint on Illuminate Model mixins
 
 ## [0.1.3] - 2018-07-20
+
 ### Fixed
+
 - Usage on Windows + Laravel Homestead ([#55](https://github.com/nunomaduro/larastan/pull/55))
 
 ## [0.1.2] - 2018-07-20
+
 ### Added
+
 - `Illuminate\Contracts` property extension
 
 ## [0.1.1] - 2018-07-18
+
 ### Fixed
+
 - Infinite recursion in mixins middleware ([b5a4317](https://github.com/nunomaduro/larastan/commit/b5a4317ef7c19b9008e4efff7ef50d2649b00151))
 
 ## 0.1.0 - 2018-07-17
+
 ### Added
+
 - Adds first alpha version
 
-[Unreleased]: https://github.com/nunomaduro/larastan/compare/v2.2.0...HEAD
+[unreleased]: https://github.com/nunomaduro/larastan/compare/v2.2.0...HEAD
 [2.2.0]: https://github.com/nunomaduro/larastan/compare/v2.1.12...v2.2.0
 [2.1.8]: https://github.com/nunomaduro/larastan/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/nunomaduro/larastan/compare/v2.1.6...v2.1.7

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -8,8 +8,8 @@ class Builder
     /**
      * Add a subquery join clause to the query.
      *
-     * @template TModelClass of \Illuminate\Database\Eloquent\Model
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModelClass>|string  $query
+     * @template TAnyModelClass of \Illuminate\Database\Eloquent\Model
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TAnyModelClass>|string  $query
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -198,10 +198,10 @@ class Builder
     public function testJoinSubAllowsEloquentBuilder(): void
     {
         User::query()->joinSub(
-            User::query()->whereIn('id', [1, 2, 3]),
+            Post::query()->whereIn('id', [1, 2, 3]),
             'users',
             'users.id',
-            'users.id'
+            'posts.id'
         );
     }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

Expands on #1212.

**Changes**

The previous version of this docblock used the template `TModelClass`.  
However, this template was already in use at the class level, effectively limiting the argument to `joinSub` to be a QueryBuilder of the same type.

The test proved that this was allowed:

```php
User::query()->joinSub(
    User::query()->whereIn('id', [1, 2, 3]),
    'users',
    'users.id',
    'users.id'
);
```

However, in the wild, I noticed that `User::query()->joinSub(Post::query(), ...)` was _not_ allowed.

This change fixes that, simply by renaming the template in the `joinSub` docblock.

**Breaking changes**

None.
