### PR TITLE
Document PHPStan compatible version for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## ⚗️ About Larastan
 
-> If you are using a Laravel version older than 9.x, please refer to [Larastan v1.x](https://github.com/nunomaduro/larastan/tree/1.x).
+> If you are using a Laravel version older than 9.x, please refer to [Larastan v1.x](https://github.com/nunomaduro/larastan/tree/1.x) with [PHPStan 1.8.x](https://github.com/nunomaduro/larastan/pull/1431#issuecomment-1303332293).
 
 Larastan was created by [Can Vural](https://github.com/canvural) and [Nuno Maduro](https://github.com/nunomaduro), got artwork designed by [@Caneco](http://github.com/caneco), is maintained by [Can Vural](https://github.com/canvural), [Nuno Maduro](https://github.com/nunomaduro), and [Viktor Szépe](https://github.com/szepeviktor), and is a [PHPStan](https://phpstan.org/) wrapper for Laravel. Larastan focuses on **finding errors in your code**. It catches whole classes of bugs even **before you write tests** for the code.
 


### PR DESCRIPTION
This PR adds 3 words in the README, to emphasize that Larastan 1.x is only compatible with PHPStan 1.8.x.

Along with a link to https://github.com/nunomaduro/larastan/pull/1431#issuecomment-1303332293, explaining why.

---

In my case the requirements in composer.json was not sufficient : since phpstan 1.9.0 was already installed (in docker), composer simply switchted to larastan 1.0.3 (without the incompatibility information)...