### PR TITLE
Prevent false positive for NoUnnecessaryCollectionCallRule when using arrow functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: conditional return types for `Eloquent\Collection::find()` by @sebdesign
 - feat: add support for generic paginators by @erikgaal
 - feat: add support for encrypted and parameterized eloquent casts by @jdjfisher
+- fix: prevent false positive for NoUnnecessaryCollectionCallRule when using arrow functions by @JeppeKnockaert
 
 ## [2.2.0] - 2022-08-31
 

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -204,7 +204,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
             // 'contains' can also be called with Model instances or keys as its first argument
             /** @var \PhpParser\Node\Arg[] $args */
             $args = $node->args;
-            if (count($args) === 1 && ! ($args[0]->value instanceof Node\Expr\Closure)) {
+            if (count($args) === 1 && ! ($args[0]->value instanceof Node\FunctionLike)) {
                 return [$this->formatError($name->toString())];
             }
 

--- a/tests/Rules/Data/CorrectCollectionCalls.php
+++ b/tests/Rules/Data/CorrectCollectionCalls.php
@@ -73,6 +73,16 @@ class CorrectCollectionCalls
     }
 
     /**
+     * Can't analyze the arrow function as a parameter to contains, so should not throw any error.
+     *
+     * @return bool
+     */
+    public function testContainsArrowFunction(): bool
+    {
+        return User::where('id', '>', 1)->get()->contains(fn (User $user): bool => $user->id === 2);
+    }
+
+    /**
      * Can't analyze the closure as a parameter to first, so should not throw any error.
      *
      * @return User|null
@@ -82,6 +92,16 @@ class CorrectCollectionCalls
         return User::where('id', '>', 1)->get()->first(function (User $user): bool {
             return $user->id === 2;
         });
+    }
+
+    /**
+     * Can't analyze the arrow function as a parameter to first, so should not throw any error.
+     *
+     * @return User|null
+     */
+    public function testFirstArrowFunction(): ?User
+    {
+        return User::where('id', '>', 1)->get()->first(fn (User $user): bool => $user->id === 2);
     }
 
     /** @phpstan-return mixed */


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

**Changes**

Using arrow functions in `contains` and `first` no longer results in false positives for NoUnnecessaryCollectionCallRule.
