### PR TITLE
Added trans-string type which must be a defined translation key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
+- feat: Added `trans-string` type which checks if a `string` is a valid translation key by @mad-briller https://github.com/nunomaduro/larastan/pull/1383
 
 ## [2.2.0] - 2022-08-31
 

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -22,13 +22,13 @@ public function renderView(string $view): View
     return view($view);
 }
 ```
-Now, whenever you call `renderView`, Larastan will try to check whether 
+Now, whenever you call `renderView`, Larastan will try to check whether
 the given string is a valid blade view.
 
 
 If the string is not an existing blade view, the following error will be displayed by Larastan.
 ```
-Parameter #1 $view of method TestClass::renderView() expects view-string, string given.  
+Parameter #1 $view of method TestClass::renderView() expects view-string, string given.
 ```
 
 ## model-property
@@ -38,3 +38,25 @@ All of the Laravel core methods have this type thanks to the stubs. So whenever 
 
 The actual check is done by the `ModelPropertyRule`. You can read the details [here](rules.md#ModelPropertyRule).
 
+
+## trans-string
+
+`trans-string` is a subset of the `string` type. Any `string` that passes the `trans()->has($string)` test
+is also a valid `trans-string`.
+
+**Example:**
+
+```php
+/**
+ * @phpstan-param trans-string $key
+ * @param string $key
+ * @return mixed
+ */
+public function getTrans(string $key): mixed
+{
+    return trans($key);
+}
+```
+
+Now, whenever `getTrans` is called, Larastan will check whether
+the given string is a defined [translation](https://laravel.com/docs/master/localization#defining-translation-strings) key.

--- a/extension.neon
+++ b/extension.neon
@@ -359,6 +359,11 @@ services:
             - phpstan.phpDoc.typeNodeResolverExtension
 
     -
+        class: NunoMaduro\Larastan\Types\TransStringTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
         class: NunoMaduro\Larastan\Rules\OctaneCompatibilityRule
 
     -

--- a/src/Types/TransStringType.php
+++ b/src/Types/TransStringType.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * The custom 'trans-string' type class. It's a subset of the string type. Every string that passes the
+ * trans()->exists($string) test is a valid trans-string type.
+ */
+class TransStringType extends StringType
+{
+    public function describe(\PHPStan\Type\VerbosityLevel $level): string
+    {
+        return 'trans-string';
+    }
+
+    public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+    {
+        if ($type instanceof CompoundType) {
+            return $type->isAcceptedBy($this, $strictTypes);
+        }
+
+        if ($type instanceof ConstantStringType) {
+            /** @var \Illuminate\Translation\Translator $translator */
+            $translator = trans();
+
+            return TrinaryLogic::createFromBoolean($translator->has($type->getValue()));
+        }
+
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof StringType) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    public function isSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof ConstantStringType) {
+            /** @var \Illuminate\Translation\Translator $translator */
+            $translator = trans();
+
+            return TrinaryLogic::createFromBoolean($translator->has($type->getValue()));
+        }
+
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type instanceof parent) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    /**
+     * @param  mixed[]  $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self();
+    }
+}

--- a/src/Types/TransStringTypeNodeResolverExtension.php
+++ b/src/Types/TransStringTypeNodeResolverExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Type;
+
+/**
+ * Ensures a 'trans-string' type in PHPDoc is recognised to be of type TransStringType.
+ */
+class TransStringTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->__toString() === 'trans-string') {
+            return new TransStringType();
+        }
+
+        return null;
+    }
+}

--- a/stubs/Contracts/Translation.stub
+++ b/stubs/Contracts/Translation.stub
@@ -2,4 +2,25 @@
 
 namespace Illuminate\Contracts\Translation;
 
-interface Translator {}
+interface Translator {
+    /**
+     * Get the translation for a given key.
+     *
+     * @param  trans-string  $key
+     * @param  array<string, scalar>  $replace
+     * @param  string|null  $locale
+     * @return mixed
+     */
+    public function get($key, array $replace = [], $locale = null);
+
+    /**
+     * Get a translation according to an integer value.
+     *
+     * @param  trans-string  $key
+     * @param  \Countable|int|array<array-key, mixed>  $number
+     * @param  array<string, scalar>  $replace
+     * @param  string|null  $locale
+     * @return string
+     */
+    public function choice($key, $number, array $replace = [], $locale = null);
+}

--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -135,7 +135,7 @@ function view($view = null, $data = [], $mergeData = [])
 /**
  * Translate the given message.
  *
- * @param  string|null  $key
+ * @param  trans-string|null  $key
  * @param  array<string, scalar>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : mixed)
@@ -147,7 +147,7 @@ function trans($key = null, $replace = [], $locale = null)
  /**
  * Translate the given message.
  *
- * @param  string|null  $key
+ * @param  trans-string|null  $key
  * @param  array<string, scalar>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? null : mixed)

--- a/tests/Application/lang/en/trans.php
+++ b/tests/Application/lang/en/trans.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'language-key' => 'language-value',
+];

--- a/tests/Features/ReturnTypes/Helpers/ValidatorExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/ValidatorExtension.php
@@ -33,7 +33,7 @@ class ValidatorExtension
         ]);
 
         $validationAttributeNames = [
-            'message' => trans('g.label.message'),
+            'message' => trans('trans.language-key'),
         ];
 
         $validator->setAttributeNames($validationAttributeNames);

--- a/tests/Features/Types/TransStringType.php
+++ b/tests/Features/Types/TransStringType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Types;
+
+class TransStringType
+{
+    public function testTransString(): void
+    {
+        $this->doSomethingWithATransKey('trans.language-key');
+    }
+
+    /**
+     * @phpstan-param trans-string $key
+     *
+     * @param  string  $key
+     * @return void
+     */
+    private function doSomethingWithATransKey(string $key): void
+    {
+    }
+}

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -23,6 +23,7 @@ class FeaturesTest extends BaseTestCase
         File::copyDirectory(__DIR__.'/Application/database/schema', $this->getBasePath().'/database/schema');
         File::copyDirectory(__DIR__.'/Application/config', $this->getBasePath().'/config');
         File::copyDirectory(__DIR__.'/Application/resources', $this->getBasePath().'/resources');
+        File::copyDirectory(__DIR__.'/Application/lang', $this->getBasePath().'/lang');
 
         $this->configPath = __DIR__.'/phpstan-tests.neon';
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds a new `trans-string` type that is similar to `view-string` but for translation keys.

Not sold on the `trans-string` name but tried to keep convention with `view-string`, perhaps `trans-key` would be a better name? open to suggestions.