### PR TITLE
Delete `bootstrap/cache/packages.php` on vendor symlink.

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -31,6 +31,10 @@ final class ApplicationResolver
         if (
             "$laravelVendorPath/autoload.php" !== "$vendorDir/autoload.php"
         ) {
+            if ($filesystem->exists($laravel->basePath('bootstrap/cache/packages.php'))) {
+                $filesystem->delete($laravel->basePath('bootstrap/cache/packages.php'));
+            }
+
             $filesystem->delete($laravelVendorPath);
             $filesystem->link($vendorDir, $laravelVendorPath);
         }
@@ -62,7 +66,9 @@ final class ApplicationResolver
         $resolvingCallback = function ($app) {
             $packageManifest = $app->make(PackageManifest::class);
 
-            $packageManifest->build();
+            if (! file_exists($packageManifest->manifestPath)) {
+                $packageManifest->build();
+            }
         };
 
         if (class_exists(Config::class)) {


### PR DESCRIPTION
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Match changes to Testbench Core v7.10.1, this would avoid running `$packageManifest->build();` unless vendor requires re-running via `$filesystem->link()` 

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
