### PR TITLE
fix: schema dump could have .sql extension

### DIFF
--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -107,7 +107,7 @@ final class SquashedMigrationHelper
                 $schemaFiles += iterator_to_array(
                     new RegexIterator(
                         new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                        '/\.dump/i'
+                        '/\.dump|\.sql/i'
                     )
                 );
             }

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -55,4 +55,27 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
         $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
     }
+
+    /** @test */
+    public function it_can_find_schemas_with_sql_suffix(): void
+    {
+        $schemaParser = new SquashedMigrationHelper(
+            [__DIR__.'/data/schema/basic_schema_with_sql_extension'],
+            self::getContainer()->getByType(FileHelper::class),
+            new PhpMyAdminDataTypeToPhpTypeConverter()
+        );
+
+        $tables = $schemaParser->initializeTables();
+
+        $this->assertCount(1, $tables);
+        $this->assertArrayHasKey('accounts', $tables);
+        $this->assertCount(6, $tables['accounts']->columns);
+        $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
+        $this->assertSame('int', $tables['accounts']->columns['id']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['active']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['description']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
+    }
 }

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -78,4 +78,36 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
         $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
     }
+
+        /** @test */
+        public function it_can_find_schemas_with_different_extensions(): void
+        {
+            $schemaParser = new SquashedMigrationHelper(
+                [__DIR__.'/data/schema/multiple_schemas_with_different_extensions'],
+                self::getContainer()->getByType(FileHelper::class),
+                new PhpMyAdminDataTypeToPhpTypeConverter()
+            );
+    
+            $tables = $schemaParser->initializeTables();
+    
+            $this->assertCount(2, $tables);
+            $this->assertArrayHasKey('accounts', $tables);
+            $this->assertCount(6, $tables['accounts']->columns);
+            $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
+            $this->assertSame('int', $tables['accounts']->columns['id']->readableType);
+            $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
+            $this->assertSame('string', $tables['accounts']->columns['active']->readableType);
+            $this->assertSame('string', $tables['accounts']->columns['description']->readableType);
+            $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
+            $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
+            $this->assertArrayHasKey('users', $tables);
+            $this->assertCount(6, $tables['users']->columns);
+            $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+            $this->assertSame('int', $tables['users']->columns['id']->readableType);
+            $this->assertSame('string', $tables['users']->columns['name']->readableType);
+            $this->assertSame('string', $tables['users']->columns['active']->readableType);
+            $this->assertSame('string', $tables['users']->columns['description']->readableType);
+            $this->assertSame('string', $tables['users']->columns['created_at']->readableType);
+            $this->assertSame('string', $tables['users']->columns['updated_at']->readableType);
+        }
 }

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -79,35 +79,35 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
     }
 
-        /** @test */
-        public function it_can_find_schemas_with_different_extensions(): void
-        {
-            $schemaParser = new SquashedMigrationHelper(
-                [__DIR__.'/data/schema/multiple_schemas_with_different_extensions'],
-                self::getContainer()->getByType(FileHelper::class),
-                new PhpMyAdminDataTypeToPhpTypeConverter()
-            );
-    
-            $tables = $schemaParser->initializeTables();
-    
-            $this->assertCount(2, $tables);
-            $this->assertArrayHasKey('accounts', $tables);
-            $this->assertCount(6, $tables['accounts']->columns);
-            $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
-            $this->assertSame('int', $tables['accounts']->columns['id']->readableType);
-            $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
-            $this->assertSame('string', $tables['accounts']->columns['active']->readableType);
-            $this->assertSame('string', $tables['accounts']->columns['description']->readableType);
-            $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
-            $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
-            $this->assertArrayHasKey('users', $tables);
-            $this->assertCount(6, $tables['users']->columns);
-            $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
-            $this->assertSame('int', $tables['users']->columns['id']->readableType);
-            $this->assertSame('string', $tables['users']->columns['name']->readableType);
-            $this->assertSame('string', $tables['users']->columns['active']->readableType);
-            $this->assertSame('string', $tables['users']->columns['description']->readableType);
-            $this->assertSame('string', $tables['users']->columns['created_at']->readableType);
-            $this->assertSame('string', $tables['users']->columns['updated_at']->readableType);
-        }
+    /** @test */
+    public function it_can_find_schemas_with_different_extensions(): void
+    {
+        $schemaParser = new SquashedMigrationHelper(
+            [__DIR__.'/data/schema/multiple_schemas_with_different_extensions'],
+            self::getContainer()->getByType(FileHelper::class),
+            new PhpMyAdminDataTypeToPhpTypeConverter()
+        );
+
+        $tables = $schemaParser->initializeTables();
+
+        $this->assertCount(2, $tables);
+        $this->assertArrayHasKey('accounts', $tables);
+        $this->assertCount(6, $tables['accounts']->columns);
+        $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
+        $this->assertSame('int', $tables['accounts']->columns['id']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['active']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['description']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
+        $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
+        $this->assertArrayHasKey('users', $tables);
+        $this->assertCount(6, $tables['users']->columns);
+        $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+        $this->assertSame('int', $tables['users']->columns['id']->readableType);
+        $this->assertSame('string', $tables['users']->columns['name']->readableType);
+        $this->assertSame('string', $tables['users']->columns['active']->readableType);
+        $this->assertSame('string', $tables['users']->columns['description']->readableType);
+        $this->assertSame('string', $tables['users']->columns['created_at']->readableType);
+        $this->assertSame('string', $tables['users']->columns['updated_at']->readableType);
+    }
 }

--- a/tests/Unit/data/schema/basic_schema_with_sql_extension/accounts.sql
+++ b/tests/Unit/data/schema/basic_schema_with_sql_extension/accounts.sql
@@ -1,0 +1,19 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `accounts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `accounts` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `active` varchar(1) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/tests/Unit/data/schema/multiple_schemas_with_different_extensions/accounts.dump
+++ b/tests/Unit/data/schema/multiple_schemas_with_different_extensions/accounts.dump
@@ -1,0 +1,19 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `accounts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `accounts` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `active` varchar(1) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/tests/Unit/data/schema/multiple_schemas_with_different_extensions/users.sql
+++ b/tests/Unit/data/schema/multiple_schemas_with_different_extensions/users.sql
@@ -1,0 +1,19 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `users` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `active` varchar(1) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Since laravel/framework#45805 has merged (v9.50.0), a dumped database schema has a `.sql` extension instead of `.dump`. This PR searches for both type of file extensions.

**Breaking changes**
There are no breaking changes.
