### PR TITLE
fix: Fixed false detection of columns being nullable

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -546,8 +546,6 @@ final class SchemaAggregator
             return true;
         }
 
-        $parts = $argExpression->name->getParts();
-
-        return array_key_exists(0, $parts) && $parts[0] === 'true';
+        return $argExpression->name->getFirst() === 'true';
     }
 }

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -179,6 +179,7 @@ final class SchemaAggregator
                 while ($rootVar instanceof PhpParser\Node\Expr\MethodCall) {
                     if ($rootVar->name instanceof PhpParser\Node\Identifier
                         && $rootVar->name->name === 'nullable'
+                        && $this->getNullableArgumentValue($rootVar) === true
                     ) {
                         $nullable = true;
                     }
@@ -525,5 +526,28 @@ final class SchemaAggregator
         }
 
         return $table->columns[$column]->readableType;
+    }
+
+    private function getNullableArgumentValue(PhpParser\Node\Expr\MethodCall $rootVar): bool
+    {
+        if (! array_key_exists(0, $rootVar->args)) {
+            return true;
+        }
+
+        $arg = $rootVar->args[0];
+
+        if (! ($arg instanceof PhpParser\Node\Arg)) {
+            return true;
+        }
+
+        $argExpression = $arg->value;
+
+        if (! ($argExpression instanceof PhpParser\Node\Expr\ConstFetch)) {
+            return true;
+        }
+
+        $parts = $argExpression->name->getParts();
+
+        return array_key_exists(0, $parts) && $parts[0] === 'true';
     }
 }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -170,6 +170,18 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertSame([], $tables);
     }
 
+    /** @test */
+    public function it_can_handle_nullable_in_migrations()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/migrations_using_nullable'], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertSame(false, $tables['users']->columns['name']->nullable);
+        self::assertSame(true, $tables['users']->columns['email']->nullable);
+        self::assertSame(true, $tables['users']->columns['address1']->nullable);
+    }
+
     /**
      * @param  array<string, SchemaTable>  $tables
      */

--- a/tests/Unit/data/migrations_using_nullable/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migrations_using_nullable/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable(false);
+            $table->string('email')->unique()->nullable();
+            $table->string('address1')->nullable(true);
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Fixed a problem that occurred when scanning database migrations. Columns which had `nullable(false)` were incorrectly inferred as nullable.

**Breaking changes**

n/a
