### PR TITLE
[3.0] Remove if `class_exists` for classes introduced in Testbench 8.x minor releases

### DIFF
--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\PackageManifest;
 use NunoMaduro\Larastan\Internal\ComposerHelper;
 use Orchestra\Testbench\Foundation\Application as Testbench;
-use Orchestra\Testbench\Foundation\Bootstrap\CreateVendorSymlink;
 use Orchestra\Testbench\Foundation\Config;
 
 use function defined;

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -50,14 +50,12 @@ final class ApplicationResolver
 
         $config = Config::loadFromYaml($workingPath);
 
-        (new CreateVendorSymlink($vendorDir))->bootstrap(
-            Testbench::create($config['laravel'], null, ['extra' => ['dont-discover' => ['*']]])
-        );
+        Testbench::createVendorSymlink($config['laravel'], $vendorDir);
 
-        return Testbench::create(
-            $config['laravel'],
+        return Testbench::createFromConfig(
+            $config,
             $resolvingCallback,
-            ['enables_package_discoveries' => true, 'extra' => $config->getExtraAttributes()]
+            ['enables_package_discoveries' => true]
         );
     }
 }

--- a/src/ApplicationResolver.php
+++ b/src/ApplicationResolver.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
 use NunoMaduro\Larastan\Internal\ComposerHelper;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use Orchestra\Testbench\Foundation\Bootstrap\CreateVendorSymlink;
 use Orchestra\Testbench\Foundation\Config;
 
-use function class_exists;
 use function defined;
 use function file_exists;
 use function getcwd;


### PR DESCRIPTION
**Changes**

Compatibility with Testbench 9