### PR TITLE
feat: respect annotations on facades

### DIFF
--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -3,6 +3,7 @@
 namespace NunoMaduro\Larastan\Methods;
 
 use Carbon\Traits\Macro as CarbonMacro;
+use Exception;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
@@ -12,13 +13,14 @@ use Illuminate\Support\Traits\Macroable;
 use NunoMaduro\Larastan\Concerns\HasContainer;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ClosureTypeFactory;
 use ReflectionException;
 
-class MacroMethodsClassReflectionExtension implements \PHPStan\Reflection\MethodsClassReflectionExtension
+class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
     use HasContainer;
 
@@ -70,7 +72,13 @@ class MacroMethodsClassReflectionExtension implements \PHPStan\Reflection\Method
                 $classNames = ['Illuminate\Auth\SessionGuard', RequestGuard::class];
                 $macroTraitProperty = 'macros';
             } else {
-                $concrete = $facadeClass::getFacadeRoot();
+                $concrete = null;
+
+                try {
+                    $concrete = $facadeClass::getFacadeRoot();
+                } catch (Exception) {
+                    //
+                }
 
                 if ($concrete) {
                     $facadeClassName = get_class($concrete);

--- a/src/Reflection/ReflectionHelper.php
+++ b/src/Reflection/ReflectionHelper.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Mixin\MixinMethodsClassReflectionExtension;
+use PHPStan\Reflection\Mixin\MixinPropertiesClassReflectionExtension;
 
 final class ReflectionHelper
 {
@@ -23,6 +25,24 @@ final class ReflectionHelper
             }
         }
 
-        return false;
+        return (new MixinPropertiesClassReflectionExtension([]))->hasProperty($classReflection, $propertyName); // @phpstan-ignore-line
+    }
+
+    /**
+     * Does the given class or any of its ancestors have an `@method*` annotation with the given name?
+     */
+    public static function hasMethodTag(ClassReflection $classReflection, string $methodName): bool
+    {
+        if (array_key_exists($methodName, $classReflection->getMethodTags())) {
+            return true;
+        }
+
+        foreach ($classReflection->getAncestors() as $ancestor) {
+            if (array_key_exists($methodName, $ancestor->getMethodTags())) {
+                return true;
+            }
+        }
+
+        return (new MixinMethodsClassReflectionExtension([]))->hasMethod($classReflection, $methodName); // @phpstan-ignore-line
     }
 }

--- a/tests/Application/app/DummyFacade.php
+++ b/tests/Application/app/DummyFacade.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static string foo()
+ * @method static int bar()
+ */
+class DummyFacade extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'dummy';
+    }
+}

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -2,6 +2,7 @@
 
 namespace Facades;
 
+use App\DummyFacade;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -39,4 +40,7 @@ function foo()
     assertType('bool', Storage::drive()->deleteDirectory('foo'));
     assertType('string|false', Storage::putFile('foo', 'foo/bar'));
     assertType('string|false', Redis::get('foo'));
+
+    assertType('string', DummyFacade::foo());
+    assertType('int', DummyFacade::bar());
 }

--- a/tests/Type/data/gate-facade.php
+++ b/tests/Type/data/gate-facade.php
@@ -8,7 +8,7 @@ use function PHPStan\Testing\assertType;
 
 function foo(): void
 {
-    assertType('Illuminate\Contracts\Auth\Access\Gate', Gate::forUser(new User()));
+    assertType('Illuminate\Auth\Access\Gate', Gate::forUser(new User()));
     assertType('Illuminate\Auth\Access\Response', Gate::inspect('foo'));
     assertType('bool', Gate::has('foo'));
 }


### PR DESCRIPTION
With this PR missing property and methods on facades first searched on annotations. If not found then the underlying facade root is checked.