### PR TITLE
feat:dont use ExtendedMethodReflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^9",
         "mockery/mockery": "^1.4.4",
         "phpmyadmin/sql-parser": "^5.5",
-        "phpstan/phpstan": "^1.9.x-dev"
+        "phpstan/phpstan": "^1.8.7"
     },
     "require-dev": {
         "nikic/php-parser": "^4.13.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^9",
         "mockery/mockery": "^1.4.4",
         "phpmyadmin/sql-parser": "^5.5",
-        "phpstan/phpstan": "^1.8.3"
+        "phpstan/phpstan": "^1.9.x-dev"
     },
     "require-dev": {
         "nikic/php-parser": "^4.13.2",

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -20,7 +20,6 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 
@@ -87,10 +86,6 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
         if ($modelType instanceof TemplateObjectType) {
             $modelType = $modelType->getBound();
-
-            if ($modelType->equals(new ObjectType(Model::class))) {
-                return null;
-            }
         }
 
         if ($modelType instanceof TypeWithClassName) {

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -202,7 +202,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             });
 
             return new EloquentBuilderMethodReflection(
-                $methodName, $classReflection,
+                $methodName, $builderReflection,
                 $reflection,
                 $parametersAcceptor->getParameters(),
                 $returnType,

--- a/src/Reflection/EloquentBuilderMethodReflection.php
+++ b/src/Reflection/EloquentBuilderMethodReflection.php
@@ -7,7 +7,6 @@ namespace NunoMaduro\Larastan\Reflection;
 use Illuminate\Database\Eloquent\Builder;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
@@ -16,8 +15,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
-/** @phpstan-ignore-next-line */
-final class EloquentBuilderMethodReflection implements ExtendedMethodReflection
+final class EloquentBuilderMethodReflection implements MethodReflection
 {
     /**
      * @var string

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -61,7 +61,7 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
 
         $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass');
 
-        if ($model === null || ! $model instanceof ObjectType) {
+        if (! $model instanceof ObjectType) {
             return false;
         }
 

--- a/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
+++ b/src/Rules/ModelProperties/ModelPropertiesRuleHelper.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -34,7 +35,7 @@ class ModelPropertiesRuleHelper
      * @param  ClassReflection|null  $modelReflection
      * @return string[]
      *
-     * @throws \PHPStan\ShouldNotHappenException
+     * @throws ShouldNotHappenException
      */
     public function check(MethodReflection $methodReflection, Scope $scope, array $args, ?ClassReflection $modelReflection = null): array
     {

--- a/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
+++ b/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
@@ -82,6 +82,10 @@ class ModelPropertyStaticCallRule implements Rule
 
                 $currentClassReflection = $scope->getClassReflection();
 
+                if ($currentClassReflection === null) {
+                    return [];
+                }
+
                 $parentClass = $currentClassReflection->getParentClass();
 
                 if ($parentClass === null) {
@@ -125,6 +129,10 @@ class ModelPropertyStaticCallRule implements Rule
             }
 
             $modelReflection = $this->reflectionProvider->getClass($modelClassName);
+        }
+
+        if ($modelReflection === null) {
+            return [];
         }
 
         if (! $modelReflection->isSubclassOf(Model::class)) {

--- a/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
+++ b/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
@@ -50,7 +50,7 @@ class ModelPropertyStaticCallRule implements Rule
      * @param  Scope  $scope
      * @return string[]
      *
-     * @throws \PHPStan\ShouldNotHappenException|\PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -82,10 +82,6 @@ class ModelPropertyStaticCallRule implements Rule
                 }
 
                 $currentClassReflection = $scope->getClassReflection();
-
-                if ($currentClassReflection === null) {
-                    return [];
-                }
 
                 $parentClass = $currentClassReflection->getParentClass();
 
@@ -132,10 +128,6 @@ class ModelPropertyStaticCallRule implements Rule
             $modelReflection = $this->reflectionProvider->getClass($modelClassName);
         }
 
-        if ($modelReflection === null) {
-            return [];
-        }
-
         if (! $modelReflection->isSubclassOf(Model::class)) {
             return [];
         }
@@ -145,10 +137,6 @@ class ModelPropertyStaticCallRule implements Rule
         }
 
         $methodReflection = $modelReflection->getMethod($methodName, $scope);
-
-        if ($methodReflection instanceof EloquentBuilderMethodReflection) {
-            $methodReflection = $methodReflection->getOriginalMethodReflection();
-        }
 
         $className = $methodReflection->getDeclaringClass()->getName();
 

--- a/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
+++ b/src/Rules/ModelProperties/ModelPropertyStaticCallRule.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
-use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;

--- a/tests/Features/Methods/Builder.php
+++ b/tests/Features/Methods/Builder.php
@@ -335,4 +335,14 @@ class Builder
             assertType('App\PostBuilder<App\Post>', $query);
         });
     }
+
+    /**
+     * @template TModelClass of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  EloquentBuilder<TModelClass>  $query
+     */
+    public function testQueryBuilderOnEloquentBuilderWithBaseModel(EloquentBuilder $query): void
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query->select());
+    }
 }

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -24,6 +24,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/model-factories.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/environment-helper.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/view.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1346.php');
     }
 
     /**

--- a/tests/Type/data/bug-1346.php
+++ b/tests/Type/data/bug-1346.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug1346;
+
+use Illuminate\Database\Eloquent\Builder;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
+class DailyQuery
+{
+    /**
+     * @var Builder<TModel>
+     */
+    private Builder $query;
+
+    public function daily()
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $this->query->select());
+    }
+}


### PR DESCRIPTION
This PR fixes compatibility issues with PHPStan 1.9.x.

1.9.x is needed because [this](https://github.com/phpstan/phpstan-src/commit/c052aace4efa157d9594f13fb748965cbfc43be2) commit is needed here.

Closes #1386 
Closes #1289