### PR TITLE
feat: add dynamic return type extension for str helper

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -349,6 +349,11 @@ services:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
+        class: NunoMaduro\Larastan\ReturnTypes\Helpers\StrExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\TapExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/ReturnTypes/Helpers/StrExtension.php
+++ b/src/ReturnTypes/Helpers/StrExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NunoMaduro\Larastan\ReturnTypes\Helpers;
+
+use Illuminate\Support\Stringable;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+
+class StrExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'str';
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?\PHPStan\Type\Type
+    {
+        if (count($functionCall->getArgs()) === 1) {
+            return new ObjectType(Stringable::class);
+        }
+
+        return new MixedType();
+    }
+}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -130,6 +130,12 @@ function retryHelper()
     }));
 }
 
+function strHelper()
+{
+    assertType('Illuminate\Support\Stringable', str('foo'));
+    assertType('mixed', str());
+}
+
 function tapHelper()
 {
     assertType('App\User', tap(new User(), function (User $user): void {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Adds a return type extension such that code like:
```php
str('foo')->contains('bar')
```
won't fail because PHPStan thinks `str('foo')` resolves to `mixed`


Note that ideally we'd also properly resolve `str()`, right now I'm just leaving it as mixed. 
