### PR TITLE
Add covariance to tvalue of collection and enumerable stubs.

### DIFF
--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -44,7 +44,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
  */

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -8,7 +8,8 @@ use Illuminate\Support\Traits\EnumeratesValues;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * 
+ * @template-covariant TValue
  *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>

--- a/stubs/Contracts/Support.stub
+++ b/stubs/Contracts/Support.stub
@@ -7,7 +7,7 @@ interface Htmlable
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  */
 interface Arrayable
 {

--- a/stubs/Enumerable.stub
+++ b/stubs/Enumerable.stub
@@ -4,7 +4,8 @@ namespace Illuminate\Support;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @extends \IteratorAggregate<TKey, TValue>
  */

--- a/stubs/EnumeratesValues.stub
+++ b/stubs/EnumeratesValues.stub
@@ -6,7 +6,8 @@ use Illuminate\Support\HigherOrderCollectionProxy;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @property-read HigherOrderCollectionProxy<'average', TValue, static> $average
  * @property-read HigherOrderCollectionProxy<'avg', TValue, static> $avg


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Use `@template-covariance` in Illuminate stubs as is done upstream. ([Collection](https://github.com/illuminate/collections/blob/master/Collection.php#L16), [Enumerable](https://github.com/illuminate/collections/blob/master/Enumerable.php#L16))

This is to avoid the problem described here https://phpstan.org/blog/whats-up-with-template-covariant

**Breaking changes**


<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
I am not 100% certain, but from what I can tell this change is non-breaking.
