### PR TITLE
Add @mixin Query\Builder to EloquentBuilder.stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: add @mixin Query\Builder to EloquentBuilder.stub by @davidjr82 in https://github.com/nunomaduro/larastan/pull/1379
+
 ## [2.2.0] - 2022-08-31
 
 ### Added

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
+ *
+ * @mixin \Illuminate\Database\Query\Builder
  */
 class Builder
 {


### PR DESCRIPTION
- [ ] Added or updated tests (in progress, failing tests at the moment)
- [x] Documented user facing changes (not needed)
- [x] Updated CHANGELOG.md

**Changes**

Resolves #1346 as @xwillq is proposing in the issues comments.

As larastan is reading docblocks from stubs instead from source code, we need to add the mixins from Query\Builder in the Eloquent\Builder stub.

Reference: [Laravel 9 docblock source code of Eloquent\Builder](https://github.com/laravel/framework/blob/278c6d7fd04be005c1175a7eaea868976177600c/src/Illuminate/Database/Eloquent/Builder.php#L23)

**Breaking changes**

No breaking changes, only functionality is added