### PR TITLE
fix: consider camel cased relations in relation count property

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -50,7 +50,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         if (str_ends_with($propertyName, '_count')) {
-            $propertyName = Str::before($propertyName, '_count');
+            $propertyName = Str::camel(Str::before($propertyName, '_count'));
         }
 
         $hasNativeMethod = $classReflection->hasNativeMethod($propertyName);

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -72,7 +72,7 @@ function test(User $user, \App\Address $address, Account $account, ExtendsModelW
     // Relationship counts
     assertType('int<0, max>', $user->group_count);
     assertType('int<0, max>', $user->accounts_count);
-    assertType('int<0, max>', $user->syncableRelation_count);
+    assertType('int<0, max>', $user->syncable_relation_count);
 
     $users = (new Post())->users();
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $users->getEager());


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR fixes an issue with when camel cased relation names used in relation count property.

**Breaking changes**

n/a
