### PR TITLE
fix duplicate SQL parsing and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ To get around this a baseline file can be generated. The baseline file will crea
 
 A list of configurable rules specific to Laravel can be found [here](docs/rules.md).
 
+
+## Features
+
+A list of features specific to Laravel can be found [here](docs/features.md).
+
 ## Custom PHPDoc types
 
 A list of PHPDoc types specific to Larastan can be found [here](docs/custom-types.md).

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A list of configurable rules specific to Laravel can be found [here](docs/rules.
 
 ## Features
 
-A list of features specific to Laravel can be found [here](docs/features.md).
+A list of Larastan features can be found [here](docs/features.md).
 
 ## Custom PHPDoc types
 

--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -32,6 +32,15 @@ parameters:
         - app/Domain/DomainB/schema
 ```
 
+#### PostgreSQL
+
+The package used to parse the schema dumps, [phpmyadmin/sql-parser](https://github.com/phpmyadmin/sql-parser), is primarily focused on the MySQL dialect.
+It can read (or rather, try to read) PostgreSQL dumps provided they are in the *plain text (and not the 'custom') format*, but the mileage may vary as problems have been noted with timestamp columns and lengthy parse time on more complicated dumps.
+
+The viable options for PostgreSQL at the moment are:
+1. Use the [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) package to write PHPDocs directly to the Models. 
+2. Use the [laravel-migrations-generator](https://github.com/kitloong/laravel-migrations-generator) to generate migration files (or a singular squashed migration file) for Larastan to scan with the `databaseMigrationsPath` setting.
+
 ## `checkModelProperties`
 **default**: `false`
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,38 @@
+# Rules
+
+All features that are specific to Laravel applications 
+are listed here.
+
+## Laravel 9 Attributes
+
+In order for [Laravel 9 Attributes](https://laravel.com/docs/9.x/eloquent-mutators#accessors-and-mutators) to be recognized as model properties, they must be `protected` methods annotated with the `Attribute` Generic Types.
+
+The first generic type is the getter return type, and the second is the setter argument type.
+
+#### Examples
+
+```php
+/** @return Attribute<string[], string[]> */
+protected function scopes(): Attribute
+{
+	return Attribute::make(
+		get: fn (?string $value) => is_null($value) ? [] : explode(' ', $value),
+		set: function(array $value) {
+			$set = array_unique($value);
+			sort($set);
+			return ['scopes' => implode(' ', $set)];
+		}
+	);
+}
+```
+
+```php
+/** @return Attribute<bool, never> */
+protected function isTrue(): Attribute
+{
+	return Attribute::make(
+		get: fn (?string $value): bool => $value === null,
+	);
+}
+```
+

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,4 +1,4 @@
-# Rules
+# Features
 
 All features that are specific to Laravel applications 
 are listed here.

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -51,9 +51,8 @@ final class SquashedMigrationHelper
                 continue;
             }
 
-            $parser = new Parser($fileContents);
             try {
-                $parser->parse();
+                $parser = new Parser($fileContents);
             } catch (ParserException $exception) {
                 // TODO: re-throw the exception with a clear message?
                 continue;


### PR DESCRIPTION
**Changes**
The SQL Parser calls `Parser::parse` in the constructor so I removed the duplicate call.
https://github.com/phpmyadmin/sql-parser/blob/548382794d7571d42a5e3eeb81c4278aec8e50f9/src/Parser.php#L381

I also added some docs about Laravel 9 attributes and PostgreSQL dumps.

**Breaking changes**
N/A
