### PR TITLE
fix: Prevent crash with static call on instances of intersection

### DIFF
--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
@@ -102,11 +103,15 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
                 $types = [];
 
                 foreach ($classNames as $className) {
-                    if ($this->reflectionProvider->hasClass($className)) {
+                    if (! $this->reflectionProvider->hasClass($className)) {
+                        continue;
+                    }
+                    try {
                         $types[] = new GenericObjectType(
                             $this->builderHelper->determineBuilderName($className),
                             [new ObjectType($className)]
                         );
+                    } catch (MissingMethodFromReflectionException) {
                     }
                 }
 

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -223,6 +223,7 @@ function doFoo(User $user, Post $post, $userAndAuth): void
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $userAndAuth->newQueryWithoutScopes());
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $userAndAuth->newQueryWithoutScope('foo'));
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $userAndAuth->newQueryForRestoration([1]));
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $userAndAuth::query());
 
     assertType('Illuminate\Support\LazyCollection<int, App\User>', User::query()->lazy());
     assertType('Illuminate\Support\LazyCollection<int, App\User>', User::query()->lazyById());


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

There is a regression in v2.6.3 with code like this:
```php
/** @var Model&MyInterface $model */
$model::query();
```

It makes PHPStan report an internal error of the form `Internal error: Method newEloquentBuilder() was not found in reflection of class MyInterface.`.

The problem doesn't happen by removing the interface from the intersection.

I've updated `tests/Type/data/eloquent-builder.php` to reproduce it and, before applying the fix, it fails this way:
```
1) Error
The data provider specified for Type\GeneralTypeTest::testFileAsserts is invalid.
PHPStan\Reflection\MissingMethodFromReflectionException: Method newEloquentBuilder() was not found in reflection of class EloquentBuilder\OnlyUsers.
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassReflection.php:472
/code/larastan/src/Methods/BuilderHelper.php:199
/code/larastan/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php:107
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:3373
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1392
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1398
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:559
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:91
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:459
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:2594
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:1545
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:576
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:370
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:477
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:370
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:589
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:339
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:49
phar:///code/larastan/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:140
/code/larastan/tests/Type/GeneralTypeTest.php:17
```

**Breaking changes**

n/a