### PR TITLE
fix: `transform` callable argument is never null

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -163,9 +163,9 @@ function optional($value = null, callable $callback = null) {}
  * @template TReturn of mixed
  * @template TDefault of mixed
  *
- * @param TValue $value
+ * @param TValue|null $value
  * @param callable(TValue): TReturn $callback
- * @param null|TDefault|callable(TValue): TDefault $default
- * @return ($value is empty ? ($default is null ? null : TDefault) : TReturn)
+ * @param TDefault|callable(TValue|null): TDefault $default
+ * @return ($value is empty ? TDefault : TReturn)
  */
 function transform($value, callable $callback, $default = null): mixed {}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -17,6 +17,7 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__.'/data/test-case-extension.php'];
         yield [__DIR__.'/data/model-properties.php'];
         yield [__DIR__.'/data/blade-view.php'];
+        yield [__DIR__.'/data/helpers.php'];
     }
 
     /**

--- a/tests/Integration/data/helpers.php
+++ b/tests/Integration/data/helpers.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\User;
+
+function transformAcceptsNonNullableCallable(): void
+{
+    transform(User::first(), fn (User $user) => $user->toArray());
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] ~Documented user facing changes~

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Fixes an issue where the `$callback` parameter in `transform` is still expected to have a nullable argument. It surfaced during testing in our project where it gave the following error:

```
 Parameter #2 $callback of function transform expects callable(\App\User): array, Closure(\App\User): array given.
```

Also simplifies the conditional return type as suggested by @lptn in #1551.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

None.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
