### PR TITLE
feat: let Testbench handles vendor symlink if used with Testbench 7.11+

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -9,6 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
 use NunoMaduro\Larastan\Internal\ComposerHelper;
 use Orchestra\Testbench\Foundation\Application as Testbench;
+use Orchestra\Testbench\Foundation\Bootstrap\CreateVendorSymlink;
 use Orchestra\Testbench\Foundation\Config;
 
 /**
@@ -24,6 +25,12 @@ final class ApplicationResolver
      */
     public static function createSymlinkToVendorPath($app, string $vendorDir): void
     {
+        if (class_exists(CreateVendorSymlink::class)) {
+            (new CreateVendorSymlink($vendorDir))->bootstrap($app);
+
+            return;
+        }
+
         $filesystem = new Filesystem();
 
         $laravelVendorPath = $app->basePath('vendor');


### PR DESCRIPTION
- Added or updated tests
- Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Testbench 7.11 now includes `Orchestra\Testbench\Foundation\Bootstrap\CreateVendorSymlink` which would handle the symlink process. The line below will be used for packages installed with Testbench <7.11

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
