### PR TITLE
fix: Migrations in different directories are not correctly sorted

### DIFF
--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -62,7 +62,9 @@ class MigrationHelper
             return $tables;
         }
 
-        ksort($filesArray);
+        uasort($filesArray, function (SplFileInfo $a, SplFileInfo $b) {
+            return $a->getFilename() <=> $b->getFilename();
+        });
 
         foreach ($filesArray as $file) {
             try {


### PR DESCRIPTION
* Sort by filename instead, as Laravel would handle it.

Fixes #1528

Before:

```
database/migrations/2023_06_09_160908_adjust_survey_table.php ...
vendor/i-ourcompany/l-our-module/src/Database/migrations/2019_08_01_135714_create_surveys_table.php
```

After:

```
vendor/i-ourcompany/l-our-module/src/Database/migrations/2019_08_01_135714_create_surveys_table.php ...
database/migrations/2023_06_09_160908_adjust_survey_table.php
```

- [no] Added or updated tests
- [no] Documented user facing changes

**Changes**

Sorting of migraton files is corrected.

**Breaking changes**

The behavior is changes, but it is a bug fix of course.
