### PR TITLE
Assert view-string with view()->exists().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- feat: assert `view-string` when using `view()->exists()` by @mad-briller
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
 - feat: updated return type of the Request::header method by @mad-briller
 - feat: Added stub for `optional()` helper and class by @mad-briller in https://github.com/nunomaduro/larastan/pull/1344

--- a/stubs/Contracts/View.stub
+++ b/stubs/Contracts/View.stub
@@ -3,7 +3,17 @@
 namespace Illuminate\Contracts\View;
 
 interface Factory
-{}
+{
+    /**
+     * Determine if a given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     *
+     * @phpstan-assert-if-true view-string $view
+     */
+    public function exists($view);
+}
 
 interface View
 {}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -34,6 +34,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/form-request.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/database-transaction.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/container-array-access.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/view-exists.php');
     }
 
     /**

--- a/tests/Type/data/view-exists.php
+++ b/tests/Type/data/view-exists.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace IlluminateView;
+
+use function PHPStan\Testing\assertType;
+
+/** @var string $view */
+if (view()->exists($view)) {
+    assertType('view-string', $view);
+}
+
+assertType('string', $view);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves https://github.com/nunomaduro/larastan/issues/1463 https://github.com/nunomaduro/larastan/discussions/1461

Asserts a string is a `view-string` when `exists()` is called on it.