### PR TITLE
feat: add `createOneQuietly` stub

### DIFF
--- a/stubs/Factory.stub
+++ b/stubs/Factory.stub
@@ -31,6 +31,14 @@ class Factory
     public function createOne($attributes = []) {}
 
     /**
+     * Create a single model and persist it to the database.
+     *
+     * @param  array<model-property<TModel>, mixed> $attributes
+     * @return TModel
+     */
+    public function createOneQuietly($attributes = []) {}
+
+    /**
      * Create a collection of models and persist them to the database.
      *
      * @param  iterable<callable|array<model-property<TModel>, mixed>>  $records

--- a/tests/Features/ReturnTypes/ModelFactory.php
+++ b/tests/Features/ReturnTypes/ModelFactory.php
@@ -85,6 +85,11 @@ class ModelFactory
         return Post::factory()->createOne();
     }
 
+    public function testCreateOneQuietly(): Post
+    {
+        return Post::factory()->createOneQuietly();
+    }
+
     /** @phpstan-return Collection<int, Post> */
     public function testCreateMany(): Collection
     {

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -8,6 +8,7 @@ use function PHPStan\Testing\assertType;
 assertType('Database\Factories\UserFactory', User::factory());
 assertType('Database\Factories\UserFactory', User::factory()->new());
 assertType('App\User', User::factory()->createOne());
+assertType('App\User', User::factory()->createOneQuietly());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->createMany([]));
 assertType('App\User', User::factory()->makeOne());
 

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -35,11 +35,6 @@ assertType('App\User', User::factory(2)->count(null)->createQuietly());
 assertType('App\User', User::factory(2)->count(null)->createOneQuietly());
 assertType('App\User', User::factory(2)->count(null)->make());
 
-assertType('App\User', User::factory(2)->count(null)->create());
-assertType('App\User', User::factory(2)->count(null)->createQuietly());
-assertType('App\User', User::factory(2)->count(null)->createOneQuietly());
-assertType('App\User', User::factory(2)->count(null)->make());
-
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->create());
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->createQuietly());
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->createOneQuietly());

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -23,21 +23,26 @@ assertType('App\User', User::factory()->configure()->make());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->create());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->createQuietly());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory(2)->make());
+assertType('App\User', User::factory(2)->createOneQuietly());
 
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->create());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->createQuietly());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::factory()->count(1)->make());
+assertType('App\User', User::factory()->count(2)->createOneQuietly());
 
 assertType('App\User', User::factory(2)->count(null)->create());
 assertType('App\User', User::factory(2)->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->count(null)->createOneQuietly());
 assertType('App\User', User::factory(2)->count(null)->make());
 
 assertType('App\User', User::factory(2)->count(null)->create());
 assertType('App\User', User::factory(2)->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->count(null)->createOneQuietly());
 assertType('App\User', User::factory(2)->count(null)->make());
 
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->create());
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->createQuietly());
+assertType('App\User', User::factory(2)->state(['foo'])->count(null)->createOneQuietly());
 assertType('App\User', User::factory(2)->state(['foo'])->count(null)->make());
 
 function foo(?int $foo): void


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

The factory stub did not have createOneQuietly defined, which prevented PHPStan/Larastan from resolving the type correctly.

**Breaking changes**

None