### PR TITLE
Added the ability to check for unnecessary collection calls on dynamic properties in NoUnnecessaryCollectionCallRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: updated return type of the Request::header method by @mad-briller
 * feat: Added stub for `optional()` helper and class by @mad-briller in https://github.com/nunomaduro/larastan/pull/1344
 * fix: abstract Manager class causing Larastan to crash by @mad-briller
+* feat: added the ability to check for unnecessary collection calls on dynamic properties in NoUnnecessaryCollectionCallRule by @zlayaAvocado in https://github.com/nunomaduro/larastan/pull/1375
 
 ## [2.2.0] - 2022-08-31
 

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -156,12 +156,12 @@ class NoUnnecessaryCollectionCallRule implements Rule
         /** @var \PhpParser\Node\Identifier $name */
         $name = $node->name;
 
-        if (! $this->isCalledOnCollection($node->var, $scope)) {
+        $previousCall = $node->var;
+
+        if (! $this->isCalledOnCollection($previousCall, $scope)) {
             // Method was not called on a collection, so no errors.
             return [];
         }
-
-        $previousCall = $node->var;
 
         if (! $this->callIsQuery($previousCall, $scope)) {
             // Previous call wasn't on a Builder, so no errors.
@@ -280,6 +280,10 @@ class NoUnnecessaryCollectionCallRule implements Rule
      */
     protected function callIsQuery(Node\Expr $call, Scope $scope): bool
     {
+        if ($call instanceof Node\Expr\PropertyFetch) {
+            return $this->isCalledOnCollection($call, $scope);
+        }
+
         if ($call instanceof MethodCall) {
             $calledOn = $scope->getType($call->var);
 

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -103,6 +103,18 @@ class CorrectCollectionCalls
             ->pluck('id')
             ->avg();
     }
+
+    /** @phpstan-return mixed */
+    public function testRelationPropertyRiskyMethod()
+    {
+        return User::firstOrFail()->accounts->pluck('not_a_db_column');
+    }
+
+    /** @phpstan-return mixed */
+    public function testRelationPropertyNonRiskyMethod()
+    {
+        return User::firstOrFail()->accounts->shift();
+    }
 }
 
 class Foo extends Model

--- a/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/Data/UnnecessaryCollectionCallsEloquent.php
@@ -102,4 +102,9 @@ class UnnecessaryCollectionCallsEloquent
     {
         return User::pluck('id')->sum();
     }
+
+    public function relationWithRiskyMethod(): int
+    {
+        return User::firstOrFail()->accounts->count();
+    }
 }

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -35,6 +35,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RulesTest
             92 => 'Called \'modelKeys\' on Laravel collection, but could have been retrieved as a query.',
             97 => 'Called \'containsStrict\' on Laravel collection, but could have been retrieved as a query.',
             103 => 'Called \'sum\' on Laravel collection, but could have been retrieved as a query.',
+            108 => 'Called \'count\' on Laravel collection, but could have been retrieved as a query.',
         ], $errors);
     }
 

--- a/tests/phpstan-tests.neon
+++ b/tests/phpstan-tests.neon
@@ -18,3 +18,18 @@ parameters:
             message: "#Called 'Model::make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.#"
             count: 1
             path: Features/Methods/ModelExtension.php
+
+        # Even though $model->relation->first() is not performant, these tests need to
+        # access model relations via property and call methods on the resulting collection.
+        -
+            message: "#Called 'where' on Laravel collection, but could have been retrieved as a query\\.#"
+            count: 1
+            path: Features/ReturnTypes/CustomEloquentCollectionTest.php
+        -
+            message: "#Called 'first' on Laravel collection, but could have been retrieved as a query\\.#"
+            count: 1
+            path: Features/Models/Relations.php
+        -
+            message: "#Called 'first' on Laravel collection, but could have been retrieved as a query\\.#"
+            count: 1
+            path: Features/Properties/ModelPropertyExtension.php


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Documented user facing changes
- [X] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Added the ability to check for unnecessary collection calls on dynamic properties in `NoUnnecessaryCollectionCallRule`. E.g. in the following faulty example, instead of querying for all accounts for the user first, we build a query and execute it with the `count`

**Bad:**
`User::firstOrFail()->accounts->count();`

**Good:**
`User::firstOrFail()->accounts()->count();`

Also see example in [this article](https://codeburst.io/how-to-use-laravels-eloquent-efficiently-d46f5c392ca8) why it's helpful and why it can cause performance issues.

>Don’t use a collection to count the number of related entries.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
