### PR TITLE
feat: add support for generic paginators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix: Eloquent builder `whereRelation()` losing the TModelClass generic type by @mad-briller.
 - feat: updated return type of the Validator::safe and FormRequest::safe method by @jdjfisher
 - feat: Added stub for the DB::transaction method by @jdjfisher
+- feat: add support for generic paginators by @erikgaal
 
 ## [2.2.0] - 2022-08-31
 

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -109,4 +109,37 @@ class BelongsToMany extends Relation
      * @phpstan-return \Traversable<int, TRelatedModel>
      */
     public function getResults();
+
+    /**
+     * Get a paginator for the "select" statement.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\LengthAwarePaginator<TRelatedModel>
+     */
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\Paginator<TRelatedModel>
+     */
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+
+    /**
+     * Paginate the given query into a cursor paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $cursorName
+     * @param  string|null  $cursor
+     * @return \Illuminate\Pagination\CursorPaginator<TRelatedModel>
+     */
+    public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);
 }

--- a/stubs/Contracts/Pagination.stub
+++ b/stubs/Contracts/Pagination.stub
@@ -4,9 +4,6 @@ namespace Illuminate\Contracts\Pagination;
 
 /**
  * @template TItem
- *
- * @mixin \Illuminate\Support\Collection<array-key, TItem>
- * @mixin \Illuminate\Pagination\Paginator<TItem>
  */
 interface Paginator
 {
@@ -19,8 +16,6 @@ interface Paginator
 /**
  * @template TItem
  *
- * @mixin \Illuminate\Support\Collection<array-key, TItem>
- * @mixin \Illuminate\Pagination\LengthAwarePaginator<TItem>
  * @extends Paginator<TItem>
  */
 interface LengthAwarePaginator extends Paginator
@@ -28,9 +23,6 @@ interface LengthAwarePaginator extends Paginator
 
 /**
  * @template TItem
- *
- * @mixin \Illuminate\Support\Collection<array-key, TItem>
- * @mixin \Illuminate\Pagination\CursorPaginator<TItem>
  */
 interface CursorPaginator
 {

--- a/stubs/Contracts/Pagination.stub
+++ b/stubs/Contracts/Pagination.stub
@@ -3,22 +3,39 @@
 namespace Illuminate\Contracts\Pagination;
 
 /**
- * @mixin \Illuminate\Support\Collection
- * @mixin \Illuminate\Pagination\Paginator
+ * @template TItem
+ *
+ * @mixin \Illuminate\Support\Collection<array-key, TItem>
+ * @mixin \Illuminate\Pagination\Paginator<TItem>
  */
 interface Paginator
-{}
+{
+    /**
+     * @return array<TItem>
+     */
+    public function items(): array;
+}
 
 /**
- * @mixin \Illuminate\Support\Collection
- * @mixin \Illuminate\Pagination\LengthAwarePaginator
+ * @template TItem
+ *
+ * @mixin \Illuminate\Support\Collection<array-key, TItem>
+ * @mixin \Illuminate\Pagination\LengthAwarePaginator<TItem>
+ * @extends Paginator<TItem>
  */
 interface LengthAwarePaginator extends Paginator
 {}
 
 /**
- * @mixin \Illuminate\Support\Collection
- * @mixin \Illuminate\Pagination\CursorPaginator
+ * @template TItem
+ *
+ * @mixin \Illuminate\Support\Collection<array-key, TItem>
+ * @mixin \Illuminate\Pagination\CursorPaginator<TItem>
  */
-interface CursorPaginator extends Paginator
-{}
+interface CursorPaginator
+{
+    /**
+     * @return array<TItem>
+     */
+    public function items(): array;
+}

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -440,7 +440,7 @@ class Builder
      * @param  array<array-key, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Pagination\LengthAwarePaginator<TModelClass>
      *
      * @throws \InvalidArgumentException
      */
@@ -453,7 +453,7 @@ class Builder
      * @param  array<array-key, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\Paginator
+     * @return \Illuminate\Pagination\Paginator<TModelClass>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
 
@@ -463,8 +463,8 @@ class Builder
      * @param  int|null  $perPage
      * @param  array<array-key, mixed>  $columns
      * @param  string  $cursorName
-     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
-     * @return \Illuminate\Pagination\CursorPaginator
+     * @param  \Illuminate\Pagination\Cursor<TModelClass>|string|null  $cursor
+     * @return \Illuminate\Pagination\CursorPaginator<TModelClass>
      */
      public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);
 

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -463,7 +463,7 @@ class Builder
      * @param  int|null  $perPage
      * @param  array<array-key, mixed>  $columns
      * @param  string  $cursorName
-     * @param  \Illuminate\Pagination\Cursor<TModelClass>|string|null  $cursor
+     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
      * @return \Illuminate\Pagination\CursorPaginator<TModelClass>
      */
      public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);

--- a/stubs/HasManyThrough.stub
+++ b/stubs/HasManyThrough.stub
@@ -14,4 +14,37 @@ class HasManyThrough extends Relation
      * @phpstan-return \Traversable<int, TRelatedModel>
      */
     public function getResults();
+
+    /**
+     * Get a paginator for the "select" statement.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\LengthAwarePaginator<TRelatedModel>
+     */
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\Paginator<TRelatedModel>
+     */
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null);
+
+    /**
+     * Paginate the given query into a cursor paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array<int, mixed>  $columns
+     * @param  string  $cursorName
+     * @param  string|null  $cursor
+     * @return \Illuminate\Pagination\CursorPaginator<TRelatedModel>
+     */
+    public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);
 }

--- a/stubs/Pagination.stub
+++ b/stubs/Pagination.stub
@@ -28,8 +28,8 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
 /**
  * @template TValue
  *
- * @implements \ArrayAccess<mixed, TValue>
- * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \ArrayAccess<array-key, TValue>
+ * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
  *
  * @extends AbstractPaginator<TValue>
@@ -40,8 +40,8 @@ class Paginator extends AbstractPaginator implements \Illuminate\Contracts\Suppo
 /**
  * @template TValue
  *
- * @implements \ArrayAccess<mixed, TValue>
- * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \ArrayAccess<array-key, TValue>
+ * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
  *
  * @extends AbstractPaginator<TValue>
@@ -75,8 +75,8 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
 /**
  * @template TValue
  *
- * @implements \ArrayAccess<mixed, TValue>
- * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \ArrayAccess<array-key, TValue>
+ * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
  *
  * @extends AbstractCursorPaginator<TValue>

--- a/stubs/Pagination.stub
+++ b/stubs/Pagination.stub
@@ -23,6 +23,20 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
      * @return \ArrayIterator<array-key, TValue>
      */
     public function getIterator(): \Traversable;
+
+    public function offsetExists(mixed $offset): bool;
+
+    /**
+     * @return TValue|null
+     */
+    public function offsetGet(mixed $offset): mixed;
+
+    /**
+     * @param TValue $value
+     */
+    public function offsetSet(mixed $offset, $value): void;
+
+    public function offsetUnset(mixed $offset): void;
 }
 
 /**
@@ -72,6 +86,20 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
      * @return \ArrayIterator<array-key, TValue>
      */
     public function getIterator(): \Traversable;
+
+    public function offsetExists(mixed $offset): bool;
+
+    /**
+     * @return TValue|null
+     */
+    public function offsetGet(mixed $offset): mixed;
+
+    /**
+     * @param TValue $value
+     */
+    public function offsetSet(mixed $offset, $value): void;
+
+    public function offsetUnset(mixed $offset): void;
 }
 
 /**

--- a/stubs/Pagination.stub
+++ b/stubs/Pagination.stub
@@ -85,9 +85,7 @@ class CursorPaginator extends AbstractCursorPaginator implements \Illuminate\Con
 {}
 
 /**
- * @template TValue
- *
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<array-key, mixed>
  */
 class Cursor implements \Illuminate\Contracts\Support\Arrayable
 {}

--- a/stubs/Pagination.stub
+++ b/stubs/Pagination.stub
@@ -31,6 +31,7 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
  * @implements \ArrayAccess<array-key, TValue>
  * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ * @implements \Illuminate\Contracts\Pagination\Paginator<TValue>
  *
  * @extends AbstractPaginator<TValue>
  */
@@ -43,6 +44,7 @@ class Paginator extends AbstractPaginator implements \Illuminate\Contracts\Suppo
  * @implements \ArrayAccess<array-key, TValue>
  * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ * @implements \Illuminate\Contracts\Pagination\LengthAwarePaginator<TValue>
  *
  * @extends AbstractPaginator<TValue>
  */
@@ -78,6 +80,7 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
  * @implements \ArrayAccess<array-key, TValue>
  * @implements \IteratorAggregate<array-key, TValue>
  * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ * @implements \Illuminate\Contracts\Pagination\CursorPaginator<TValue>
  *
  * @extends AbstractCursorPaginator<TValue>
  */

--- a/stubs/Pagination.stub
+++ b/stubs/Pagination.stub
@@ -3,37 +3,91 @@
 namespace Illuminate\Pagination;
 
 /**
- * @mixin \Illuminate\Support\Collection
+ * @template TValue
+ *
+ * @mixin \Illuminate\Support\Collection<mixed, TValue>
  */
 abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlable
-{}
+{
+    /**
+     * @return array<TValue>
+     */
+    public function items(): array;
+
+    /**
+     * @return \Illuminate\Support\Collection<array-key, TValue>
+     */
+    public function getCollection(): \Illuminate\Support\Collection;
+
+    /**
+     * @return \ArrayIterator<array-key, TValue>
+     */
+    public function getIterator(): \Traversable;
+}
 
 /**
- * @implements \ArrayAccess<mixed, mixed>
- * @implements \IteratorAggregate<mixed, mixed>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, mixed>
+ * @template TValue
+ *
+ * @implements \ArrayAccess<mixed, TValue>
+ * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ *
+ * @extends AbstractPaginator<TValue>
  */
 class Paginator extends AbstractPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\Paginator
 {}
 
 /**
- * @implements \ArrayAccess<mixed, mixed>
- * @implements \IteratorAggregate<mixed, mixed>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, mixed>
+ * @template TValue
+ *
+ * @implements \ArrayAccess<mixed, TValue>
+ * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ *
+ * @extends AbstractPaginator<TValue>
  */
 class LengthAwarePaginator extends AbstractPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\LengthAwarePaginator
 {}
 
 /**
- * @implements \ArrayAccess<mixed, mixed>
- * @implements \IteratorAggregate<mixed, mixed>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, mixed>
+ * @template TValue
+ *
+ * @mixin \Illuminate\Support\Collection<mixed, TValue>
  */
-class CursorPaginator extends AbstractPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\CursorPaginator
+abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\Htmlable
+{
+    /**
+     * @return array<TValue>
+     */
+    public function items(): array;
+
+    /**
+     * @return \Illuminate\Support\Collection<array-key, TValue>
+     */
+    public function getCollection(): \Illuminate\Support\Collection;
+
+    /**
+     * @return \ArrayIterator<array-key, TValue>
+     */
+    public function getIterator(): \Traversable;
+}
+
+/**
+ * @template TValue
+ *
+ * @implements \ArrayAccess<mixed, TValue>
+ * @implements \IteratorAggregate<mixed, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
+ *
+ * @extends AbstractCursorPaginator<TValue>
+ */
+class CursorPaginator extends AbstractCursorPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\CursorPaginator
 {}
 
 /**
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, mixed>
+ * @template TValue
+ *
+ * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
  */
 class Cursor implements \Illuminate\Contracts\Support\Arrayable
 {}

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Features\Methods;
 
-use App\Account;
 use App\Post;
 use App\PostBuilder;
 use App\User;

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Features\Methods;
 
+use App\Account;
 use App\Post;
 use App\PostBuilder;
 use App\User;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use function PHPStan\Testing\assertType;
 
@@ -344,5 +346,21 @@ class Builder
     public function testQueryBuilderOnEloquentBuilderWithBaseModel(EloquentBuilder $query): void
     {
         assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query->select());
+    }
+
+    /**
+     * @phpstan-return LengthAwarePaginator<User>
+     */
+    public function testPaginate()
+    {
+        return User::query()->paginate();
+    }
+
+    /**
+     * @phpstan-return array<User>
+     */
+    public function testPaginateItems()
+    {
+        return User::query()->paginate()->items();
     }
 }

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -9,7 +9,6 @@ use App\Group;
 use App\Post;
 use App\Role;
 use App\User;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -19,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Pagination\LengthAwarePaginator;
 use function PHPStan\Testing\assertType;
 
 class Relations
@@ -86,6 +86,9 @@ class Relations
         return $user->accounts()->decrement('id', 5);
     }
 
+    /**
+     * @return LengthAwarePaginator<Account>
+     */
     public function testPaginate(User $user): LengthAwarePaginator
     {
         return $user->accounts()->paginate(5);

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -7,6 +7,13 @@ namespace PaginatorExtension;
 use App\User;
 use function PHPStan\Testing\assertType;
 
-assertType('array', User::paginate()->all());
-assertType('array', User::simplePaginate()->all());
-assertType('array', User::cursorPaginate()->all());
+assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
+assertType('array<App\User>', User::paginate()->items());
+
+assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
+assertType('array<App\User>', User::simplePaginate()->items());
+
+assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
+assertType('array<App\User>', User::cursorPaginate()->items());
+
+assertType('ArrayIterator<mixed, App\User>', User::query()->paginate()->getIterator());

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -10,14 +10,17 @@ use function PHPStan\Testing\assertType;
 assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
 assertType('array<App\User>', User::paginate()->all());
 assertType('array<App\User>', User::paginate()->items());
+assertType('App\User', User::paginate()[0]);
 
 assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
 assertType('array<App\User>', User::simplePaginate()->all());
 assertType('array<App\User>', User::simplePaginate()->items());
+assertType('App\User', User::simplePaginate()[0]);
 
 assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
 assertType('array<App\User>', User::cursorPaginate()->all());
 assertType('array<App\User>', User::cursorPaginate()->items());
+assertType('App\User', User::cursorPaginate()[0]);
 
 assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());
 

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -8,12 +8,15 @@ use App\User;
 use function PHPStan\Testing\assertType;
 
 assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
+assertType('array<App\User>', User::paginate()->all());
 assertType('array<App\User>', User::paginate()->items());
 
 assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
+assertType('array<App\User>', User::simplePaginate()->all());
 assertType('array<App\User>', User::simplePaginate()->items());
 
 assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
+assertType('array<App\User>', User::cursorPaginate()->all());
 assertType('array<App\User>', User::cursorPaginate()->items());
 
 assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -16,4 +16,4 @@ assertType('array<App\User>', User::simplePaginate()->items());
 assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
 assertType('array<App\User>', User::cursorPaginate()->items());
 
-assertType('ArrayIterator<mixed, App\User>', User::query()->paginate()->getIterator());
+assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -17,3 +17,9 @@ assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPagina
 assertType('array<App\User>', User::cursorPaginate()->items());
 
 assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());
+
+// HasMany
+assertType('Illuminate\Pagination\LengthAwarePaginator<App\Account>', (new User())->accounts()->paginate());
+
+// BelongsToMany
+assertType('Illuminate\Pagination\LengthAwarePaginator<App\Post>', (new User())->posts()->paginate());

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -10,17 +10,17 @@ use function PHPStan\Testing\assertType;
 assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
 assertType('array<App\User>', User::paginate()->all());
 assertType('array<App\User>', User::paginate()->items());
-assertType('App\User', User::paginate()[0]);
+assertType('App\User|null', User::paginate()[0]);
 
 assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
 assertType('array<App\User>', User::simplePaginate()->all());
 assertType('array<App\User>', User::simplePaginate()->items());
-assertType('App\User', User::simplePaginate()[0]);
+assertType('App\User|null', User::simplePaginate()[0]);
 
 assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
 assertType('array<App\User>', User::cursorPaginate()->all());
 assertType('array<App\User>', User::cursorPaginate()->items());
-assertType('App\User', User::cursorPaginate()[0]);
+assertType('App\User|null', User::cursorPaginate()[0]);
 
 assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR adds support for generic paginators.

Before:

```php
$users = User::query()->paginate(); // LengthAwarePaginator
$users->items(); // array
```

After:

```php
$users = User::query()->paginate(); // LengthAwarePaginator<User>
$users->items(); // array<User>
```

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
