### PR TITLE
test: Fix the line numbers after CS changes

### DIFF
--- a/tests/Rules/UndefinedArgumentOrOptionRuleTest.php
+++ b/tests/Rules/UndefinedArgumentOrOptionRuleTest.php
@@ -26,11 +26,11 @@ class UndefinedArgumentOrOptionRuleTest extends RuleTestCase
         ], [
             [
                 'Command "foo" does not have argument "foobar".',
-                21,
+                22,
             ],
             [
                 'Command "foo" does not have option "foobar".',
-                35,
+                36,
             ],
         ]);
     }


### PR DESCRIPTION
**Changes**

The unit tests fail since fcec74837c88ad84d4ebc137ebbb3235533e7711.
It went undetected because of the usage of `[skip ci]` in the commit message.

**Breaking changes**

n/a
