### PR TITLE
fix: incorrect EloquentBuilder::where() return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- fix: changed return type of `Illuminate\Database\Eloquent\Builder::where()` from `static` to `$this` to match original by @taka-oyama
 - fix: changed dependency from `Illuminate\Config\Repository` to Config interface by @nai4rus
 - feat: assert `view-string` when using `view()->exists()` by @mad-briller
 - feat: freed `joinSub` to allow models to join other models by @harmenjanssen in https://github.com/nunomaduro/larastan/pull/1352

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -221,7 +221,7 @@ class Builder
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return static
+     * @return $this
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and');
 

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -175,6 +175,16 @@ class Foo extends Model
     use FooTrait;
 }
 
+/** @extends Builder<Foo> */
+class FooBuilder extends Builder
+{
+    /** @return $this */
+    public function whereFoo()
+    {
+        return $this->where('foo', 'foo');
+    }
+}
+
 /** @template TModelClass of Model */
 trait FooTrait
 {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated CHANGELOG.md

**Changes**

This changes the return type of `where` in the `EloquentBuilder.stub` which did not match the original file.

This was throwing false positives in my custom Builder class.

For example, the following code.
```
class UserBuilder extends Builder
{
    /** @return $this */
    public function visible()
    {
        return $this->where('visible', true);
    }
}
```

Was giving me this error.

```
Method App\Models\Builders\UserBuilder::visible() should return $this(App\Models\Builders\UserBuilder) but returns static(App\Models\Builders\UserBuilder).
```
