### PR TITLE
feat: container binding implements abstract rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+.vscode/
 .idea/codeStyleSettings.xml
 composer.lock
 /vendor/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -137,6 +137,31 @@ And if you call the function above with a property that does not exist in User m
 takesOnlyUserModelProperties('emaiil');
 ```
 
+## ContainerBindingImplementsAbstractRule
+
+Checks for improper container bindings where the resolved type does not implement the provided abstract class.
+
+Supported container methods are:
+- `bind`
+- `bindIf`
+- `singleton`
+- `singletonIf`
+
+### Examples
+
+Following code
+```php
+public function register()
+{
+    $this->app->bind(CarContract::class, Dog::class);
+}
+```
+Will result in the following error:
+
+```
+Container binding of type App\Dog does not implement App\Contracts\CarContract.
+```
+
 ## OctaneCompatibilityRule
 
 This is an optional rule that can check your application for Laravel Octane compatibility.

--- a/extension.neon
+++ b/extension.neon
@@ -13,6 +13,7 @@ parameters:
         - bootstrap.php
     checkOctaneCompatibility: false
     noModelMake: true
+    containerBindingImplementsAbstract: true
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
@@ -26,6 +27,7 @@ parameters:
 parametersSchema:
     checkOctaneCompatibility: bool()
     noModelMake: bool()
+    containerBindingImplementsAbstract: bool()
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
@@ -38,6 +40,8 @@ parametersSchema:
 conditionalTags:
     NunoMaduro\Larastan\Rules\NoModelMakeRule:
         phpstan.rules.rule: %noModelMake%
+    NunoMaduro\Larastan\Rules\ContainerBindingImplementsAbstractRule:
+        phpstan.rules.rule: %containerBindingImplementsAbstract%
     NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
     NunoMaduro\Larastan\Rules\OctaneCompatibilityRule:
@@ -367,6 +371,9 @@ services:
         class: NunoMaduro\Larastan\Rules\NoModelMakeRule
 
     -
+        class: NunoMaduro\Larastan\Rules\ContainerBindingImplementsAbstractRule
+
+    -
         class: NunoMaduro\Larastan\Rules\NoUnnecessaryCollectionCallRule
         arguments:
             onlyMethods: %noUnnecessaryCollectionCallOnly%
@@ -474,10 +481,17 @@ services:
         class: NunoMaduro\Larastan\Collectors\UsedRouteFacadeViewCollector
         tags:
             - phpstan.collector
+
+    -
+        class: NunoMaduro\Larastan\Collectors\ContainerBindingsCollector
+        tags:
+            - phpstan.collector
+
     -
         class: NunoMaduro\Larastan\Collectors\UsedViewInAnotherViewCollector
         arguments:
             parser: @currentPhpVersionSimpleDirectParser
+
     -
         class: NunoMaduro\Larastan\Support\ViewFileHelper
         arguments:

--- a/src/Collectors/ContainerBindingsCollector.php
+++ b/src/Collectors/ContainerBindingsCollector.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Collectors;
+
+use Illuminate\Contracts\Container\Container;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements Collector<Node\Expr\MethodCall, array{string, ?string, int}>
+ */
+final class ContainerBindingsCollector implements Collector
+{
+    const METHODS = [
+        'bind',
+        'bindIf',
+        'singleton',
+        'singletonIf',
+    ];
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param  MethodCall  $node
+     * @param  Scope  $scope
+     * @return ?array{string, bool, ?string, int}
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (! $this->isContainerBinding($node, $scope)) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+
+        $concreteType = null;
+
+        if (count($args) > 1) {
+            $concreteType = $this->getConcreteType($args[1]->value, $scope);
+        }
+
+        $bindingExpr = $args[0]->value;
+
+        // Binding ID is a class
+        if ($bindingExpr instanceof Node\Expr\ClassConstFetch && $bindingExpr->class instanceof Node\Name) {
+            return [
+                $bindingExpr->class->toString(),
+                true,
+                $concreteType,
+                $node->getLine(),
+            ];
+        }
+
+        // Binding ID is a string
+        if ($bindingExpr instanceof Node\Scalar\String_) {
+            return [
+                $bindingExpr->value,
+                false,
+                $concreteType,
+                $node->getLine(),
+            ];
+        }
+
+        // Unknown binding ID type
+        return null;
+    }
+
+    private function isContainerBinding(MethodCall $node, Scope $scope): bool
+    {
+        if (! $node->name instanceof Identifier) {
+            return false;
+        }
+
+        $methodName = $node->name->name;
+
+        if (! in_array($methodName, self::METHODS, true)) {
+            return false;
+        }
+
+        $calledOnType = $scope->getType($node->var);
+
+        return (new ObjectType(Container::class))->isSuperTypeOf($calledOnType)->yes();
+    }
+
+    private function getConcreteType(Expr $expr, Scope $scope): ?string
+    {
+        if ($expr instanceof Node\Expr\ClassConstFetch && $expr->class instanceof Node\Name) {
+            return $expr->class->toString();
+        }
+
+        if ($expr instanceof Node\FunctionLike) {
+            $functionType = $scope->getType($expr);
+
+            if ($functionType instanceof ClosureType) {
+                return $functionType->getReturnType()->describe(VerbosityLevel::value());
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Rules/ContainerBindingImplementsAbstractRule.php
+++ b/src/Rules/ContainerBindingImplementsAbstractRule.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules;
+
+use NunoMaduro\Larastan\Collectors\ContainerBindingsCollector;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/** @implements Rule<CollectedDataNode> */
+class ContainerBindingImplementsAbstractRule implements Rule
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private TypeStringResolver $typeStringResolver
+    ) {
+    }
+
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param  CollectedDataNode  $node
+     * @param  Scope  $scope
+     * @return array<int, RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        /** @var array<string, list<array{string, bool, ?string, int}>> $containerBindingsData */
+        $containerBindingsData = $node->get(ContainerBindingsCollector::class);
+
+        foreach ($containerBindingsData as $file => $declarations) {
+            foreach ($declarations as [$bindingId, $isClassBinding, $concreteTypeString, $line]) {
+                // No binding was given, skip
+                if (! $concreteTypeString) {
+                    continue;
+                }
+
+                // If the binding ID is not a valid class-string, skip (e.g 'auth.driver')
+                if (! $isClassBinding || ! $this->reflectionProvider->hasClass($bindingId)) {
+                    continue;
+                }
+
+                $abstractType = $this->typeStringResolver->resolve($bindingId);
+                $concreteType = $this->typeStringResolver->resolve($concreteTypeString);
+
+                if (! $abstractType->isSuperTypeOf($concreteType)->yes()) {
+                    $errors[] = $this->getRuleError($bindingId, $concreteTypeString, $file, $line);
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private function getRuleError(
+        string $astractType,
+        string $concreteType,
+        string $file,
+        int $line
+    ): \PHPStan\Rules\RuleError {
+        $message = sprintf('Container binding of type %s does not implement %s.', $concreteType, $astractType);
+
+        return RuleErrorBuilder::message($message)
+            ->identifier('rules.containerBindingImplementsAbstract')
+            ->line($line)
+            ->file($file)
+            ->build();
+    }
+}

--- a/tests/Rules/ContainerBindingImplementsAbstractRuleTest.php
+++ b/tests/Rules/ContainerBindingImplementsAbstractRuleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use NunoMaduro\Larastan\Collectors\ContainerBindingsCollector;
+use NunoMaduro\Larastan\Rules\ContainerBindingImplementsAbstractRule;
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<ContainerBindingImplementsAbstractRule> */
+class ContainerBindingImplementsAbstractRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        $provider = $this->createReflectionProvider();
+        $resolver = self::getContainer()->getByType(TypeStringResolver::class);
+
+        return new ContainerBindingImplementsAbstractRule($provider, $resolver);
+    }
+
+    protected function getCollectors(): array
+    {
+        return [
+            new ContainerBindingsCollector(),
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Data/container-binding-implements-abstract-rule.php'], [
+            // bind
+            [
+                'Container binding of type Bindings\Buzz does not implement Bindings\FooContract.',
+                62,
+            ],
+            [
+                'Container binding of type Bindings\FooImplementation does not implement Bindings\AbstractBar.',
+                64,
+            ],
+            [
+                'Container binding of type Bindings\BarConcretion|Bindings\Buzz does not implement Bindings\AbstractBar.',
+                66,
+            ],
+            // bindIf
+            [
+                'Container binding of type Bindings\Buzz does not implement Bindings\FooContract.',
+                86,
+            ],
+            [
+                'Container binding of type Bindings\FooImplementation does not implement Bindings\AbstractBar.',
+                88,
+            ],
+            [
+                'Container binding of type Bindings\BarConcretion|Bindings\Buzz does not implement Bindings\AbstractBar.',
+                90,
+            ],
+            // singleton
+            [
+                'Container binding of type Bindings\Buzz does not implement Bindings\FooContract.',
+                110,
+            ],
+            [
+                'Container binding of type Bindings\FooImplementation does not implement Bindings\AbstractBar.',
+                112,
+            ],
+            [
+                'Container binding of type Bindings\BarConcretion|Bindings\Buzz does not implement Bindings\AbstractBar.',
+                114,
+            ],
+            // singletonIf
+            [
+                'Container binding of type Bindings\Buzz does not implement Bindings\FooContract.',
+                134,
+            ],
+            [
+                'Container binding of type Bindings\FooImplementation does not implement Bindings\AbstractBar.',
+                136,
+            ],
+            [
+                'Container binding of type Bindings\BarConcretion|Bindings\Buzz does not implement Bindings\AbstractBar.',
+                138,
+            ],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/phpstan-rules.neon',
+        ];
+    }
+}

--- a/tests/Rules/Data/container-binding-implements-abstract-rule.php
+++ b/tests/Rules/Data/container-binding-implements-abstract-rule.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bindings;
+
+interface FooContract
+{
+    public function foo(): string;
+}
+
+class FooImplementation implements FooContract
+{
+    public function foo(): string
+    {
+        return 'lorem';
+    }
+}
+
+class OtherFooImplementation implements FooContract
+{
+    public function foo(): string
+    {
+        return 'ipsum';
+    }
+}
+
+abstract class AbstractBar
+{
+    abstract public function bar(): void;
+}
+
+class BarConcretion extends AbstractBar
+{
+    public function bar(): void
+    {
+        //
+    }
+}
+
+class Buzz
+{
+    //
+}
+
+// bind - positive
+
+app()->bind(Buzz::class);
+
+app()->bind('fizz', Buzz::class);
+
+app()->bind(FooContract::class, FooImplementation::class);
+
+app()->bind(AbstractBar::class, fn () => new BarConcretion());
+
+app()->bind(FooContract::class, function () {
+    return rand() ? new OtherFooImplementation() : new FooImplementation();
+});
+
+// bind - negative
+
+app()->bind(FooContract::class, Buzz::class);
+
+app()->bind(AbstractBar::class, fn () => new FooImplementation());
+
+app()->bind(AbstractBar::class, function () {
+    return rand() ? new Buzz() : new BarConcretion();
+});
+
+// bindIf - positive
+
+app()->bindIf(Buzz::class);
+
+app()->bindIf('fizz', Buzz::class);
+
+app()->bindIf(FooContract::class, FooImplementation::class);
+
+app()->bindIf(AbstractBar::class, fn () => new BarConcretion());
+
+app()->bindIf(FooContract::class, function () {
+    return rand() ? new OtherFooImplementation() : new FooImplementation();
+});
+
+// bindIf - negative
+
+app()->bindIf(FooContract::class, Buzz::class);
+
+app()->bindIf(AbstractBar::class, fn () => new FooImplementation());
+
+app()->bindIf(AbstractBar::class, function () {
+    return rand() ? new Buzz() : new BarConcretion();
+});
+
+// singleton - positive
+
+app()->singleton(Buzz::class);
+
+app()->singleton('fizz', Buzz::class);
+
+app()->singleton(FooContract::class, FooImplementation::class);
+
+app()->singleton(AbstractBar::class, fn () => new BarConcretion());
+
+app()->singleton(FooContract::class, function () {
+    return rand() ? new OtherFooImplementation() : new FooImplementation();
+});
+
+// singleton - negative
+
+app()->singleton(FooContract::class, Buzz::class);
+
+app()->singleton(AbstractBar::class, fn () => new FooImplementation());
+
+app()->singleton(AbstractBar::class, function () {
+    return rand() ? new Buzz() : new BarConcretion();
+});
+
+// singletonIf - positive
+
+app()->singletonIf(Buzz::class);
+
+app()->singletonIf('fizz', Buzz::class);
+
+app()->singletonIf(FooContract::class, FooImplementation::class);
+
+app()->singletonIf(AbstractBar::class, fn () => new BarConcretion());
+
+app()->singletonIf(FooContract::class, function () {
+    return rand() ? new OtherFooImplementation() : new FooImplementation();
+});
+
+// singletonIf - negative
+
+app()->singletonIf(FooContract::class, Buzz::class);
+
+app()->singletonIf(AbstractBar::class, fn () => new FooImplementation());
+
+app()->singletonIf(AbstractBar::class, function () {
+    return rand() ? new Buzz() : new BarConcretion();
+});


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Adds a new collector and rule to check that container bindings make sense.

Questions:
- Should this rule be optional?
- Add support for `$bindings` and `$singletons` defined on Service Providers?
- Should this check that the concrete type is either an instance or instantiable? 

