### PR TITLE
fix: don't attempt to discover any packages during symlink.

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -74,7 +74,7 @@ final class ApplicationResolver
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml($workingPath);
 
-            static::createSymlinkToVendorPath(Testbench::create($config['laravel']), $vendorDir, ['extra' => ['dont-discover' => ['*']]]);
+            static::createSymlinkToVendorPath(Testbench::create($config['laravel'], null,  ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
 
             return Testbench::create(
                 $config['laravel'],
@@ -83,7 +83,7 @@ final class ApplicationResolver
             );
         }
 
-        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath()), $vendorDir, ['extra' => ['dont-discover' => ['*']]]);
+        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath(), null,  ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
 
         return Testbench::create(
             null,

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -74,7 +74,7 @@ final class ApplicationResolver
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml($workingPath);
 
-            static::createSymlinkToVendorPath(Testbench::create($config['laravel'], null,  ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
+            static::createSymlinkToVendorPath(Testbench::create($config['laravel'], null, ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
 
             return Testbench::create(
                 $config['laravel'],
@@ -83,7 +83,7 @@ final class ApplicationResolver
             );
         }
 
-        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath(), null,  ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
+        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath(), null, ['extra' => ['dont-discover' => ['*']]]), $vendorDir);
 
         return Testbench::create(
             null,

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -74,7 +74,7 @@ final class ApplicationResolver
         if (class_exists(Config::class)) {
             $config = Config::loadFromYaml($workingPath);
 
-            static::createSymlinkToVendorPath(Testbench::create($config['laravel']), $vendorDir);
+            static::createSymlinkToVendorPath(Testbench::create($config['laravel']), $vendorDir, ['extra' => ['dont-discover' => ['*']]]);
 
             return Testbench::create(
                 $config['laravel'],
@@ -83,7 +83,7 @@ final class ApplicationResolver
             );
         }
 
-        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath()), $vendorDir);
+        static::createSymlinkToVendorPath(Testbench::create(Testbench::applicationBasePath()), $vendorDir, ['extra' => ['dont-discover' => ['*']]]);
 
         return Testbench::create(
             null,


### PR DESCRIPTION
solves nunomaduro/larastan#1345

- ~~[ ] Added or updated tests~~
- ~~[ ] Documented user facing changes~~
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
We shouldn't attempt to autoload root package providers during `vendor` symlink, it causes an issue when the root package depends on another service provider to be available.

**Breaking changes**

None
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
