### PR TITLE
Remove duplicate decleration of Collection::pop()

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -136,11 +136,6 @@ class Collection implements \ArrayAccess, Enumerable
     public function pluck($value, $key = null) {}
 
     /**
-     * @return TValue
-     */
-    public function pop() {}
-
-    /**
      * Push one or more items onto the end of the collection.
      *
      * @param TValue ...$values


### PR DESCRIPTION
**Changes**

Remove duplicate deceleration of Collection::pop() that would cause errors on some setups:

```
Error: Cannot redeclare method Illuminate\Support\Collection::pop().
 ------ --------------------------------------------------------------- 
  Line   vendor/nunomaduro/larastan/stubs/Collection.stub               
 ------ --------------------------------------------------------------- 
  141    Cannot redeclare method Illuminate\Support\Collection::pop().  
```

To be specific this happens when using PHPStan 1.9.0 and not being in the package root (monorepo):

phpstan 1.9.0
`package1/vendor/bin/phpstan` : triggers error
`cd package1 && vendor/bin/phpstan` : no error

phpstan 1.8.11
`package1/vendor/bin/phpstan` : no error
`cd package1 && vendor/bin/phpstan` : no error