### PR TITLE
Fix stub for Builder::havingBetween()

### DIFF
--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -149,12 +149,12 @@ class Builder
      * Add a "having between " clause to the query.
      *
      * @param  string  $column
-     * @param  array<string, mixed>  $values
+     * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function havingBetween($column, array $values, $boolean = 'and', $not = false);
+    public function havingBetween($column, iterable $values, $boolean = 'and', $not = false);
 
     /**
      * Add an "order by" clause to the query.


### PR DESCRIPTION
havingBetween accepts `iterable`, not arrays only:

https://github.com/laravel/framework/blob/136ed754f2d80e5c7cd407a4262eb2eac478e7e8/src/Illuminate/Database/Query/Builder.php#L2221-L2243
