### PR TITLE
Improve handling of read types on custom model casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: conditional return types for `Eloquent\Collection::find()` by @sebdesign
 - feat: add support for generic paginators by @erikgaal
 - feat: add support for encrypted and parameterized eloquent casts by @jdjfisher
+- fix: improve handling of read types on custom model casts by @Aberdeener
 
 ## [2.2.0] - 2022-08-31
 

--- a/tests/Application/app/Money.php
+++ b/tests/Application/app/Money.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+class Money
+{
+    public function __construct(
+        private int $amount = 100,
+    ) {
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+}

--- a/tests/Application/app/MoneyCast.php
+++ b/tests/Application/app/MoneyCast.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App;
+
+class MoneyCast implements \Illuminate\Contracts\Database\Eloquent\CastsAttributes
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function get($model, string $key, $value, array $attributes): ?Money
+    {
+        return new \App\Money($value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        // TODO: Implement set() method.
+    }
+}

--- a/tests/Application/app/MoneyCast.php
+++ b/tests/Application/app/MoneyCast.php
@@ -4,7 +4,6 @@ namespace App;
 
 class MoneyCast implements \Illuminate\Contracts\Database\Eloquent\CastsAttributes
 {
-
     /**
      * @inheritDoc
      */

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -50,6 +50,7 @@ class User extends Authenticatable
         'floatButRoundedDecimalString' => 'decimal:1',
         'options' => AsArrayObject::class,
         'properties' => AsCollection::class,
+        'balance' => MoneyCast::class,
     ];
 
     /**

--- a/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Application/database/migrations/2020_01_30_000000_create_users_table.php
@@ -29,6 +29,7 @@ class CreateUsersTable extends Migration
             $table->json('properties');
             $table->boolean('blocked');
             $table->unknownColumnType('unknown_column');
+            $table->integer('balance');
             $table->rememberToken();
             $table->timestamps();
             $table->softDeletes();

--- a/tests/Features/Properties/ModelPropertyExtension.php
+++ b/tests/Features/Properties/ModelPropertyExtension.php
@@ -8,6 +8,7 @@ use App\Account;
 use App\Address;
 use App\Group;
 use App\GuardedModel;
+use App\Money;
 use App\Role;
 use App\Team;
 use App\Thread;
@@ -200,6 +201,14 @@ class ModelPropertyExtension
     public function testSoftDeletesCastDateTimeAndNullable(User $user): ?string
     {
         return $user->deleted_at?->format('d/m/Y');
+    }
+
+    /** @return Money|null */
+    public function testCastClassReturnsDifferentClassInstanceOrNull(User $user)
+    {
+        assertType('App\\Money|null', $user->balance);
+
+        return $user->balance;
     }
 
     public function testWriteToSoftDeletesColumn(): void


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes (I don't think this is needed?)
- [x] Updated CHANGELOG.md

**Changes**
This PR fixes a pretty annoying issue while using Larastan and model casts.
For example, when using the [Laravel Money](https://github.com/cknow/laravel-money) package, it has a custom cast class `\Cknow\Money\Casts\MoneyIntegerCast`.
This casts `get` method returns a `\Cknow\Money\Money` object, but Larastan only detected the `MoneyIntegerCast` as the return type.
This causes dozens of errors similar to:
```
Parameter #1 $price of static method                              
         `App\Helpers\TaxHelper::calculateFor()` expects `Cknow\Money\Money`
         `Cknow\Money\Casts\MoneyIntegerCast` given.
```
To fix this issue, I have used reflection to determine the return type of the casts underlying `get` method, and (if it is defined), use that as the read type for the attribute.

I am aware of this PR https://github.com/nunomaduro/larastan/pull/1333, but I thought a smaller PR to fix this problem faster would be nice, until that one gets merged.