### PR TITLE
Add stub for `FormRequest::validated`

### DIFF
--- a/stubs/common/Foundation/Http/FormRequest.stub
+++ b/stubs/common/Foundation/Http/FormRequest.stub
@@ -12,4 +12,13 @@ class FormRequest
      * @return ($keys is null ? \Illuminate\Support\ValidatedInput : array<string, mixed>)
      */
     public function safe(array $keys = null);
+
+    /**
+     * Get the validated data from the request.
+     *
+     * @param  array|int|string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<string, mixed> : mixed)
+     */
+    public function validated($key = null, $default = null);
 }

--- a/stubs/common/Foundation/Http/FormRequest.stub
+++ b/stubs/common/Foundation/Http/FormRequest.stub
@@ -16,7 +16,7 @@ class FormRequest
     /**
      * Get the validated data from the request.
      *
-     * @param  array|int|string|null  $key
+     * @param  array<string>|int|string|null  $key
      * @param  mixed  $default
      * @return ($key is null ? array<string, mixed> : mixed)
      */

--- a/tests/Type/data/form-request.php
+++ b/tests/Type/data/form-request.php
@@ -9,3 +9,4 @@ use function PHPStan\Testing\assertType;
 /** @var \Illuminate\Foundation\Http\FormRequest $request */
 assertType('Illuminate\Support\ValidatedInput', $request->safe());
 assertType('array<string, mixed>', $request->safe(['key']));
+assertType('array<string, mixed>', $request->validated());


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

I've added `validated` to the `FormRequest` stub, as I was running into issues with its current `mixed` return type:

```php
$item = Item::create($request->validated());
```

> Parameter $attributes of static method Illuminate\Database\Eloquent\Builder<App\Models\Item>::create() expects array<string, mixed>, mixed given. 

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
