### PR TITLE
feat (chore): run phpstan with 1 gb memory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     },
     "scripts": {
         "test:types": "phpstan analyse --ansi --memory-limit 256M",
-        "test:unit": "phpunit --colors=always -d memory_limit=2G",
+        "test:unit": "phpunit --colors=always -d memory_limit=1G",
         "test": [
             "@test:types",
             "@test:unit"

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     },
     "scripts": {
         "test:types": "phpstan analyse --ansi --memory-limit 256M",
-        "test:unit": "phpunit --colors=always -d memory_limit=1G",
+        "test:unit": "phpunit --colors=always -d memory_limit=1280M",
         "test": [
             "@test:types",
             "@test:unit"


### PR DESCRIPTION
It is possible because the recent improvement of tests.

> Time: 00:25.091, Memory: 1.14 GB

In the future this reduced memory limit will allow us to notice when tests consume more memory.