### PR TITLE
fix: proper type resolving for `foreignIdFor` fields

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -413,6 +413,7 @@ services:
             databaseMigrationPath: %databaseMigrationsPath%
             disableMigrationScan: %disableMigrationScan%
             parser: @currentPhpVersionSimpleDirectParser
+            reflectionProvider: @reflectionProvider
 
     -
         class: NunoMaduro\Larastan\Properties\SquashedMigrationHelper

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -7,6 +7,7 @@ namespace NunoMaduro\Larastan\Properties;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
+use PHPStan\Reflection\ReflectionProvider;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
@@ -26,6 +27,9 @@ class MigrationHelper
     /** @var FileHelper */
     private $fileHelper;
 
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
     /**
      * @param  string[]  $databaseMigrationPath
      */
@@ -34,11 +38,13 @@ class MigrationHelper
         array $databaseMigrationPath,
         FileHelper $fileHelper,
         bool $disableMigrationScan,
+        ReflectionProvider $reflectionProvider
     ) {
         $this->parser = $parser;
         $this->databaseMigrationPath = $databaseMigrationPath;
         $this->fileHelper = $fileHelper;
         $this->disableMigrationScan = $disableMigrationScan;
+        $this->reflectionProvider = $reflectionProvider;
     }
 
     /**
@@ -55,7 +61,7 @@ class MigrationHelper
             $this->databaseMigrationPath = [database_path('migrations')];
         }
 
-        $schemaAggregator = new SchemaAggregator($tables);
+        $schemaAggregator = new SchemaAggregator($this->reflectionProvider, $tables);
         $filesArray = $this->getMigrationFiles();
 
         if (empty($filesArray)) {

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -9,6 +9,7 @@ use App\Casts\BasicEnumeration;
 use App\Group;
 use App\GuardedModel;
 use App\Role;
+use App\RoleUser;
 use App\Team;
 use App\Thread;
 use App\User;
@@ -19,7 +20,7 @@ use Illuminate\Support\Stringable;
 
 use function PHPStan\Testing\assertType;
 
-function foo(User $user, Account $account, Role $role, Group $group, Team $team, GuardedModel $guardedModel, Thread $thread, Address $address)
+function foo(User $user, Account $account, Role $role, Group $group, Team $team, GuardedModel $guardedModel, Thread $thread, Address $address, RoleUser $roleUser)
 {
     assertType('*ERROR*', $user->newStyleAttribute); // Doesn't have generic type, so we treat as it doesnt exist
     assertType('int', $user->stringButInt);
@@ -80,4 +81,6 @@ function foo(User $user, Account $account, Role $role, Group $group, Team $team,
     assertType('int|null', $address->nullable_foreign_id_constrained);
     assertType('App\ValueObjects\Favorites', $user->favorites);
     assertType('string', $address->uuid);
+    assertType('string', $roleUser->role_id);
+    assertType('int', $roleUser->user_id);
 }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -22,12 +22,13 @@ class MigrationHelperTest extends PHPStanTestCase
     {
         $this->parser = self::getContainer()->getService('currentPhpVersionSimpleDirectParser');
         $this->fileHelper = self::getContainer()->getByType(FileHelper::class);
+        $this->reflectionProvider = $this->createReflectionProvider();
     }
 
     /** @test */
     public function it_will_return_empty_array_if_migrations_path_is_not_a_directory()
     {
-        $migrationHelper = new MigrationHelper($this->parser, ['foobar'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, ['foobar'], $this->fileHelper, false, $this->reflectionProvider);
 
         self::assertSame([], $migrationHelper->initializeTables());
     }
@@ -35,7 +36,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_basic_migrations_and_create_table_structure()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/basic_migration'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/basic_migration'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -45,7 +46,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_schema_definitions_from_any_method_in_class()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_with_different_methods'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_with_different_methods'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -55,7 +56,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_read_schema_definitions_with_multiple_create_and_drop_methods_for_one_table()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/complex_migrations'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/complex_migrations'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -77,7 +78,7 @@ class MigrationHelperTest extends PHPStanTestCase
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/basic_migration',
             __DIR__.'/data/additional_migrations',
-        ], $this->fileHelper, false);
+        ], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -91,7 +92,7 @@ class MigrationHelperTest extends PHPStanTestCase
     {
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/migrations_using_after_method',
-        ], $this->fileHelper, false);
+        ], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -111,7 +112,7 @@ class MigrationHelperTest extends PHPStanTestCase
     {
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/rename_migrations',
-        ], $this->fileHelper, false);
+        ], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -123,7 +124,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -136,7 +137,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_migrations_with_soft_deletes_tz()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes_tz'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_soft_deletes_tz'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -149,7 +150,7 @@ class MigrationHelperTest extends PHPStanTestCase
     /** @test */
     public function it_can_handle_connection_before_schema_create()
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migration_with_schema_connection'], $this->fileHelper, false);
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migration_with_schema_connection'], $this->fileHelper, false, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 
@@ -162,7 +163,7 @@ class MigrationHelperTest extends PHPStanTestCase
         $migrationHelper = new MigrationHelper($this->parser, [
             __DIR__.'/data/basic_migration',
             __DIR__.'/data/additional_migrations',
-        ], $this->fileHelper, true);
+        ], $this->fileHelper, true, $this->reflectionProvider);
 
         $tables = $migrationHelper->initializeTables();
 

--- a/tests/application/app/RoleUser.php
+++ b/tests/application/app/RoleUser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class RoleUser extends Pivot
+{
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
+    }
+}

--- a/tests/application/database/migrations/2023_06_12_000000_create_role_user_table.php
+++ b/tests/application/database/migrations/2023_06_12_000000_create_role_user_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use App\Role;
+use App\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRoleUserTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_user', static function (Blueprint $table) {
+            $table->foreignIdFor(Role::class);
+            $table->foreignIdFor(User::class);
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user-facing changes

Resolves #1653

**Changes**

Type for `foriginIdFor` fields will be set using a primary key column from the table for the related model, with a fallback to the previous implementation (hardcoded `int` type) when a table or column is not found.

**Breaking changes**

Type for `foriginIdFor` fields might change.
