### PR TITLE
fix: `retry` helper supports array of sleep times for $times

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -100,7 +100,7 @@ function rescue(callable $callback, $rescue = null, $report = true)
 
 /**
  * @template TValue
- * @param int $times
+ * @param int|array<int, int> $times
  * @param callable(int): TValue $callback
  * @param int $sleep
  * @param null|callable(\Exception): bool $when


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

The `retry` helper has a lesser-known additional supported type for the `$times` parameter. You can provide an array of sleep times that will be used.

**Breaking changes**

None