### PR TITLE
fix: abstract manager would cause larastan to crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
 - feat: updated return type of the Request::header method by @mad-briller
 * feat: Added stub for `optional()` helper and class by @mad-briller in https://github.com/nunomaduro/larastan/pull/1344
+* fix: abstract Manager class causing Larastan to crash by @mad-briller
 
 ## [2.2.0] - 2022-08-31
 

--- a/src/Methods/Pipes/Managers.php
+++ b/src/Methods/Pipes/Managers.php
@@ -27,7 +27,7 @@ final class Managers implements PipeContract
 
         $found = false;
 
-        if ($classReflection->isSubclassOf(Manager::class)) {
+        if ($classReflection->isSubclassOf(Manager::class) && ! $classReflection->isAbstract()) {
             $driver = null;
 
             $concrete = $this->resolve(

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -27,6 +27,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1346.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/request-header.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/optional-helper.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/abstract-manager.php');
     }
 
     /**

--- a/tests/Type/data/abstract-manager.php
+++ b/tests/Type/data/abstract-manager.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AbstractManager;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Manager;
+use function PHPStan\Testing\assertType;
+
+abstract class AbstractManager extends Manager
+{
+}
+
+class RealManager extends AbstractManager
+{
+    public function getDefaultDriver()
+    {
+        return '';
+    }
+}
+
+assertType('AbstractManager\RealManager', new RealManager(new Container()));


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Encountered a situation where an `abstract` Manager class caused Larastan to crash, because it would try to resolve it from the container and then try to call a method on the `null` result, as the container cannot build an abstract class.

wasn't sure how to add tests for this as i couldn't find anything already covering the manager pipe, let me know if i missed it.
