### PR TITLE
fix: Http/Request.stub types are incorrect

### DIFF
--- a/stubs/Http/Request.stub
+++ b/stubs/Http/Request.stub
@@ -12,7 +12,7 @@ class Request {
      * @param  string|null  $key
      * @param  TDefault $default
      *
-     * @return ($key is null ? array<string, string> : string|TDefault)
+     * @return ($key is null ? array<string, array<int, string>> : string|TDefault)
      */
     public function header($key = null, $default = null);
 }

--- a/stubs/Http/Request.stub
+++ b/stubs/Http/Request.stub
@@ -12,7 +12,7 @@ class Request {
      * @param  string|null  $key
      * @param  TDefault $default
      *
-     * @return ($key is null ? array<string, array<int, string>> : string|TDefault)
+     * @return ($key is null ? array<string, array<int, string|null>> : string|TDefault)
      */
     public function header($key = null, $default = null);
 }

--- a/tests/Type/data/request-header.php
+++ b/tests/Type/data/request-header.php
@@ -7,6 +7,6 @@ namespace RequestHeader;
 use function PHPStan\Testing\assertType;
 
 /** @var \Illuminate\Http\Request $request */
-assertType('array<string, string>', $request->header());
+assertType('array<string, array<int, string|null>>', $request->header());
 assertType('string|null', $request->header('key'));
 assertType('string', $request->header('key', 'default'));


### PR DESCRIPTION
The documented type is incorrect. When not passing a key the result will be a map of headers:

```php
[
  "accept": ["text/html, application/xhtml+xml"],
  "user-agent": ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"],
  // ...
]
```