### PR TITLE
feat: console command analysis

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -497,9 +497,29 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ConsoleCommand\ArgumentDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ConsoleCommand\HasArgumentDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ConsoleCommand\OptionDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: NunoMaduro\Larastan\ReturnTypes\ConsoleCommand\HasOptionDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
     - NunoMaduro\Larastan\ReturnTypes\AppMakeHelper
+    - NunoMaduro\Larastan\Internal\ConsoleApplicationResolver
+    - NunoMaduro\Larastan\Internal\ConsoleApplicationHelper
 
 rules:
     - NunoMaduro\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule
     - NunoMaduro\Larastan\Rules\UselessConstructs\NoUselessValueFunctionCallsRule
     - NunoMaduro\Larastan\Rules\DeferrableServiceProviderMissingProvidesRule
+    - NunoMaduro\Larastan\Rules\ConsoleCommand\UndefinedArgumentOrOptionRule

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -1,10 +1,13 @@
 <?php
 
+use Illuminate\Filesystem\Filesystem;
+
 require_once __DIR__.'/vendor/autoload.php';
 
-$filesystem = new \Illuminate\Filesystem\Filesystem();
+$filesystem = new Filesystem();
 
 $filesystem->copyDirectory(__DIR__.'/tests/application/database/migrations', __DIR__.'/vendor/orchestra/testbench-core/laravel/database/migrations');
 $filesystem->copyDirectory(__DIR__.'/tests/application/database/schema', __DIR__.'/vendor/orchestra/testbench-core/laravel/database/schema');
 $filesystem->copyDirectory(__DIR__.'/tests/application/config', __DIR__.'/vendor/orchestra/testbench-core/laravel/config');
 $filesystem->copyDirectory(__DIR__.'/tests/application/resources', __DIR__.'/vendor/orchestra/testbench-core/laravel/resources');
+$filesystem->copyDirectory(__DIR__.'/tests/application/app/Console', __DIR__.'/vendor/orchestra/testbench-core/laravel/app/Console');

--- a/src/Internal/ConsoleApplicationHelper.php
+++ b/src/Internal/ConsoleApplicationHelper.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Internal;
+
+use InvalidArgumentException;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+final class ConsoleApplicationHelper
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver)
+    {
+    }
+
+    public function getArguments(ClassReflection $classReflection, Scope $scope): ?Type
+    {
+        $argTypes = [];
+
+        foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+            try {
+                $arguments = $command->getDefinition()->getArguments();
+                $builder = ConstantArrayTypeBuilder::createEmpty();
+
+                foreach ($arguments as $name => $argument) {
+                    $argumentType = $this->getArgumentType($scope, $argument);
+                    $builder->setOffsetValueType(new ConstantStringType($name), $argumentType);
+                }
+
+                $argTypes[] = $builder->getArray();
+            } catch (InvalidArgumentException) {
+                // noop
+            }
+        }
+
+        return count($argTypes) > 0 ? TypeCombinator::union(...$argTypes) : null;
+    }
+
+    public function getArgumentType(Scope $scope, InputArgument $argument): Type
+    {
+        if ($argument->isArray()) {
+            $argType = new ArrayType(new IntegerType(), new StringType());
+
+            if (! $argument->isRequired() && $argument->getDefault() !== []) {
+                $argType = TypeCombinator::union($argType, $scope->getTypeFromValue($argument->getDefault()));
+            }
+        } else {
+            $argType = new StringType();
+
+            if (! $argument->isRequired()) {
+                $argType = TypeCombinator::union($argType, $scope->getTypeFromValue($argument->getDefault()));
+            }
+        }
+
+        return $argType;
+    }
+
+    public function getOptions(ClassReflection $classReflection, Scope $scope): ?Type
+    {
+        $optTypes = [];
+
+        foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+            try {
+                $options = $command->getDefinition()->getOptions();
+                $builder = ConstantArrayTypeBuilder::createEmpty();
+                foreach ($options as $name => $option) {
+                    $argumentType = $this->getOptionType($scope, $option);
+                    $builder->setOffsetValueType(new ConstantStringType($name), $argumentType);
+                }
+
+                $optTypes[] = $builder->getArray();
+            } catch (InvalidArgumentException) {
+                // noop
+            }
+        }
+
+        return count($optTypes) > 0 ? TypeCombinator::union(...$optTypes) : null;
+    }
+
+    public function getOptionType(Scope $scope, InputOption $option): Type
+    {
+        if (! $option->acceptValue()) {
+            if ($option->isNegatable()) {
+                return new UnionType([new BooleanType(), new NullType()]);
+            }
+
+            return new BooleanType();
+        }
+
+        $optType = TypeCombinator::union(new StringType(), new NullType());
+
+        if ($option->isValueRequired() && ($option->isArray() || $option->getDefault() !== null)) {
+            $optType = TypeCombinator::removeNull($optType);
+        }
+
+        if ($option->isArray()) {
+            $optType = new ArrayType(new IntegerType(), $optType);
+        }
+
+        return TypeCombinator::union($optType, $scope->getTypeFromValue($option->getDefault()));
+    }
+}

--- a/src/Internal/ConsoleApplicationResolver.php
+++ b/src/Internal/ConsoleApplicationResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Internal;
+
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ObjectType;
+
+/** @internal */
+final class ConsoleApplicationResolver
+{
+    private ?Application $application = null;
+
+    /**
+     * @return Command[]
+     */
+    public function findCommands(ClassReflection $classReflection): array
+    {
+        $consoleApplication = $this->getApplication();
+
+        $classType = new ObjectType($classReflection->getName());
+
+        if (! (new ObjectType('Illuminate\Console\Command'))->isSuperTypeOf($classType)->yes()) {
+            return [];
+        }
+
+        $commands = [];
+
+        foreach ($consoleApplication->all() as $name => $command) {
+            if (! $classType->isSuperTypeOf(new ObjectType(get_class($command)))->yes()) {
+                continue;
+            }
+
+            $commands[$name] = $command;
+        }
+
+        return $commands; // @phpstan-ignore-line
+    }
+
+    private function getApplication(): Application
+    {
+        if ($this->application === null) {
+            $this->application = new Application(app(Container::class), app(Dispatcher::class), app()->version());
+        }
+
+        return $this->application;
+    }
+}

--- a/src/ReturnTypes/ConsoleCommand/ArgumentDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ConsoleCommand/ArgumentDynamicReturnTypeExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\ReturnTypes\ConsoleCommand;
+
+use InvalidArgumentException;
+use NunoMaduro\Larastan\Internal\ConsoleApplicationHelper;
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class ArgumentDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver, private ConsoleApplicationHelper $consoleApplicationHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return 'Illuminate\Console\Command';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['argument', 'arguments'], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+
+        $defaultReturnType = ParametersAcceptorSelector::selectFromArgs($scope, $methodCall->getArgs(), $methodReflection->getVariants())->getReturnType();
+
+        if ($args === [] || $methodReflection->getName() === 'arguments') {
+            return $this->consoleApplicationHelper->getArguments($classReflection, $scope);
+        }
+
+        $argStrings = $scope->getType($args[0]->value)->getConstantStrings();
+
+        if (count($argStrings) === 0) {
+            return null;
+        }
+
+        $returnTypes = [];
+
+        foreach ($argStrings as $argString) {
+            $argName = $argString->getValue();
+
+            $argTypes = [];
+
+            foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+                try {
+                    $command->mergeApplicationDefinition();
+                    $argument = $command->getDefinition()->getArgument($argName);
+
+                    $argTypes[] = $this->consoleApplicationHelper->getArgumentType($scope, $argument);
+                } catch (InvalidArgumentException) {
+                    // noop
+                }
+
+                $returnTypes[] = count($argTypes) > 0 ? TypeCombinator::union(...$argTypes) : $defaultReturnType;
+            }
+        }
+
+        return count($returnTypes) > 0 ? TypeCombinator::union(...$returnTypes) : null;
+    }
+}

--- a/src/ReturnTypes/ConsoleCommand/HasArgumentDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ConsoleCommand/HasArgumentDynamicReturnTypeExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes\ConsoleCommand;
+
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+class HasArgumentDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return 'Illuminate\Console\Command';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'hasArgument';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        if ($methodCall->getArgs() === []) {
+            return null;
+        }
+
+        $constantStrings = $scope->getType($methodCall->getArgs()[0]->value)->getConstantStrings();
+
+        if (count($constantStrings) !== 1) {
+            return null;
+        }
+
+        $returnTypes = [];
+
+        foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+            $command->mergeApplicationDefinition();
+            $returnTypes[] = $command->getDefinition()->hasArgument($constantStrings[0]->getValue());
+        }
+
+        if (count($returnTypes) === 0) {
+            return null;
+        }
+
+        $returnTypes = array_unique($returnTypes);
+
+        return count($returnTypes) === 1 ? new ConstantBooleanType($returnTypes[0]) : null;
+    }
+}

--- a/src/ReturnTypes/ConsoleCommand/HasOptionDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ConsoleCommand/HasOptionDynamicReturnTypeExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes\ConsoleCommand;
+
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+class HasOptionDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return 'Illuminate\Console\Command';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'hasOption';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        if ($methodCall->getArgs() === []) {
+            return null;
+        }
+
+        $constantStrings = $scope->getType($methodCall->getArgs()[0]->value)->getConstantStrings();
+
+        if (count($constantStrings) !== 1) {
+            return null;
+        }
+
+        $argName = $constantStrings[0]->getValue();
+
+        $returnTypes = [];
+
+        foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+            $command->mergeApplicationDefinition();
+            $returnTypes[] = $command->getDefinition()->hasOption($argName) || $command->getDefinition()->hasShortcut($argName);
+        }
+
+        if (count($returnTypes) === 0) {
+            return null;
+        }
+
+        $returnTypes = array_unique($returnTypes);
+
+        return count($returnTypes) === 1 ? new ConstantBooleanType($returnTypes[0]) : null;
+    }
+}

--- a/src/ReturnTypes/ConsoleCommand/OptionDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ConsoleCommand/OptionDynamicReturnTypeExtension.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes\ConsoleCommand;
+
+use InvalidArgumentException;
+use NunoMaduro\Larastan\Internal\ConsoleApplicationHelper;
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class OptionDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver, private ConsoleApplicationHelper $consoleApplicationHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return 'Illuminate\Console\Command';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['option', 'options'], true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+
+        $defaultReturnType = ParametersAcceptorSelector::selectFromArgs($scope, $methodCall->getArgs(), $methodReflection->getVariants())->getReturnType();
+
+        if ($args === [] || $methodReflection->getName() === 'options') {
+            return $this->consoleApplicationHelper->getOptions($classReflection, $scope);
+        }
+
+        $argStrings = $scope->getType($args[0]->value)->getConstantStrings();
+
+        if (count($argStrings) === 0) {
+            return null;
+        }
+
+        $returnTypes = [];
+
+        foreach ($argStrings as $argString) {
+            $argName = $argString->getValue();
+
+            $argTypes = [];
+
+            foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {
+                try {
+                    $command->mergeApplicationDefinition();
+                    $definition = $command->getDefinition();
+
+                    if ($definition->hasShortcut($argName)) {
+                        $argument = $definition->getOptionForShortcut($argName);
+                    } else {
+                        $argument = $definition->getOption($argName);
+                    }
+
+                    $argTypes[] = $this->consoleApplicationHelper->getOptionType($scope, $argument);
+                } catch (InvalidArgumentException) {
+                    // noop
+                }
+
+                $returnTypes[] = count($argTypes) > 0 ? TypeCombinator::union(...$argTypes) : $defaultReturnType;
+            }
+        }
+
+        return count($returnTypes) > 0 ? TypeCombinator::union(...$returnTypes) : null;
+    }
+}

--- a/src/Rules/ConsoleCommand/UndefinedArgumentOrOptionRule.php
+++ b/src/Rules/ConsoleCommand/UndefinedArgumentOrOptionRule.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Rules\ConsoleCommand;
+
+use function count;
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use function sprintf;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+final class UndefinedArgumentOrOptionRule implements Rule
+{
+    public function __construct(private ConsoleApplicationResolver $consoleApplicationResolver)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @return RuleError[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return [];
+        }
+
+        if (! (new ObjectType('Illuminate\Console\Command'))->isSuperTypeOf(new ObjectType($classReflection->getName()))->yes()) {
+            return [];
+        }
+
+        if (! (new ObjectType('Illuminate\Console\Command'))->isSuperTypeOf($scope->getType($node->var))->yes()) {
+            return [];
+        }
+
+        if (! $node->name instanceof Node\Identifier || ! in_array($node->name->name, ['argument', 'option'], true)) {
+            return [];
+        }
+
+        $methodName = $node->name->name;
+
+        if (count($node->getArgs()) !== 1) {
+            return [];
+        }
+
+        $argType = $scope->getType($node->getArgs()[0]->value);
+
+        $argStrings = $argType->getConstantStrings();
+
+        if (count($argStrings) !== 1) {
+            return [];
+        }
+
+        $argName = $argStrings[0]->getValue();
+
+        $errors = [];
+
+        foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $name => $command) {
+            $command->mergeApplicationDefinition();
+
+            if ($methodName === 'argument') {
+                if (! $command->getDefinition()->hasArgument($argName)) {
+                    $errors[] = RuleErrorBuilder::message(sprintf('Command "%s" does not have argument "%s".', $name, $argName))
+                        ->line($node->getLine())
+                        ->identifier('larastan.undefinedArgument')
+                        ->build();
+                }
+            } elseif (! $command->getDefinition()->hasOption($argName) && ! $command->getDefinition()->hasShortcut($argName)) {
+                $errors[] = RuleErrorBuilder::message(sprintf('Command "%s" does not have option "%s".', $name, $argName))
+                    ->line($node->getLine())
+                    ->identifier('larastan.undefinedOption')
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Rules/UndefinedArgumentOrOptionRuleTest.php
+++ b/tests/Rules/UndefinedArgumentOrOptionRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use NunoMaduro\Larastan\Internal\ConsoleApplicationResolver;
+use NunoMaduro\Larastan\Rules\ConsoleCommand\UndefinedArgumentOrOptionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<UndefinedArgumentOrOptionRule> */
+class UndefinedArgumentOrOptionRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new UndefinedArgumentOrOptionRule(self::getContainer()->getByType(ConsoleApplicationResolver::class));
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/../application/app/Console/Commands/FooCommand.php',
+            __DIR__.'/../application/app/Console/Commands/BarCommand.php',
+            __DIR__.'/../application/app/Console/Commands/BazCommand.php',
+        ], [
+            [
+                'Command "foo" does not have argument "foobar".',
+                21,
+            ],
+            [
+                'Command "foo" does not have option "foobar".',
+                35,
+            ],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__.'/phpstan-rules.neon',
+        ];
+    }
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -52,6 +52,13 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/gate-facade.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/helpers.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
+
+        //##############################################################################################################
+
+        // Console Commands
+        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/FooCommand.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BarCommand.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BazCommand.php');
     }
 
     /**

--- a/tests/application/app/Console/Commands/BarCommand.php
+++ b/tests/application/app/Console/Commands/BarCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use function PHPStan\Testing\assertType;
+
+class BarCommand extends Command
+{
+    protected $signature = 'bar {argumentArray*} {--optionArray=*}';
+
+    protected $description = 'Dummy command used to test console command types.';
+
+    public function handle(): void
+    {
+        assertType('array{argumentArray: array<int, string>}', $this->argument());
+        assertType('array{argumentArray: array<int, string>}', $this->arguments());
+        assertType('array<int, string>', $this->argument('argumentArray'));
+
+        assertType('true', $this->hasArgument('argumentArray'));
+
+        assertType('array{optionArray: array<int, string|null>, help: bool, quiet: bool, verbose: bool, version: bool, ansi: bool|null, no-interaction: bool, env: string|null}', $this->options());
+        assertType('array{optionArray: array<int, string|null>, help: bool, quiet: bool, verbose: bool, version: bool, ansi: bool|null, no-interaction: bool, env: string|null}', $this->option());
+        assertType('array<int, string|null>', $this->option('optionArray'));
+
+        assertType('true', $this->hasOption('optionArray'));
+    }
+}

--- a/tests/application/app/Console/Commands/BazCommand.php
+++ b/tests/application/app/Console/Commands/BazCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use function PHPStan\Testing\assertType;
+
+class BazCommand extends Command
+{
+    protected $signature = 'baz {optionalArgumentArray?*}';
+
+    protected $description = 'Dummy command used to test console command types.';
+
+    public function handle(): void
+    {
+        assertType('array{optionalArgumentArray: array<int, string>}', $this->argument());
+        assertType('array{optionalArgumentArray: array<int, string>}', $this->arguments());
+        assertType('array<int, string>', $this->argument('optionalArgumentArray'));
+
+        assertType('true', $this->hasArgument('optionalArgumentArray'));
+    }
+}

--- a/tests/application/app/Console/Commands/FooCommand.php
+++ b/tests/application/app/Console/Commands/FooCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use function PHPStan\Testing\assertType;
+
+class FooCommand extends Command
+{
+    protected $signature = 'foo {argument} {optionalArg?} {optionalArgWithDefault=1} {--O|option} {--optionWithValue=}';
+
+    protected $description = 'Dummy command used to test console command types.';
+
+    public function handle(): void
+    {
+        assertType('array{argument: string, optionalArg: string|null, optionalArgWithDefault: string}', $this->argument());
+        assertType('array{argument: string, optionalArg: string|null, optionalArgWithDefault: string}', $this->arguments());
+        assertType('string', $this->argument('argument'));
+        assertType('string|null', $this->argument('optionalArg'));
+        assertType('string', $this->argument('optionalArgWithDefault'));
+        assertType('array|bool|string|null', $this->argument('foobar'));
+
+        assertType('true', $this->hasArgument('argument'));
+        assertType('true', $this->hasArgument('optionalArg'));
+        assertType('true', $this->hasArgument('optionalArgWithDefault'));
+        assertType('false', $this->hasArgument('foobar'));
+
+        assertType('array{option: bool, optionWithValue: string|null, help: bool, quiet: bool, verbose: bool, version: bool, ansi: bool|null, no-interaction: bool, env: string|null}', $this->options());
+        assertType('array{option: bool, optionWithValue: string|null, help: bool, quiet: bool, verbose: bool, version: bool, ansi: bool|null, no-interaction: bool, env: string|null}', $this->option());
+        assertType('bool', $this->option('O'));
+        assertType('bool', $this->option('option'));
+        assertType('string|null', $this->option('optionWithValue'));
+        assertType('bool', $this->option('help'));
+        assertType('bool', $this->option('v'));
+        assertType('array|bool|string|null', $this->option('foobar'));
+
+        assertType('true', $this->hasOption('O'));
+        assertType('true', $this->hasOption('option'));
+        assertType('true', $this->hasOption('optionWithValue'));
+        assertType('true', $this->hasOption('help'));
+        assertType('true', $this->hasOption('v'));
+        assertType('false', $this->hasOption('foobar'));
+    }
+}

--- a/tests/application/app/Console/Kernel.php
+++ b/tests/application/app/Console/Kernel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console;
+
+use App\Console\Commands\BarCommand;
+use App\Console\Commands\BazCommand;
+use App\Console\Commands\FooCommand;
+use Illuminate\Console\Application as Artisan;
+
+class Kernel extends \Illuminate\Foundation\Console\Kernel
+{
+    protected function commands(): void
+    {
+        Artisan::starting(function ($artisan) {
+            $artisan->resolve(FooCommand::class);
+            $artisan->resolve(BarCommand::class);
+            $artisan->resolve(BazCommand::class);
+        });
+    }
+
+    protected function bootstrappers(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
This PR adds console command analysis. 
- It infers more specific types for `argument`, `arguments`, `option` and `options` methods.
- Adds 2 new rules to find undefined argument or option usages.

**Breaking changes**

N/A
