### PR TITLE
feat: conditional return types for `Eloquent\Collection::find()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: Added stub for `optional()` helper and class by @mad-briller in https://github.com/nunomaduro/larastan/pull/1344
 - fix: abstract Manager class causing Larastan to crash by @mad-briller
 - fix: Eloquent builder `whereRelation()` losing the TModelClass generic type by @mad-briller.
+- feat: conditional return types for `Eloquent\Collection::find()` by @sebdesign
 
 ## [2.2.0] - 2022-08-31
 

--- a/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
@@ -28,7 +28,7 @@ class CollectionGenericStaticMethodDynamicMethodReturnTypeExtension implements D
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
         if ($methodReflection->getDeclaringClass()->getName() === EloquentCollection::class) {
-            return false;
+            return in_array($methodReflection->getName(), ['find']);
         }
 
         return in_array($methodReflection->getName(), [

--- a/stubs/EloquentCollection.stub
+++ b/stubs/EloquentCollection.stub
@@ -13,5 +13,14 @@ use Illuminate\Support\Collection as BaseCollection;
  */
 class Collection extends BaseCollection implements QueueableCollection
 {
-    // ..
+    /**
+     * Find a model in the collection by key.
+     *
+     * @template TFindDefault
+     *
+     * @param  mixed  $key
+     * @param  TFindDefault  $default
+     * @phpstan-return ($key is \Illuminate\Database\Eloquent\Model ? TModel|TFindDefault : ($key is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? static<TKey, TModel> : TModel|TFindDefault))
+     */
+    public function find($key, $default = null);
 }

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -11,12 +11,31 @@ use function PHPStan\Testing\assertType;
 /** @var SupportCollection<string, int> $items */
 /** @var App\TransactionCollection<int, Transaction> $customEloquentCollection */
 /** @var App\UserCollection $secondCustomEloquentCollection */
+/** @var User $user */
 assertType('Illuminate\Database\Eloquent\Collection<int, int>', EloquentCollection::range(1, 10));
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
 assertType('Illuminate\Support\Collection<int, mixed>', $items->collapse());
 
 assertType('Illuminate\Database\Eloquent\Collection<int, array<int, App\User|int>>', $collection->crossJoin([1]));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
+assertType('App\User|null', $collection->find($user));
+assertType('App\User|null', $collection->find(1));
+assertType('App\User|bool', $collection->find(1, false));
+
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find($items));
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find([1]));
+assertType('App\Transaction|null', $customEloquentCollection->find($user));
+assertType('App\Transaction|null', $customEloquentCollection->find(1));
+assertType('App\Transaction|bool', $customEloquentCollection->find(1, false));
+
+assertType('App\UserCollection', $secondCustomEloquentCollection->find($items));
+assertType('App\UserCollection', $secondCustomEloquentCollection->find([1]));
+assertType('App\User|null', $secondCustomEloquentCollection->find($user));
+assertType('App\User|null', $secondCustomEloquentCollection->find(1));
+assertType('App\User|bool', $secondCustomEloquentCollection->find(1, false));
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\Collection<int, mixed>', $items->flatten());

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -9,6 +9,7 @@ use function PHPStan\Testing\assertType;
 
 /** @var EloquentCollection<int, User> $collection */
 /** @var SupportCollection<string, int> $items */
+/** @var User $user */
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->each(function (User $user, int $key): void {
 }));
 
@@ -19,6 +20,12 @@ assertType('Illuminate\Support\Collection<string, int>', $items->each(function (
 assertType('Illuminate\Support\Collection<string, string>', $items->map(function (int $item): string {
     return (string) $item;
 }));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
+assertType('App\User|null', $collection->find($user));
+assertType('App\User|null', $collection->find(1));
+assertType('App\User|bool', $collection->find(1, false));
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->pluck('id'));
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

This was originally submitted here: https://github.com/laravel/framework/pull/44459

**Changes**

Thanks to PHPStan's conditional return types, we can now infer what does the `find` method of the Eloquent Collection returns.
When the `$key` argument is an `array` or an `Arrayable` object, it returns a new collection with the found items.
In all other cases, it returns a single item, or the `$default` value.
