### PR TITLE
Make UndefinedArgumentOrOptionRule fail sooner to avoid expensive type system calls

### DIFF
--- a/src/Rules/ConsoleCommand/UndefinedArgumentOrOptionRule.php
+++ b/src/Rules/ConsoleCommand/UndefinedArgumentOrOptionRule.php
@@ -35,6 +35,14 @@ final class UndefinedArgumentOrOptionRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        if (! $node->name instanceof Node\Identifier || ! in_array($node->name->name, ['argument', 'option'], true)) {
+            return [];
+        }
+
+        if (count($node->getArgs()) !== 1) {
+            return [];
+        }
+
         $classReflection = $scope->getClassReflection();
 
         if ($classReflection === null) {
@@ -49,15 +57,7 @@ final class UndefinedArgumentOrOptionRule implements Rule
             return [];
         }
 
-        if (! $node->name instanceof Node\Identifier || ! in_array($node->name->name, ['argument', 'option'], true)) {
-            return [];
-        }
-
         $methodName = $node->name->name;
-
-        if (count($node->getArgs()) !== 1) {
-            return [];
-        }
 
         $argType = $scope->getType($node->getArgs()[0]->value);
 


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

Reorder the checks in `UndefinedArgumentOrOptionRule` so that cheap checks are first

this reduced the cost of this rule from 1% to 0% of total time on a decent sized class that is not an instance of `Command`. 