### PR TITLE
fix: `make`, `makeWith` and `resolve` methods not resolving to correct type on Application and Container.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
             checkout-with: |
               {
                 "repository": "koel/koel",
-                "ref": "0b85ff18b949714ef46b4d2bc73c6c1f6587a1ad",
+                "ref": "9e864c937f5f060aa0192596d4e0776e68dc16e5",
                 "path": "e2e"
               }
           - repo: "canvural/larastan-test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - fix: changed dependency from `Illuminate\Config\Repository` to Config interface by @nai4rus
 - feat: assert `view-string` when using `view()->exists()` by @mad-briller
+- feat: Add return-type extension for Application / Container `make` `makeWith` and `resolve` methods by @mad-briller.
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
 - feat: updated return type of the Request::header method by @mad-briller
 - feat: Added stub for `optional()` helper and class by @mad-briller in https://github.com/nunomaduro/larastan/pull/1344

--- a/extension.neon
+++ b/extension.neon
@@ -479,6 +479,19 @@ services:
         class: NunoMaduro\Larastan\Support\ViewFileHelper
         arguments:
             viewDirectories: %viewDirectories%
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ApplicationMakeDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ContainerMakeDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    - NunoMaduro\Larastan\ReturnTypes\AppMakeHelper
+
 rules:
     - NunoMaduro\Larastan\Rules\RelationExistenceRule
     - NunoMaduro\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule

--- a/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
@@ -5,23 +5,18 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes;
 
 use Illuminate\Support\Facades\App;
-use NunoMaduro\Larastan\Concerns\HasContainer;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\NeverType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Throwable;
 
 final class AppMakeDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
-    use HasContainer;
+    public function __construct(
+        private AppMakeHelper $appMakeHelper
+    ) {
+    }
 
     public function getClass(): string
     {
@@ -35,30 +30,6 @@ final class AppMakeDynamicReturnTypeExtension implements DynamicStaticMethodRetu
 
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
     {
-        if (count($methodCall->getArgs()) === 0) {
-            return new ErrorType();
-        }
-
-        $expr = $methodCall->getArgs()[0]->value;
-        if ($expr instanceof String_) {
-            try {
-                /** @var object|null $resolved */
-                $resolved = $this->resolve($expr->value);
-
-                if ($resolved === null) {
-                    return new ErrorType();
-                }
-
-                return new ObjectType(get_class($resolved));
-            } catch (Throwable $exception) {
-                return new ErrorType();
-            }
-        }
-
-        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
-            return new ObjectType($expr->class->toString());
-        }
-
-        return new NeverType();
+        return $this->appMakeHelper->resolveTypeFromCall($methodCall);
     }
 }

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use NunoMaduro\Larastan\Concerns\HasContainer;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Throwable;
+
+final class AppMakeHelper
+{
+    use HasContainer;
+
+    public function resolveTypeFromCall(FuncCall|MethodCall|StaticCall $call): Type
+    {
+        if (count($call->getArgs()) === 0) {
+            return new ErrorType();
+        }
+
+        $expr = $call->getArgs()[0]->value;
+        if ($expr instanceof String_) {
+            try {
+                /** @var object|null $resolved */
+                $resolved = $this->resolve($expr->value);
+
+                if ($resolved === null) {
+                    return new ErrorType();
+                }
+
+                return new ObjectType(get_class($resolved));
+            } catch (Throwable $exception) {
+                return new ErrorType();
+            }
+        }
+
+        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
+            return new ObjectType($expr->class->toString());
+        }
+
+        return new NeverType();
+    }
+}

--- a/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Contracts\Foundation\Application;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class ApplicationMakeDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(
+        private AppMakeHelper $appMakeHelper
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return Application::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        return $this->appMakeHelper->resolveTypeFromCall($methodCall);
+    }
+}

--- a/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Contracts\Container\Container;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class ContainerMakeDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(
+        private AppMakeHelper $appMakeHelper
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return Container::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        return $this->appMakeHelper->resolveTypeFromCall($methodCall);
+    }
+}

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -5,24 +5,20 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
 
 use Illuminate\Foundation\Application;
-use NunoMaduro\Larastan\Concerns\HasContainer;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ClassConstFetch;
+use NunoMaduro\Larastan\ReturnTypes\AppMakeHelper;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Throwable;
 
 class AppExtension implements DynamicFunctionReturnTypeExtension
 {
-    use HasContainer;
+    public function __construct(
+        private AppMakeHelper $appMakeHelper
+    ) {
+    }
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
@@ -38,28 +34,6 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
             return new ObjectType(Application::class);
         }
 
-        /** @var Expr $expr */
-        $expr = $functionCall->getArgs()[0]->value;
-
-        if ($expr instanceof String_) {
-            try {
-                /** @var object|null $resolved */
-                $resolved = $this->resolve($expr->value);
-
-                if ($resolved === null) {
-                    return new ErrorType();
-                }
-
-                return new ObjectType(get_class($resolved));
-            } catch (Throwable $exception) {
-                return new ErrorType();
-            }
-        }
-
-        if ($expr instanceof ClassConstFetch && $expr->class instanceof FullyQualified) {
-            return new ObjectType($expr->class->toString());
-        }
-
-        return new NeverType();
+        return $this->appMakeHelper->resolveTypeFromCall($functionCall);
     }
 }

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -35,6 +35,8 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/database-transaction.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/container-array-access.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/view-exists.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/application-make.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/container-make.php');
     }
 
     /**

--- a/tests/Type/data/application-make.php
+++ b/tests/Type/data/application-make.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ApplicationMake;
+
+use Illuminate\Contracts\Config\Repository;
+use function PHPStan\Testing\assertType;
+
+/** @var \Illuminate\Foundation\Application $app */
+assertType('Illuminate\Contracts\Config\Repository', $app->make(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $app->makeWith(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $app->resolve(Repository::class));
+
+/** @var \Illuminate\Contracts\Foundation\Application $app */
+assertType('Illuminate\Contracts\Config\Repository', $app->make(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $app->makeWith(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $app->resolve(Repository::class));

--- a/tests/Type/data/container-make.php
+++ b/tests/Type/data/container-make.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ContainerMake;
+
+use Illuminate\Contracts\Config\Repository;
+use function PHPStan\Testing\assertType;
+
+/** @var \Illuminate\Container\Container $container */
+assertType('Illuminate\Contracts\Config\Repository', $container->make(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $container->makeWith(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $container->resolve(Repository::class));
+
+/** @var \Illuminate\Contracts\Container\Container $container */
+assertType('Illuminate\Contracts\Config\Repository', $container->make(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $container->makeWith(Repository::class));
+assertType('Illuminate\Contracts\Config\Repository', $container->resolve(Repository::class));


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

resolves https://github.com/nunomaduro/larastan/issues/1441

**Changes**
Added return type extension for Application and Container `make`, `makeWith` and `resolves` method.

Abstracts repeated behavior into a `AppMakeHelper` and uses that in places i could find it being duplicated.

