### PR TITLE
fix: changed concrete config class to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- fix: changed dependency from `Illuminate\Config\Repository` to Config interface by @nai4rus
 - feat: assert `view-string` when using `view()->exists()` by @mad-briller
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352
 - feat: updated return type of the Request::header method by @mad-briller

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Concerns;
 
-use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 trait LoadsAuthModel
 {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
- [x] Updated CHANGELOG.md

"Resolves: #1477"

**Changes**

Сoncrete `Illuminate\Config\Repository` class was changed to `Illuminate\Contracts\Config\Repository` interface. 

**Breaking changes**

There are no beahvior and breaking changes