### PR TITLE
feat: add stub for transform helper method

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -155,3 +155,17 @@ function __($key = null, $replace = [], $locale = null) {}
  * @return ($callback is null ? mixed : ($value is null ? null : TReturn))
  */
 function optional($value = null, callable $callback = null) {}
+
+/**
+ * Transform the given value if it is present.
+ *
+ * @template TValue of mixed
+ * @template TReturn of mixed
+ * @template TDefault of mixed
+ *
+ * @param TValue $value
+ * @param callable(TValue): TReturn $callback
+ * @param null|TDefault|callable(TValue): TDefault $default
+ * @return ($value is empty ? ($default is null ? null : TDefault) : TReturn)
+ */
+function transform($value, callable $callback, $default = null): mixed {}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -161,3 +161,24 @@ function valueHelper()
 
     assertType('5', value(5));
 }
+
+function transformHelper()
+{
+    assertType('array|null', transform(User::first(), fn (User $user) => $user->toArray()));
+    assertType('array', transform(User::sole(), fn (User $user) => $user->toArray()));
+
+    // falls back to default if provided
+    assertType('int|string', transform(optional(), fn () => 1, 'default'));
+    // default as callable
+    assertType('int|string', transform(optional(), fn () => 1, fn () => 'string'));
+
+    // non empty values
+    assertType('int', transform('filled', fn () => 1));
+    assertType('int', transform(['filled'], fn () => 1));
+    assertType('int', transform(new User(), fn () => 1));
+
+    // "empty" values
+    assertType('null', transform(null, fn () => 1));
+    assertType('null', transform('', fn () => 1));
+    assertType('null', transform([], fn () => 1));
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds a stub method for the `transform` helper method. Previously it would always return `mixed`. Now it has the correct return type based on the passed value and callbacks.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
