### PR TITLE
Changed `retry()` helper stub to accept callable as `$sleepMilliseconds`

### DIFF
--- a/stubs/Helpers.stub
+++ b/stubs/Helpers.stub
@@ -100,13 +100,13 @@ function rescue(callable $callback, $rescue = null, $report = true) {}
  * @template TValue
  * @param int|array<int, int> $times
  * @param callable(int): TValue $callback
- * @param int $sleep
+ * @param int|callable(int, \Exception): int $sleepMilliseconds
  * @param null|callable(\Exception): bool $when
  * @phpstan-return TValue
  *
  * @throws \Exception
  */
-function retry($times, callable $callback, $sleep = 0, $when = null) {}
+function retry($times, callable $callback, $sleepMilliseconds = 0, $when = null) {}
 
 /**
  * @template TValue

--- a/tests/Integration/data/helpers.php
+++ b/tests/Integration/data/helpers.php
@@ -6,3 +6,14 @@ function transformAcceptsNonNullableCallable(): void
 {
     transform(User::first(), fn (User $user) => $user->toArray());
 }
+
+function retryAcceptsCallableAsSleepMilliseconds(): void
+{
+    retry(5, function (int $attempt): bool {
+        return false;
+    }, function (int $attempt, Exception $e): int {
+        return 0;
+    }, function (Exception $e): bool {
+        return true;
+    });
+}

--- a/tests/Integration/data/helpers.php
+++ b/tests/Integration/data/helpers.php
@@ -11,9 +11,9 @@ function retryAcceptsCallableAsSleepMilliseconds(): void
 {
     retry(5, function (int $attempt): bool {
         return false;
-    }, function (int $attempt, Exception $e): int {
+    }, function (int $attempt, \Exception $e): int {
         return 0;
-    }, function (Exception $e): bool {
+    }, function (\Exception $e): bool {
         return true;
     });
 }


### PR DESCRIPTION
This PR fixes false negative saying that `Parameter $sleepMilliseconds of function retry expects int, Closure given.`

<img width="688" alt="image" src="https://github.com/nunomaduro/larastan/assets/17316322/0f12ac7b-f52f-40d5-a027-38edc9f1743b">

- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->


Renamed `$sleep` to `$sleepMilliseconds` and updated stub to accept callable.
[Link to `retry()` helper in laravel](https://github.com/laravel/framework/blob/c59d540ab142d36ee0f62c3ddc749329a968466b/src/Illuminate/Support/helpers.php#L225)

<img width="706" alt="image" src="https://github.com/nunomaduro/larastan/assets/17316322/c002baa7-f62c-4044-bfa4-31ace96f5c4a">


**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
None

