### PR TITLE
Less arguments passed to ScopeFactory

### DIFF
--- a/src/Types/RelationParserHelper.php
+++ b/src/Types/RelationParserHelper.php
@@ -78,12 +78,7 @@ class RelationParserHelper
             return null;
         }
 
-        $scope = $this->scopeFactory->create(
-            ScopeContext::create($fileName),
-            false,
-            [],
-            $methodReflection
-        );
+        $scope = $this->scopeFactory->create(ScopeContext::create($fileName));
 
         $methodScope = $scope
             ->enterClass($methodReflection->getDeclaringClass())


### PR DESCRIPTION
The `$methodReflection` is immediately rewritten anyway...

I'm changing the ScopeFactory a bit in PHPStan 1.9.0 but with this change the BC break isn't as concerning :)