### PR TITLE
feat: add test for dropColumn() when an array is passed

### DIFF
--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -185,4 +185,19 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertSame('string', $tables['users']->columns['created_at']->readableType);
         self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
     }
+
+    /** @test */
+    public function it_can_handle_migrations_with_array_passed_to_drop_column()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [
+            __DIR__.'/data/migrations_using_drop_column',
+        ], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(5, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+    }
 }

--- a/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingDropColumn;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAddDropToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('users', static function (Blueprint $table) {
+            $table->string('country')->nullable();
+            $table->string('city')->nullable();
+        });
+
+        Schema::table('users', static function (Blueprint $table) {
+            $table->dropColumn(['country', 'city']);
+        });
+    }
+}

--- a/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
@@ -25,6 +25,11 @@ class CreateAddDropToUsersTable extends Migration
         });
 
         Schema::table('users', static function (Blueprint $table) {
+            $table->string('country')->nullable();
+            $table->string('city')->nullable();
+        });
+
+        Schema::table('users', static function (Blueprint $table) {
             $table->dropColumn(['country', 'city']);
         });
     }

--- a/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
@@ -19,12 +19,9 @@ class CreateAddDropToUsersTable extends Migration
             $table->bigIncrements('id');
             $table->string('name')->nullable();
             $table->string('email')->unique();
-            $table->timestamps();
-        });
-
-        Schema::table('users', static function (Blueprint $table) {
             $table->string('country')->nullable();
             $table->string('city')->nullable();
+            $table->timestamps();
         });
 
         Schema::table('users', static function (Blueprint $table) {

--- a/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_column/2023_08_07_000000_create_add_drop_to_users_table.php
@@ -25,11 +25,6 @@ class CreateAddDropToUsersTable extends Migration
         });
 
         Schema::table('users', static function (Blueprint $table) {
-            $table->string('country')->nullable();
-            $table->string('city')->nullable();
-        });
-
-        Schema::table('users', static function (Blueprint $table) {
             $table->dropColumn(['country', 'city']);
         });
     }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR adds a test to confirm that an array of column names can be passed to `dropColumn()` and that the columns are indeed dropped by asserting the count/remaining columns.