### PR TITLE
feat: Add support for uuid field with default name

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -239,13 +239,18 @@ final class SchemaAggregator
                             continue;
                         }
 
-                        if ($firstMethodCall->name->name === 'softDeletes'
-                            || $firstMethodCall->name->name === 'softDeletesTz'
-                            || $firstMethodCall->name->name === 'dropSoftDeletes'
-                            || $firstMethodCall->name->name === 'dropSoftDeletesTz'
-                        ) {
-                            $columnName = 'deleted_at';
-                        } else {
+                        $defaultsMap = [
+                            'softDeletes' => 'deleted_at',
+                            'softDeletesTz' => 'deleted_at',
+                            'dropSoftDeletes' => 'deleted_at',
+                            'dropSoftDeletesTz' => 'deleted_at',
+
+                            'uuid' => 'uuid',
+                        ];
+                        if (array_key_exists($firstMethodCall->name->name, $defaultsMap)) {
+                            $columnName = $defaultsMap[$firstMethodCall->name->name];
+                        }
+                        else {
                             continue;
                         }
                     } else {

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -244,13 +244,11 @@ final class SchemaAggregator
                             'softDeletesTz' => 'deleted_at',
                             'dropSoftDeletes' => 'deleted_at',
                             'dropSoftDeletesTz' => 'deleted_at',
-
                             'uuid' => 'uuid',
                         ];
                         if (array_key_exists($firstMethodCall->name->name, $defaultsMap)) {
                             $columnName = $defaultsMap[$firstMethodCall->name->name];
-                        }
-                        else {
+                        } else {
                             continue;
                         }
                     } else {

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -79,4 +79,5 @@ function foo(User $user, Account $account, Role $role, Group $group, Team $team,
     assertType('int', $address->foreign_id_constrained);
     assertType('int|null', $address->nullable_foreign_id_constrained);
     assertType('App\ValueObjects\Favorites', $user->favorites);
+    assertType('string', $address->uuid);
 }

--- a/tests/application/database/migrations/2021_09_10_000000_create_addresses_table.php
+++ b/tests/application/database/migrations/2021_09_10_000000_create_addresses_table.php
@@ -19,6 +19,7 @@ class CreateAddressesTable extends Migration
     {
         Schema::create('addresses', static function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->uuid();
             $table->foreignIdFor(User::class);
             $table->foreignIdFor(User::class, 'custom_foreign_id_for_name');
             $table->foreignIdFor(Address::class);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves https://github.com/nunomaduro/larastan/issues/1436

**Changes**

Currently when `SchemaAggregator::processColumnUpdates` processed `Blueprint::uuid` method without parameters it skips that statement.
This PR corrected the `SchemaAggregator::processColumnUpdates` method to add a uuid column to the processed table.

**Breaking changes**

No

