### PR TITLE
fix: internal error with macros defined by a string

### DIFF
--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -104,7 +104,23 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                     if ($found) {
                         $macroDefinition = $refProperty->getValue()[$methodName];
 
-                        if (is_array($macroDefinition)) {
+                        if (is_string($macroDefinition)) {
+                            if (str_contains($macroDefinition, '::')) {
+                                $macroDefinition = explode('::', $macroDefinition, 2);
+                                $macroClassName = $macroDefinition[0];
+                                if (! $this->reflectionProvider->hasClass($macroClassName) || ! $this->reflectionProvider->getClass($macroClassName)->hasNativeMethod($macroDefinition[1])) {
+                                    throw new ShouldNotHappenException('Class '.$macroClassName.' does not exist');
+                                }
+
+                                $methodReflection = $this->reflectionProvider->getClass($macroClassName)->getNativeMethod($macroDefinition[1]);
+                            } elseif (is_callable($macroDefinition)) {
+                                $methodReflection = new Macro(
+                                    $macroClassReflection, $methodName, $this->closureTypeFactory->fromClosureObject(\Closure::fromCallable($macroDefinition))
+                                );
+                            } else {
+                                throw new ShouldNotHappenException('Function '.$macroDefinition.' does not exist');
+                            }
+                        } elseif (is_array($macroDefinition)) {
                             $macroClassName = get_class($macroDefinition[0]);
                             if ($macroClassName === false || ! $this->reflectionProvider->hasClass($macroClassName) || ! $this->reflectionProvider->getClass($macroClassName)->hasNativeMethod($macroDefinition[1])) {
                                 throw new ShouldNotHappenException('Class '.$macroClassName.' does not exist');

--- a/tests/Type/data/macros.php
+++ b/tests/Type/data/macros.php
@@ -9,10 +9,12 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use PHPStan\TrinaryLogic;
+
 use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
-use PHPStan\TrinaryLogic;
 
 try {
     Request::validate([]);
@@ -30,5 +32,8 @@ assertType('int', Auth::requestGuardMacro());
 
 assertType('string', collect([])->customCollectionMacro());
 assertType('string', Collection::customCollectionMacro());
+
+assertType('string', Str::trimMacro(''));
+assertType('string', Str::asciiAliasMacro(''));
 
 assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,9 @@ Carbon::macro('foo', static function (): string {
     return 5;
 });
 
+\Illuminate\Support\Str::macro('trimMacro', 'trim');
+\Illuminate\Support\Str::macro('asciiAliasMacro', \Illuminate\Support\Str::class.'::ascii');
+
 class CustomCollectionMacro
 {
     public function registerMacro()


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

While digging into Larastan's code,  I've noticed some cases with the macros were not handled properly, causing internal errors:

```
 -- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
     Error                                                                                                                                                                                                                                                                               
 -- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
     Internal error: Internal error: PHPStan\Type\ClosureTypeFactory::fromClosureObject(): Argument #1 ($closure) must be of type Closure, string given, called in /code/repro-larastan-factory-mixin/vendor/nunomaduro/larastan/src/Methods/MacroMethodsClassReflectionExtension.php on  
     line 116 in file /code/repro-larastan-factory-mixin/app/demo.php                                                                                                                                                                                                                    
     Run PHPStan with -v option and post the stack trace to:                                                                                                                                                                                                                             
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md                                                                                                                                                                                                                
     Child process error (exit code 1):                                                                                                                                                                                                                                                  
 -- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

**Changes**

Handle macros declared like this:
```php
\Illuminate\Support\Str::macro('trimMacro', 'trim');
\Illuminate\Support\Str::macro('asciiAliasMacro', \Illuminate\Support\Str::class.'::ascii');
```

**Breaking changes**

none
