### PR TITLE
fix: throw_if/unless can be called without a second argument

### DIFF
--- a/src/Types/AbortIfFunctionTypeSpecifyingExtension.php
+++ b/src/Types/AbortIfFunctionTypeSpecifyingExtension.php
@@ -44,7 +44,7 @@ final class AbortIfFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
         Scope $scope,
         TypeSpecifierContext $context
     ): SpecifiedTypes {
-        if (count($node->args) < 2) {
+        if (! str_starts_with($this->methodName, 'throw') && count($node->args) < 2) {
             return new SpecifiedTypes();
         }
 

--- a/tests/Type/data/throw.php
+++ b/tests/Type/data/throw.php
@@ -39,4 +39,32 @@ class ThrowTest
 
         assertType('int', $foo);
     }
+
+    public function testThrowIfWithoutSecondArgument(int|string $foo = 5): void
+    {
+        throw_if(is_string($foo));
+
+        assertType('int', $foo);
+    }
+
+    public function testThrowIfWithStringArgument(int|string $foo = 5): void
+    {
+        throw_if(is_string($foo), 'Exception message');
+
+        assertType('int', $foo);
+    }
+
+    public function testThrowUnlessWithoutSecondArgument(int|string $foo = 5): void
+    {
+        throw_unless(! is_string($foo));
+
+        assertType('int', $foo);
+    }
+
+    public function testThrowUnlessWithStringArgument(int|string $foo = 5): void
+    {
+        throw_unless(! is_string($foo), 'Exception message');
+
+        assertType('int', $foo);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes (not necessary I think)

**Changes**

Currently, specifying types works with `abort_if/unless` and `throw_if/unless` like this:
```php
public function test(int|string $foo = 5): void
{
    throw_if(is_string($foo), new \Exception('$foo is a string'));

    assertType('int', $foo); // this passes, Phpstan knows it can't be a string anymore
}
```

But you can also call `throw_if` without a second argument, and that currently doesn't work:
```php
public function test(int|string $foo = 5): void
{
    throw_if(is_string($foo));

    assertType('int', $foo); // this fails, Phpstan still thinks its int|string
}
```

This PR fixes this, and makes Phpstan understand the type after `throw_if/unless` is used without a second argument.



**Breaking changes**

No breaking changes that I'm aware of.
