### PR TITLE
feat: use `Orchestra\Testbench\Foundation\Application` and allow custom `laravel` path based on `testbench.yaml`

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -38,7 +38,6 @@ final class ApplicationResolver
             $app = Testbench::create(options: ['enables_package_discoveries' => true]);
         }
 
-
         $vendorDir = self::getVendorDir() ?? getcwd().DIRECTORY_SEPARATOR.'vendor';
         $composerConfigPath = dirname($vendorDir).DIRECTORY_SEPARATOR.'composer.json';
 

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\PackageManifest;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use Orchestra\Testbench\Foundation\Config;
-use Illuminate\Foundation\PackageManifest as IlluminatePackageManifest;
 
 /**
  * @internal
@@ -24,7 +24,7 @@ final class ApplicationResolver
     public static function resolve(): Application
     {
         $resolvingCallback = function ($app) {
-            $packageManifest = $app->make(IlluminatePackageManifest::class);
+            $packageManifest = $app->make(PackageManifest::class);
 
             if (! file_exists($packageManifest->manifestPath)) {
                 $packageManifest->build();

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\PackageManifest;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use Orchestra\Testbench\Foundation\Config;
-use Illuminate\Foundation\PackageManifest as IlluminatePackageManifest;
 
 /**
  * @internal
@@ -28,7 +28,7 @@ final class ApplicationResolver
         }
 
         $resolvingCallback = function ($app) {
-            $packageManifest = $app->make(IlluminatePackageManifest::class);
+            $packageManifest = $app->make(PackageManifest::class);
 
             if (! file_exists($packageManifest->manifestPath)) {
                 $packageManifest->build();

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -4,23 +4,16 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan;
 
-use Composer\Autoload\ClassLoader;
-use Composer\ClassMapGenerator\ClassMapGenerator;
-use const DIRECTORY_SEPARATOR;
 use Illuminate\Contracts\Foundation\Application;
-use function in_array;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use Orchestra\Testbench\Foundation\Config;
-use ReflectionClass;
+use Illuminate\Foundation\PackageManifest as IlluminatePackageManifest;
 
 /**
  * @internal
  */
 final class ApplicationResolver
 {
-    /** @var mixed */
-    public static $composer;
-
     /**
      * Creates an application and registers service providers found.
      *
@@ -30,127 +23,29 @@ final class ApplicationResolver
      */
     public static function resolve(): Application
     {
+        $resolvingCallback = function ($app) {
+            $packageManifest = $app->make(IlluminatePackageManifest::class);
+
+            if (! file_exists($packageManifest->manifestPath)) {
+                $packageManifest->build();
+            }
+        };
+
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml(getcwd());
 
-            $app = Testbench::create(basePath: $config['laravel'], options: ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]);
+            $app = Testbench::create(
+                basePath: $config['laravel'],
+                resolvingCallback: $resolvingCallback,
+                options: ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]
+            );
         } else {
-            $app = Testbench::create(options: ['enables_package_discoveries' => true]);
-        }
-
-        $vendorDir = self::getVendorDir() ?? getcwd().DIRECTORY_SEPARATOR.'vendor';
-        $composerConfigPath = dirname($vendorDir).DIRECTORY_SEPARATOR.'composer.json';
-
-        if (file_exists($composerConfigPath)) {
-            self::$composer = json_decode((string) file_get_contents($composerConfigPath), true);
-            $namespace = (string) key(self::$composer['autoload']['psr-4']);
-            $serviceProviders = array_values(array_filter(self::getProjectClasses($namespace, $vendorDir), static function ($class) use (
-                $namespace
-            ) {
-                /** @var class-string $class */
-                return strpos($class, $namespace) === 0 && self::isServiceProvider($class);
-            }));
-
-            foreach ($serviceProviders as $serviceProvider) {
-                $app->register($serviceProvider);
-            }
+            $app = Testbench::create(
+                resolvingCallback: $resolvingCallback,
+                options: ['enables_package_discoveries' => true]
+            );
         }
 
         return $app;
-    }
-
-    protected static function getVendorDir(): ?string
-    {
-        $reflector = new ReflectionClass(ClassLoader::class);
-        $classLoaderPath = $reflector->getFileName();
-        if ($classLoaderPath === false) {
-            return null;
-        }
-
-        $vendorDir = dirname($classLoaderPath, 2);
-        if (! is_dir($vendorDir)) {
-            return null;
-        }
-
-        return $vendorDir;
-    }
-
-    /**
-     * @phpstan-param class-string $class
-     *
-     * @return bool
-     *
-     * @throws \ReflectionException
-     */
-    private static function isServiceProvider(string $class): bool
-    {
-        $classParents = class_parents($class);
-
-        if (! $classParents) {
-            return false;
-        }
-
-        return in_array(\Illuminate\Support\ServiceProvider::class, $classParents, true)
-            && ! (new \ReflectionClass($class))->isAbstract();
-    }
-
-    /**
-     * @param  string  $namespace
-     * @return string[]
-     *
-     * @throws \ReflectionException
-     */
-    private static function getProjectClasses(string $namespace, string $vendorDir): array
-    {
-        $projectDirs = self::getProjectSearchDirs($namespace, $vendorDir);
-        /** @var array<string, string> $maps */
-        $maps = [];
-        // Use composer's ClassMapGenerator to pull the class list out of each project search directory
-        foreach ($projectDirs as $dir) {
-            $maps = array_merge($maps, ClassMapGenerator::createMap($dir));
-        }
-
-        // Create array of dev classes from Composer configuration.
-        $devClasses = [];
-        $autoloadDev = self::$composer['autoload-dev'] ?? [];
-        $autoloadDevPsr4 = $autoloadDev['psr-4'] ?? [];
-        foreach ($autoloadDevPsr4 as $paths) {
-            $paths = is_array($paths) ? $paths : [$paths];
-
-            foreach ($paths as $path) {
-                $devClasses = array_merge($devClasses, array_keys(ClassMapGenerator::createMap($path)));
-            }
-        }
-
-        // now class list of maps are assembled, use class_exists calls to explicitly autoload them,
-        // while not running them
-        /**
-         * @var string $class
-         * @var string $file
-         */
-        foreach ($maps as $class => $file) {
-            if (! in_array($class, $devClasses, true)) {
-                class_exists($class, true);
-            }
-        }
-
-        return get_declared_classes();
-    }
-
-    /**
-     * @param  string  $namespace
-     * @param  string  $vendorDir
-     * @return string[]
-     *
-     * @throws \ReflectionException
-     */
-    private static function getProjectSearchDirs(string $namespace, string $vendorDir): array
-    {
-        $composerDir = $vendorDir.DIRECTORY_SEPARATOR.'composer';
-
-        $file = $composerDir.DIRECTORY_SEPARATOR.'autoload_psr4.php';
-        $raw = include $file;
-
-        return $raw[$namespace];
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -38,7 +38,7 @@ final class ApplicationResolver
 
         $appBasePath ??= Testbench::applicationBasePath();
 
-        $app = Testbench::create($appBasePath, null, ['enables_package_discoveries' => true]);
+        $app = Testbench::create(basePath: $appBasePath, options: ['enables_package_discoveries' => true]);
 
         $vendorDir = self::getVendorDir() ?? getcwd().DIRECTORY_SEPARATOR.'vendor';
         $composerConfigPath = dirname($vendorDir).DIRECTORY_SEPARATOR.'composer.json';

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -33,12 +33,11 @@ final class ApplicationResolver
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml(getcwd());
 
-            $appBasePath = $config['laravel'];
+            $app = Testbench::create(basePath: $config['laravel'], options: ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]);
+        } else {
+            $app = Testbench::create(options: ['enables_package_discoveries' => true]);
         }
 
-        $appBasePath ??= Testbench::applicationBasePath();
-
-        $app = Testbench::create(basePath: $appBasePath, options: ['enables_package_discoveries' => true]);
 
         $vendorDir = self::getVendorDir() ?? getcwd().DIRECTORY_SEPARATOR.'vendor';
         $composerConfigPath = dirname($vendorDir).DIRECTORY_SEPARATOR.'composer.json';

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -31,8 +31,10 @@ final class ApplicationResolver
     public static function resolve(): Application
     {
         if (file_exists(getcwd().'/testbench.yaml')) {
-            $appBasePath = transform(Yaml::parseFile(getcwd().'/testbench.yaml'), function ($config) {
-                return $config['laravel'];
+            $config = Yaml::parseFile(getcwd().'/testbench.yaml');
+
+            $appBasePath = transform($config['laravel'], function ($basePath) {
+                return str_replace('./', getcwd().'/', $basePath);
             });
         }
 

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -40,7 +40,7 @@ final class ApplicationResolver
                 options: ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]
             );
         }
-            
+
         return Testbench::create(
             resolvingCallback: $resolvingCallback,
             options: ['enables_package_discoveries' => true]

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Foundation\PackageManifest;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use Orchestra\Testbench\Foundation\Config;
+use Illuminate\Foundation\PackageManifest as IlluminatePackageManifest;
 
 /**
  * @internal
@@ -23,8 +23,12 @@ final class ApplicationResolver
      */
     public static function resolve(): Application
     {
+        if (! defined('TESTBENCH_WORKING_PATH')) {
+            define('TESTBENCH_WORKING_PATH', $workingPath = getcwd());
+        }
+
         $resolvingCallback = function ($app) {
-            $packageManifest = $app->make(PackageManifest::class);
+            $packageManifest = $app->make(IlluminatePackageManifest::class);
 
             if (! file_exists($packageManifest->manifestPath)) {
                 $packageManifest->build();
@@ -32,7 +36,7 @@ final class ApplicationResolver
         };
 
         if (class_exists(Config::class)) {
-            $config = Config::loadFromYaml(getcwd());
+            $config = Config::loadFromYaml($workingPath);
 
             return Testbench::create(
                 basePath: $config['laravel'],

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -34,18 +34,16 @@ final class ApplicationResolver
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml(getcwd());
 
-            $app = Testbench::create(
+            return Testbench::create(
                 basePath: $config['laravel'],
                 resolvingCallback: $resolvingCallback,
                 options: ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]
             );
-        } else {
-            $app = Testbench::create(
-                resolvingCallback: $resolvingCallback,
-                options: ['enables_package_discoveries' => true]
-            );
         }
-
-        return $app;
+            
+        return Testbench::create(
+            resolvingCallback: $resolvingCallback,
+            options: ['enables_package_discoveries' => true]
+        );
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -10,8 +10,8 @@ use const DIRECTORY_SEPARATOR;
 use Illuminate\Contracts\Foundation\Application;
 use function in_array;
 use Orchestra\Testbench\Foundation\Application as Testbench;
+use Orchestra\Testbench\Foundation\Config;
 use ReflectionClass;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * @internal
@@ -30,12 +30,10 @@ final class ApplicationResolver
      */
     public static function resolve(): Application
     {
-        if (file_exists(getcwd().'/testbench.yaml')) {
-            $config = Yaml::parseFile(getcwd().'/testbench.yaml');
+        if (class_exists(Config::class)) {
+            $config = Config::loadFromYaml(getcwd());
 
-            $appBasePath = transform($config['laravel'], function ($basePath) {
-                return str_replace('./', getcwd().'/', $basePath);
-            });
+            $appBasePath = $config['laravel'];
         }
 
         $appBasePath ??= Testbench::applicationBasePath();
@@ -77,17 +75,6 @@ final class ApplicationResolver
         }
 
         return $vendorDir;
-    }
-
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        // ..
     }
 
     /**


### PR DESCRIPTION
- ~~Added or updated tests~~
- ~~Documented user facing changes~~
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Allow developers to utilize custom Laravel stub via `testbench.yaml` if needed.

As an example, `laravel/nova` uses `laravel/nova-dusk-suite` as it's application stub and `laravel/nova` does have `testbench.yaml` with following:

```yaml
laravel: ./vendor/laravel/nova-dusk-suite
```

In tests and using Testbench Commander, everything points to `vendor/laravel/nova-dusk-suite` but Larastan still uses `vendor/orchestra/testbench-core/laravel` as the application stub. This fix that.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
None, all functionally provided from `orchestra/testbench`