### PR TITLE
fix: carry over collection class name for HigherOrderCollectionProxy

### DIFF
--- a/src/Methods/HigherOrderCollectionProxyExtension.php
+++ b/src/Methods/HigherOrderCollectionProxyExtension.php
@@ -33,11 +33,14 @@ final class HigherOrderCollectionProxyExtension implements MethodsClassReflectio
         /** @var Type\ObjectType $valueType */
         $valueType = $activeTemplateTypeMap->getType('TValue');
 
+        /** @var Type\ObjectType $collectionType */
+        $collectionType = $activeTemplateTypeMap->getType('TCollection');
+
         $modelMethodReflection = $valueType->getMethod($methodName, new OutOfClassScope());
 
         $modelMethodReturnType = ParametersAcceptorSelector::selectSingle($modelMethodReflection->getVariants())->getReturnType();
 
-        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $valueType, $modelMethodReturnType);
+        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $valueType, $modelMethodReturnType, $collectionType->getClassName());
 
         return new class($classReflection, $methodName, $modelMethodReflection, $returnType) implements MethodReflection
         {

--- a/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
+++ b/src/Properties/HigherOrderCollectionProxyPropertyExtension.php
@@ -31,9 +31,12 @@ final class HigherOrderCollectionProxyPropertyExtension implements PropertiesCla
         /** @var Type\ObjectType $modelType */
         $modelType = $activeTemplateTypeMap->getType('TValue');
 
+        /** @var Type\ObjectType $collectionType */
+        $collectionType = $activeTemplateTypeMap->getType('TCollection');
+
         $propertyType = $modelType->getProperty($propertyName, new OutOfClassScope())->getReadableType();
 
-        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $modelType, $propertyType);
+        $returnType = HigherOrderCollectionProxyHelper::determineReturnType($methodType->getValue(), $modelType, $propertyType, $collectionType->getClassName());
 
         return new class($classReflection, $returnType) implements PropertyReflection
         {

--- a/src/Support/HigherOrderCollectionProxyHelper.php
+++ b/src/Support/HigherOrderCollectionProxyHelper.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Support;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\HigherOrderCollectionProxy;
 use PHPStan\Reflection\ClassReflection;
@@ -24,7 +22,7 @@ class HigherOrderCollectionProxyHelper
 
         $activeTemplateTypeMap = $classReflection->getActiveTemplateTypeMap();
 
-        if ($activeTemplateTypeMap->count() !== 2) {
+        if ($activeTemplateTypeMap->count() !== 3) {
             return false;
         }
 
@@ -35,7 +33,9 @@ class HigherOrderCollectionProxyHelper
             return false;
         }
 
-        if (! $methodType instanceof Type\Constant\ConstantStringType) {
+        $constants = $methodType->getConstantStrings();
+
+        if (count($constants) !== 1) {
             return false;
         }
 
@@ -50,14 +50,8 @@ class HigherOrderCollectionProxyHelper
         return $valueType->hasProperty($name)->yes();
     }
 
-    public static function determineReturnType(string $name, Type\Type $valueType, Type\Type $methodOrPropertyReturnType): Type\Type
+    public static function determineReturnType(string $name, Type\Type $valueType, Type\Type $methodOrPropertyReturnType, string $collectionType): Type\Type
     {
-        if ((new Type\ObjectType(Model::class))->isSuperTypeOf($valueType)->yes()) {
-            $collectionType = Collection::class;
-        } else {
-            $collectionType = SupportCollection::class;
-        }
-
         $types = [new Type\IntegerType(), $valueType];
 
         switch ($name) {

--- a/stubs/EnumeratesValues.stub
+++ b/stubs/EnumeratesValues.stub
@@ -8,31 +8,31 @@ use Illuminate\Support\HigherOrderCollectionProxy;
  * @template TKey of array-key
  * @template TValue
  *
- * @property-read HigherOrderCollectionProxy<'average', TValue> $average
- * @property-read HigherOrderCollectionProxy<'avg', TValue> $avg
- * @property-read HigherOrderCollectionProxy<'contains', TValue> $contains
- * @property-read HigherOrderCollectionProxy<'each', TValue> $each
- * @property-read HigherOrderCollectionProxy<'every', TValue> $every
- * @property-read HigherOrderCollectionProxy<'filter', TValue> $filter
- * @property-read HigherOrderCollectionProxy<'first', TValue> $first
- * @property-read HigherOrderCollectionProxy<'flatMap', TValue> $flatMap
- * @property-read HigherOrderCollectionProxy<'groupBy', TValue> $groupBy
- * @property-read HigherOrderCollectionProxy<'keyBy', TValue> $keyBy
- * @property-read HigherOrderCollectionProxy<'map', TValue> $map
- * @property-read HigherOrderCollectionProxy<'max', TValue> $max
- * @property-read HigherOrderCollectionProxy<'min', TValue> $min
- * @property-read HigherOrderCollectionProxy<'partition', TValue> $partition
- * @property-read HigherOrderCollectionProxy<'reject', TValue> $reject
- * @property-read HigherOrderCollectionProxy<'some', TValue> $some
- * @property-read HigherOrderCollectionProxy<'sortBy', TValue> $sortBy
- * @property-read HigherOrderCollectionProxy<'sortByDesc', TValue> $sortByDesc
- * @property-read HigherOrderCollectionProxy<'skipUntil', TValue> $skipUntil
- * @property-read HigherOrderCollectionProxy<'skipWhile', TValue> $skipWhile
- * @property-read HigherOrderCollectionProxy<'sum', TValue> $sum
- * @property-read HigherOrderCollectionProxy<'takeUntil', TValue> $takeUntil
- * @property-read HigherOrderCollectionProxy<'takeWhile', TValue> $takeWhile
- * @property-read HigherOrderCollectionProxy<'unique', TValue> $unique
- * @property-read HigherOrderCollectionProxy<'until', TValue> $until
+ * @property-read HigherOrderCollectionProxy<'average', TValue, static> $average
+ * @property-read HigherOrderCollectionProxy<'avg', TValue, static> $avg
+ * @property-read HigherOrderCollectionProxy<'contains', TValue, static> $contains
+ * @property-read HigherOrderCollectionProxy<'each', TValue, static> $each
+ * @property-read HigherOrderCollectionProxy<'every', TValue, static> $every
+ * @property-read HigherOrderCollectionProxy<'filter', TValue, static> $filter
+ * @property-read HigherOrderCollectionProxy<'first', TValue, static> $first
+ * @property-read HigherOrderCollectionProxy<'flatMap', TValue, static> $flatMap
+ * @property-read HigherOrderCollectionProxy<'groupBy', TValue, static> $groupBy
+ * @property-read HigherOrderCollectionProxy<'keyBy', TValue, static> $keyBy
+ * @property-read HigherOrderCollectionProxy<'map', TValue, static> $map
+ * @property-read HigherOrderCollectionProxy<'max', TValue, static> $max
+ * @property-read HigherOrderCollectionProxy<'min', TValue, static> $min
+ * @property-read HigherOrderCollectionProxy<'partition', TValue, static> $partition
+ * @property-read HigherOrderCollectionProxy<'reject', TValue, static> $reject
+ * @property-read HigherOrderCollectionProxy<'some', TValue, static> $some
+ * @property-read HigherOrderCollectionProxy<'sortBy', TValue, static> $sortBy
+ * @property-read HigherOrderCollectionProxy<'sortByDesc', TValue, static> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<'skipUntil', TValue, static> $skipUntil
+ * @property-read HigherOrderCollectionProxy<'skipWhile', TValue, static> $skipWhile
+ * @property-read HigherOrderCollectionProxy<'sum', TValue, static> $sum
+ * @property-read HigherOrderCollectionProxy<'takeUntil', TValue, static> $takeUntil
+ * @property-read HigherOrderCollectionProxy<'takeWhile', TValue, static> $takeWhile
+ * @property-read HigherOrderCollectionProxy<'unique', TValue, static> $unique
+ * @property-read HigherOrderCollectionProxy<'until', TValue, static> $until
  */
 trait EnumeratesValues
 {

--- a/stubs/HigherOrderProxies.stub
+++ b/stubs/HigherOrderProxies.stub
@@ -17,6 +17,7 @@ class HigherOrderTapProxy
 /**
  * @template T
  * @template TValue
+ * @template TCollection
  */
 class HigherOrderCollectionProxy
 {}

--- a/tests/Type/data/higher-order-collection-proxy-methods.php
+++ b/tests/Type/data/higher-order-collection-proxy-methods.php
@@ -11,8 +11,9 @@ use function PHPStan\Testing\assertType;
 /**
  * @param  Collection<int, User>  $users
  * @param  SupportCollection<int, Importer>  $collection
+ * @param  SupportCollection<int, User>  $supportCollectionWithModels
  */
-function doFoo(Collection $users, User $user, SupportCollection $collection)
+function doFoo(Collection $users, User $user, SupportCollection $collection, SupportCollection $supportCollectionWithModels)
 {
     assertType('float', $users->avg->id() + $users->average->id());
     assertType('bool', $users->contains->isActive());
@@ -64,5 +65,6 @@ function doFoo(Collection $users, User $user, SupportCollection $collection)
     assertType('int', $users->sum->id);
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $users->takeUntil->email);
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $users->takeWhile->email);
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $users->unique->email);
+
+    assertType('Illuminate\Support\Collection<int, App\User>', $supportCollectionWithModels->reject->isActive());
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

This PR fixes an issue where method calls and property accesses on HigherOrderCollectionProxy resulting in wrong collection class.
