### PR TITLE
Removed duplicated method pop() in Collection.stub

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -136,11 +136,6 @@ class Collection implements \ArrayAccess, Enumerable
     public function pluck($value, $key = null) {}
 
     /**
-     * @return TValue
-     */
-    public function pop() {}
-
-    /**
      * Push one or more items onto the end of the collection.
      *
      * @param TValue ...$values


### PR DESCRIPTION
Reason: PHPStan reports that pop() method is already defined in Collection.stub

- [ ] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Removed duplicated method pop() in Collection.stub

**Breaking changes**

- No breaking changes
