### PR TITLE
feat: extension for MakesHttpRequests

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -241,7 +241,12 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: NunoMaduro\Larastan\ReturnTypes\TestCaseExtension
+        class: NunoMaduro\Larastan\ReturnTypes\TestCaseMakesHttpRequestsExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\TestCaseMockeryExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/src/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
+++ b/src/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes;
+
+use Illuminate\Foundation\Testing\TestCase;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @internal
+ */
+final class TestCaseMakesHttpRequestsExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return TestCase::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), [
+            'get',
+            'getJson',
+            'post',
+            'postJson',
+            'put',
+            'putJson',
+            'patch',
+            'patchJson',
+            'delete',
+            'deleteJson',
+            'options',
+            'optionsJson',
+            'head',
+            'json',
+            'call',
+        ], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        return new ObjectType('Illuminate\\Testing\\TestResponse');
+    }
+}

--- a/src/ReturnTypes/TestCaseMockeryExtension.php
+++ b/src/ReturnTypes/TestCaseMockeryExtension.php
@@ -18,7 +18,7 @@ use PHPStan\Type\TypeUtils;
 /**
  * @internal
  */
-final class TestCaseExtension implements DynamicMethodReturnTypeExtension
+final class TestCaseMockeryExtension implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {

--- a/tests/Features/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\ReturnTypes;
+
+use App\User;
+use Illuminate\Foundation\Application;
+
+class TestCaseMockeryExtension
+{
+    public function testGetMethod(): void
+    {
+        (new TestMakesRequestTestCase())->testGet();
+    }
+}
+
+class TestMakesRequestTestCase extends \Illuminate\Foundation\Testing\TestCase
+{
+    public function testGet(): void
+    {
+        $response = $this->get('/');
+        $response->assertStatus(200);
+    }
+
+    public function createApplication()
+    {
+        return new Application('');
+    }
+}

--- a/tests/Features/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseMakesHttpRequestsExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Features\ReturnTypes;
 
-use App\User;
 use Illuminate\Foundation\Application;
 
 class TestCaseMockeryExtension

--- a/tests/Features/ReturnTypes/TestCaseMockeryExtension.php
+++ b/tests/Features/ReturnTypes/TestCaseMockeryExtension.php
@@ -7,25 +7,25 @@ namespace Tests\Features\ReturnTypes;
 use App\User;
 use Illuminate\Foundation\Application;
 
-class TestCaseExtension
+class TestCaseMockeryExtension
 {
     public function testMockMethod(): void
     {
-        (new TestTestCase())->testMockMethod();
+        (new TestMockeryTestCase())->testMockMethod();
     }
 
     public function testPartialMockMethod(): void
     {
-        (new TestTestCase())->testPartialMockMethod();
+        (new TestMockeryTestCase())->testPartialMockMethod();
     }
 
     public function testSpyMethod(): void
     {
-        (new TestTestCase())->testSpyMethod();
+        (new TestMockeryTestCase())->testSpyMethod();
     }
 }
 
-class TestTestCase extends \Illuminate\Foundation\Testing\TestCase
+class TestMockeryTestCase extends \Illuminate\Foundation\Testing\TestCase
 {
     public function testMockMethod(): void
     {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [ ] Updated CHANGELOG.md

**Changes**

Adds an extension called `TestCaseMakesHttpRequestsExtension` and renames `TestCaseExtension` to `TestCaseMockeryExtension`.

The purpose of `TestCaseMakesHttpRequestsExtension` is to apply the return type of `Illuminate\Testing\TestResponse` to HTTP request testing methods such as `get`, `getJson` and `post` etc.

At current, these methods will return a `mixed` type meaning PHPStan can't process tests using these methods effectively.

I'm new to making changes to PHPStan codebases and rules so if there's a better way of doing this or something I've missed in the PR, please feel free to guide me in the best way of handling this.

**Breaking changes**

None
