### PR TITLE
feat: create options to disable migration and schema scanning

### DIFF
--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -20,6 +20,17 @@ parameters:
         - app/Domain/DomainB/migrations
 ```
 
+## `disableMigrationScan`
+**default**: `false`
+
+You can disable use this config to disable migration scanning.
+
+#### Example
+```neon
+parameters:
+    disableMigrationScan: true
+```
+
 ## `squashedMigrationsPath`
 
 By default, Larastan will check `database/schema` directory to find schema dumps. If you have them in other locations or if you have multiple folders, you can use this config option to add them.
@@ -40,6 +51,17 @@ It can read (or rather, try to read) PostgreSQL dumps provided they are in the *
 The viable options for PostgreSQL at the moment are:
 1. Use the [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) package to write PHPDocs directly to the Models. 
 2. Use the [laravel-migrations-generator](https://github.com/kitloong/laravel-migrations-generator) to generate migration files (or a singular squashed migration file) for Larastan to scan with the `databaseMigrationsPath` setting.
+
+## `disableSchemaScan`
+**default**: `false`
+
+You can disable use this config to disable schema scanning.
+
+#### Example
+```neon
+parameters:
+    disableSchemaScan: true
+```
 
 ## `checkModelProperties`
 **default**: `false`

--- a/extension.neon
+++ b/extension.neon
@@ -18,6 +18,8 @@ parameters:
     noUnnecessaryCollectionCallExcept: []
     squashedMigrationsPath: []
     databaseMigrationsPath: []
+    disableMigrationScan: false
+    disableSchemaScan: false
     viewDirectories: []
     checkModelProperties: false
     checkPhpDocMissingReturn: false
@@ -30,8 +32,10 @@ parametersSchema:
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
     databaseMigrationsPath: listOf(string())
+    disableMigrationScan: bool()
     viewDirectories: listOf(string())
     squashedMigrationsPath: listOf(string())
+    disableSchemaScan: bool()
     checkModelProperties: bool()
     checkUnusedViews: bool()
 
@@ -407,12 +411,14 @@ services:
         class: NunoMaduro\Larastan\Properties\MigrationHelper
         arguments:
             databaseMigrationPath: %databaseMigrationsPath%
+            disableMigrationScan: %disableMigrationScan%
             parser: @currentPhpVersionSimpleDirectParser
 
     -
         class: NunoMaduro\Larastan\Properties\SquashedMigrationHelper
         arguments:
             schemaPaths: %squashedMigrationsPath%
+            disableSchemaScan: %disableSchemaScan%
 
     -
         class: NunoMaduro\Larastan\Properties\ModelCastHelper

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -20,17 +20,25 @@ class MigrationHelper
     /** @var string[] */
     private $databaseMigrationPath;
 
+    /** @var bool */
+    private $disableMigrationScan;
+
     /** @var FileHelper */
     private $fileHelper;
 
     /**
      * @param  string[]  $databaseMigrationPath
      */
-    public function __construct(Parser $parser, array $databaseMigrationPath, FileHelper $fileHelper)
-    {
+    public function __construct(
+        Parser $parser,
+        array $databaseMigrationPath,
+        FileHelper $fileHelper,
+        bool $disableMigrationScan,
+    ) {
         $this->parser = $parser;
         $this->databaseMigrationPath = $databaseMigrationPath;
         $this->fileHelper = $fileHelper;
+        $this->disableMigrationScan = $disableMigrationScan;
     }
 
     /**
@@ -39,6 +47,10 @@ class MigrationHelper
      */
     public function initializeTables(array $tables = []): array
     {
+        if ($this->disableMigrationScan) {
+            return $tables;
+        }
+
         if (count($this->databaseMigrationPath) === 0) {
             $this->databaseMigrationPath = [database_path('migrations')];
         }

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -23,12 +23,17 @@ final class SquashedMigrationHelper
         private array $schemaPaths,
         private FileHelper $fileHelper,
         private PhpMyAdminDataTypeToPhpTypeConverter $converter,
+        private bool $disableSchemaScan,
     ) {
     }
 
     /** @return SchemaTable[] */
     public function initializeTables(): array
     {
+        if ($this->disableSchemaScan) {
+            return [];
+        }
+
         if (empty($this->schemaPaths)) {
             $this->schemaPaths = [database_path('schema')];
         }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -27,7 +27,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_will_return_empty_array_if_migrations_path_is_not_a_directory()
     {
-        $migrationHelper = new MigrationHelper($this->parser, ['foobar'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, ['foobar'], $this->fileHelper, false);
 
         self::assertSame([], $migrationHelper->initializeTables());
     }
@@ -35,7 +35,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_basic_migrations_and_create_table_structure()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/basic_migration'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/basic_migration'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -45,7 +45,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_schema_definitions_from_any_method_in_class()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_with_different_methods'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_with_different_methods'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -55,7 +55,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_schema_definitions_with_multiple_create_and_drop_methods_for_one_table()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/complex_migrations'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/complex_migrations'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -77,7 +77,7 @@ class MigrationHelperTest extends PHPStanTestCase
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/basic_migration',
             __DIR__.'/data/additional_migrations',
-        ], $this->fileHelper);
+        ], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -91,7 +91,7 @@ class MigrationHelperTest extends PHPStanTestCase
     {
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/migrations_using_after_method',
-        ], $this->fileHelper);
+        ], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -111,7 +111,7 @@ class MigrationHelperTest extends PHPStanTestCase
     {
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/rename_migrations',
-        ], $this->fileHelper);
+        ], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -123,7 +123,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -136,7 +136,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes_tz()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes_tz'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes_tz'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -149,11 +149,24 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_connection_before_schema_create()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migration_with_schema_connection'], $this->fileHelper);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migration_with_schema_connection'], $this->fileHelper, false);
 
         $tables = $migrationHelper->initializeTables();
 
         $this->assertUsersTableSchema($tables);
+    }
+
+    /** @test */
+    public function it_can_disable_migration_scanning(): void
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [
+            __DIR__.'/data/basic_migration',
+            __DIR__.'/data/additional_migrations',
+        ], $this->fileHelper, true);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertSame([], $tables);
     }
 
     /**

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -16,7 +16,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__.'/data/schema/basic_schema'],
             self::getContainer()->getByType(FileHelper::class),
-            new PhpMyAdminDataTypeToPhpTypeConverter()
+            new PhpMyAdminDataTypeToPhpTypeConverter(),
+            false
         );
 
         $tables = $schemaParser->initializeTables();
@@ -39,7 +40,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__.'/data/schema/multiple_schemas_for_same_table'],
             self::getContainer()->getByType(FileHelper::class),
-            new PhpMyAdminDataTypeToPhpTypeConverter()
+            new PhpMyAdminDataTypeToPhpTypeConverter(),
+            false,
         );
 
         $tables = $schemaParser->initializeTables();
@@ -62,7 +64,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__.'/data/schema/basic_schema_with_sql_extension'],
             self::getContainer()->getByType(FileHelper::class),
-            new PhpMyAdminDataTypeToPhpTypeConverter()
+            new PhpMyAdminDataTypeToPhpTypeConverter(),
+            false
         );
 
         $tables = $schemaParser->initializeTables();
@@ -85,7 +88,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__.'/data/schema/multiple_schemas_with_different_extensions'],
             self::getContainer()->getByType(FileHelper::class),
-            new PhpMyAdminDataTypeToPhpTypeConverter()
+            new PhpMyAdminDataTypeToPhpTypeConverter(),
+            false
         );
 
         $tables = $schemaParser->initializeTables();
@@ -109,5 +113,20 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame('string', $tables['users']->columns['description']->readableType);
         $this->assertSame('string', $tables['users']->columns['created_at']->readableType);
         $this->assertSame('string', $tables['users']->columns['updated_at']->readableType);
+    }
+
+    /** @test */
+    public function it_can_disable_schema_scanning(): void
+    {
+        $schemaParser = new SquashedMigrationHelper(
+            [__DIR__.'/data/schema/multiple_schemas_with_different_extensions'],
+            self::getContainer()->getByType(FileHelper::class),
+            new PhpMyAdminDataTypeToPhpTypeConverter(),
+            true
+        );
+
+        $tables = $schemaParser->initializeTables();
+
+        $this->assertSame([], $tables);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
I added options to disable migrations and schema scanning. As mentioned in #1569, Postgres schemas are scanned (which may take upwards of 7 minutes) even when they produce invalid results. This will enable the end user to simply disable scanning if desired.

**Breaking changes**
N/A