### PR TITLE
Check for method name earlier in NoUnnecessaryCollectionCallRule to avoid expensive calls to type system.

### DIFF
--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -156,6 +156,10 @@ class NoUnnecessaryCollectionCallRule implements Rule
         /** @var \PhpParser\Node\Identifier $name */
         $name = $node->name;
 
+        if (! in_array($name->toLowerString(), $this->shouldHandle, true)) {
+            return [];
+        }
+
         if (! $this->isCalledOnCollection($node->var, $scope)) {
             // Method was not called on a collection, so no errors.
             return [];
@@ -172,10 +176,6 @@ class NoUnnecessaryCollectionCallRule implements Rule
         if (! ($previousCall->name instanceof Identifier)) {
             // Previous call was made dynamically e.g. User::query()->{$method}()
             // Can't really analyze it in this scenario so no errors.
-            return [];
-        }
-
-        if (! in_array($name->toLowerString(), $this->shouldHandle, true)) {
             return [];
         }
 


### PR DESCRIPTION

- [x] Added or updated tests
- [x] Documented user facing changes

Reorder checks in `NoUnnecessaryCollectionCallRule` so that cheap checks are first

this reduced the cost of this rule on a decent sized class that doesn't use `Collection` at all from 6% to 0% of total time
