### PR TITLE
fix: correct return type of `Illuminate\Database\Query\Builder::pluck()` in stubs/QueryBuilder.stub

### DIFF
--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -188,7 +188,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
             return [$this->formatError($name->toString())];
         } elseif ($this->isRiskyParamMethod($name)) {
             if (count($node->args) === 0) {
-                // Calling e.g. DB::table()->pluck($columnName)-sum()
+                // Calling e.g. DB::table()->pluck($columnName)->sum()
                 // We have to check whether $columnName is actually a database column
                 // and not an alias for some computed attribute
                 if ($previousCall->name->name === 'pluck' && $this->firstArgIsDatabaseColumn($previousCall, $scope)) {

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -210,7 +210,7 @@ class Builder
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  string|null  $key
-     * @return \Illuminate\Support\Collection<string, mixed>
+     * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function pluck($column, $key = null);
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -15,6 +15,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
     {
         yield from $this->gatherAssertTypes(__DIR__.'/data/request-object.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/query-builder.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');

--- a/tests/Type/data/query-builder.php
+++ b/tests/Type/data/query-builder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EloquentBuilder;
+
+use Illuminate\Support\Facades\DB;
+
+use function PHPStan\Testing\assertType;
+
+function testPluckReturnType()
+{
+    $record = DB::table('user')->pluck('email', 'id');
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', $record);
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

