### PR TITLE
feat: Support migrations with conditional statements

### DIFF
--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -20,6 +20,8 @@ parameters:
         - app/Domain/DomainB/migrations
 ```
 
+**Note:** If your migrations are using `if` statements to conditionally alter database structure (ex: create table only if it's not there, add column only if table exists and column does not etc...) Larastan will assume those if statements evaluate to true and will consider everything from the `if` body.
+
 ## `disableMigrationScan`
 **default**: `false`
 

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -550,7 +550,7 @@ final class SchemaAggregator
     }
 
     /**
-     * @param PhpParser\Node\Expr $updateClosure
+     * @param  PhpParser\Node\Expr  $updateClosure
      *
      * @return PhpParser\Node\Stmt\Expression[]
      */

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -146,7 +146,7 @@ final class SchemaAggregator
         ) {
             $argName = $call->getArgs()[1]->value->params[0]->var->name;
 
-            $this->processColumnUpdates($tableName, $argName, $updateClosure->stmts);
+            $this->processColumnUpdates($tableName, $argName, $this->getUpdateStatements($updateClosure));
         }
     }
 
@@ -547,5 +547,35 @@ final class SchemaAggregator
         }
 
         return $argExpression->name->getFirst() === 'true';
+    }
+
+    /**
+     * @param PhpParser\Node\Expr $updateClosure
+     *
+     * @return PhpParser\Node\Stmt\Expression[]
+     */
+    private function getUpdateStatements(PhpParser\Node\Expr $updateClosure): array
+    {
+        if (! property_exists($updateClosure, 'stmts')) {
+            return [];
+        }
+
+        $statements = [];
+        $nodeFinder = new NodeFinder();
+
+        foreach ($updateClosure->stmts as $updateStatement) {
+            if ($updateStatement instanceof PhpParser\Node\Stmt\If_) {
+                $statements = array_merge(
+                    $statements,
+                    $nodeFinder->findInstanceOf($updateStatement, PhpParser\Node\Stmt\Expression::class)
+                );
+
+                continue;
+            }
+
+            $statements[] = $updateStatement;
+        }
+
+        return $statements;
     }
 }

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -551,7 +551,6 @@ final class SchemaAggregator
 
     /**
      * @param  PhpParser\Node\Expr  $updateClosure
-     *
      * @return PhpParser\Node\Stmt\Expression[]
      */
     private function getUpdateStatements(PhpParser\Node\Expr $updateClosure): array

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -212,4 +212,18 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertCount(5, $tables['users']->columns);
         self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
     }
+
+    /** @test */
+    public function it_can_handle_migrations_with_if_statements()
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__.'/data/conditional_migrations'], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertArrayHasKey('id', $tables['users']->columns);
+        self::assertArrayHasKey('name', $tables['users']->columns);
+        self::assertArrayHasKey('email', $tables['users']->columns);
+        self::assertArrayHasKey('address1', $tables['users']->columns);
+        self::assertArrayHasKey('address2', $tables['users']->columns);
+    }
 }

--- a/tests/Unit/data/conditional_migrations/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/conditional_migrations/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+        });
+    }
+}

--- a/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_address1_to_users_table.php
+++ b/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_address1_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAddress1ToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('users') === true) {
+            Schema::table('users', static function (Blueprint $table) {
+                if (Schema::hasColumn('users', 'address1') === false) {
+                    $table->string('address1');
+                }
+            });
+        }
+    }
+}

--- a/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_address2_to_users_table.php
+++ b/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_address2_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAddress2ToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('users') === true) {
+            Schema::table('users', static function (Blueprint $table) {
+                if (Schema::hasColumn('users', 'address2') === true) {
+                    return;
+                }
+
+                $table->string('address2')->nullable();
+            });
+        }
+    }
+}

--- a/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_email_to_users_table.php
+++ b/tests/Unit/data/conditional_migrations/2020_01_31_000000_add_email_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BasicMigrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEmailToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('users') === false) {
+            return;
+        }
+
+        Schema::table('users', static function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'email') === false) {
+                $table->string('email')->unique();
+            }
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

Larastan is already doing an awesome job in understanding the table structure and model properties by scanning the migrations, however, a problem arises when there are if conditions inside the migrations. Statements which are under an if condition do not get processed and therefor errors like "Undefined property" for models start to pop up.

One might use if conditions inside the migration files in order to make sure no errors will happen if you accidentally run the same migration multiple times or your database was manually altered (table / columns were deleted / altered by hand).

In my day job, I'm using if conditions in migrations before changing anything as our project is using multi-tenancy and someone is always creating new tenants by manually creating new databases. Because of that, sometimes a situation happens where the new tenant database is up-to-date with the changes, however, that's not reflected in the migrations table. Because of that, our deploys were sometimes failing and we decided to write migrations in a way where errors would not happen and deploy would not fail if some change is already done but not reflected in the migrations table.

**Breaking changes**

n/a
