### PR TITLE
Filter out null from callback in `when` method

### DIFF
--- a/stubs/Conditionable.stub
+++ b/stubs/Conditionable.stub
@@ -12,7 +12,7 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return (TWhenReturnType is void|null ? $this : TWhenReturnType)

--- a/tests/Type/data/conditionable.php
+++ b/tests/Type/data/conditionable.php
@@ -25,6 +25,11 @@ assertType('int', (new Foo())->when(true, function (Foo $foo): int {
     return rand();
 }));
 
+// Test to make sure the callback has a non-null value.
+(new Foo())->when(User::first(), function (Foo $foo, $user): void {
+    assertType(User::class, $user);
+});
+
 assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
     // do nothing
 }));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
When passing a value that has a type of `string|null` to Laravel's `when` method I'd expect to be able to narrow that type to `string` for the second parameter.

**Breaking changes**
—

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
