### PR TITLE
Fix dropColumn() migrations when they contain arrays

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -207,6 +207,14 @@ final class SchemaAggregator
                     }
 
                     if (! $firstArg instanceof PhpParser\Node\Scalar\String_) {
+                        if ($firstArg instanceof PhpParser\Node\Expr\Array_ && $firstMethodCall->name->name === 'dropColumn') {
+                            foreach ($firstArg->items as $array_item) {
+                                if ($array_item !== null && $array_item->value instanceof PhpParser\Node\Scalar\String_) {
+                                    $table->dropColumn($array_item->value->value);
+                                }
+                            }
+                        }
+
                         if ($firstMethodCall->name->name === 'timestamps'
                             || $firstMethodCall->name->name === 'timestampsTz'
                             || $firstMethodCall->name->name === 'nullableTimestamps'

--- a/tests/Unit/data/complex_migrations/2020_01_31_000000_alter_users_table.php
+++ b/tests/Unit/data/complex_migrations/2020_01_31_000000_alter_users_table.php
@@ -33,6 +33,8 @@ class AlterUsersTable extends Migration
             $table->bigIncrements('id');
             $table->string('name')->nullable();
             $table->string('email')->unique();
+            $table->string('address1')->nullable();
+            $table->string('address2')->nullable();
             $table->date('birthday');
             $table->timestamps();
         });
@@ -42,6 +44,7 @@ class AlterUsersTable extends Migration
     {
         Schema::table('users', static function (Blueprint $table) {
             $table->dropColumn('name');
+            $table->dropColumn(['address1', 'address2']);
             $table->integer('active');
         });
     }


### PR DESCRIPTION
- [x] Added or updated tests
~~Documented user facing changes~~


**Issue**
Larastan parses migrations but only handles`dropColumn()` if a string is passed in.
```php
$table->dropColumn('column') //This line works
$table->dropColumn(['address1','address2']); //This line is ignored
```

**Changes**
This PR has fixed that issue and added a test to check.
