### PR TITLE
feat: refined return type of Request::header method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
+- feat: updated return type of the Request::header method by @mad-briller
 
 ## [2.2.0] - 2022-08-31
 

--- a/stubs/Http/Request.stub
+++ b/stubs/Http/Request.stub
@@ -2,4 +2,18 @@
 
 namespace Illuminate\Http;
 
-class Request {}
+class Request {
+
+    /**
+     * Retrieve a header from the request.
+     *
+     * @template TDefault of string|array<string, string>|null
+     *
+     * @param  string|null  $key
+     * @param  TDefault $default
+     *
+     * @return ($key is null ? array<string, string> : string|TDefault)
+     */
+    public function header($key = null, $default = null)
+    {}
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -25,6 +25,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/environment-helper.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/view.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1346.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/request-header.php');
     }
 
     /**

--- a/tests/Type/data/request-header.php
+++ b/tests/Type/data/request-header.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestHeader;
+
+use function PHPStan\Testing\assertType;
+
+/** @var \Illuminate\Http\Request $request */
+assertType('array<string, string>', $request->header());
+assertType('string|null', $request->header('key'));
+assertType('string', $request->header('key', 'default'));


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Refines return type of the `\Illuminate\Http\Request::header` method.
