### PR TITLE
Refactor src/Types/GenericEloquentBuilderTypeNodeResolverExtension to be able to fail quicker.

### DIFF
--- a/src/Types/GenericEloquentBuilderTypeNodeResolverExtension.php
+++ b/src/Types/GenericEloquentBuilderTypeNodeResolverExtension.php
@@ -38,11 +38,15 @@ class GenericEloquentBuilderTypeNodeResolverExtension implements TypeNodeResolve
                 && (new ObjectType(Model::class))->isSuperTypeOf(new ObjectType($nameScope->resolveStringName($innerTypeNode->name)))->yes()
             ) {
                 $modelTypeNode = $innerTypeNode;
-                continue;
             }
+        }
 
-            if (
-                $innerTypeNode instanceof IdentifierTypeNode
+        if ($modelTypeNode === null) {
+            return null;
+        }
+
+        foreach ($typeNode->types as $innerTypeNode) {
+            if ($innerTypeNode instanceof IdentifierTypeNode
                 && $this->provider->hasClass($nameScope->resolveStringName($innerTypeNode->name))
                 && ($nameScope->resolveStringName($innerTypeNode->name) === Builder::class || (new ObjectType(Builder::class))->isSuperTypeOf(new ObjectType($nameScope->resolveStringName($innerTypeNode->name)))->yes())
             ) {
@@ -50,7 +54,7 @@ class GenericEloquentBuilderTypeNodeResolverExtension implements TypeNodeResolve
             }
         }
 
-        if ($modelTypeNode === null || $builderTypeNode === null) {
+        if ($builderTypeNode === null) {
             return null;
         }
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

Profiling larastan on a simple script like this:

```php
<?php

var_dump(collect());
```

i noticed that the `GenericEloquentBuilderTypeNodeResolverExtension` was taking up 8% of the execution time, the majority being spent in the `isSuperTypeOf` checks
and after fiddling with it a bit, the cost is reduced to 4% of time with this small change

it seems counterintuitive but looping twice allows us to fail earlier, which is useful when the majority of times the extension is called with non-matching input, and we know we will only ever iterate twice in each foreach thanks to the if above