### PR TITLE
To avoid PHPUnit deprecations, add the 'static' keyword to the method

### DIFF
--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -12,7 +12,7 @@ class IntegrationTest extends PHPStanTestCase
     /**
      * @return iterable<mixed>
      */
-    public function dataIntegrationTests(): iterable
+    public static function dataIntegrationTests(): iterable
     {
         self::getContainer();
         yield [__DIR__.'/data/test-case-extension.php'];

--- a/tests/Reflection/MacroMethodsClassReflectionExtensionTest.php
+++ b/tests/Reflection/MacroMethodsClassReflectionExtensionTest.php
@@ -61,7 +61,7 @@ class MacroMethodsClassReflectionExtensionTest extends PHPStanTestCase
         $this->assertSame($exceptionClass, $method->getThrowType()->getClassName());
     }
 
-    public function methodAndClassProvider(): Generator
+    public static function methodAndClassProvider(): Generator
     {
         yield [Request::class, 'validate'];
         yield [Request::class, 'validateWithBag'];
@@ -69,7 +69,7 @@ class MacroMethodsClassReflectionExtensionTest extends PHPStanTestCase
         yield [Request::class, 'hasValidRelativeSignature'];
     }
 
-    public function methodAndThrowTypeProvider(): Generator
+    public static function methodAndThrowTypeProvider(): Generator
     {
         yield [Request::class, 'validate', ValidationException::class];
         yield [Request::class, 'validateWithBag', ValidationException::class];

--- a/tests/Reflection/RedirectResponseMethodsClassReflectionExtensionTest.php
+++ b/tests/Reflection/RedirectResponseMethodsClassReflectionExtensionTest.php
@@ -75,14 +75,14 @@ class RedirectResponseMethodsClassReflectionExtensionTest extends PHPStanTestCas
     }
 
     /** @return iterable<mixed> */
-    public function greenMethodProvider(): iterable
+    public static function greenMethodProvider(): iterable
     {
         yield ['withFoo'];
         yield ['withFooAndBar'];
     }
 
     /** @return iterable<mixed> */
-    public function redMethodProvider(): iterable
+    public static function redMethodProvider(): iterable
     {
         yield ['non-existent'];
         yield ['aWith'];

--- a/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
@@ -9,13 +9,13 @@ class CollectionDynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInfe
     /**
      * @return iterable<mixed>
      */
-    public function dataFileAsserts(): iterable
+    public static function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__.'/data/collection-filter.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/collection-where-not-null.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/collection-filter.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/collection-where-not-null.php');
 
         if (PHP_VERSION_ID >= 70400) {
-            yield from $this->gatherAssertTypes(__DIR__.'/data/collection-filter-arrow-function.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/collection-filter-arrow-function.php');
         }
     }
 

--- a/tests/Type/CollectionDynamicReturnTypeExtensionsTest.php
+++ b/tests/Type/CollectionDynamicReturnTypeExtensionsTest.php
@@ -9,16 +9,16 @@ class CollectionDynamicReturnTypeExtensionsTest extends \PHPStan\Testing\TypeInf
     /**
      * @return iterable<mixed>
      */
-    public function dataFileAsserts(): iterable
+    public static function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__.'/data/collection-helper.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/collection-make-static.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/collection-stubs.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/collection-helper.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/collection-make-static.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/collection-stubs.php');
 
         if (version_compare(LARAVEL_VERSION, '9.48.0', '<')) {
-            yield from $this->gatherAssertTypes(__DIR__.'/data/collection-generic-static-methods.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/collection-generic-static-methods.php');
         } else {
-            yield from $this->gatherAssertTypes(__DIR__.'/data/collection-generic-static-methods-l948.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/collection-generic-static-methods-l948.php');
         }
     }
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -11,64 +11,64 @@ class GeneralTypeTest extends TypeInferenceTestCase
     /**
      * @return iterable<mixed>
      */
-    public function dataFileAsserts(): iterable
+    public static function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__.'/data/request-object.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/query-builder.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/route.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/conditionable.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/tappable.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/translate.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-factories.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/environment-helper.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/view.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1346.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/request-header.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/optional-helper.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/abstract-manager.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/facades.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/where-relation.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/validator.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/form-request.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/database-transaction.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/container-array-access.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/view-exists.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/application-make.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/container-make.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/abort.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/throw.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/app-make.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/auth.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-builder.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/carbon.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/contracts.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/higher-order-collection-proxy-methods.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-relations.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/model-scopes.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/date-extension.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/gate-facade.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/helpers.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/translator.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/benchmark.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1760.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/request-object.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/eloquent-builder.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/query-builder.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/paginator-extension.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-properties.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-properties-relations.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/route.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/conditionable.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/tappable.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/translate.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-factories.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/environment-helper.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/view.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/bug-1346.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/request-header.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/optional-helper.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/abstract-manager.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/facades.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/where-relation.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/validator.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/form-request.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/database-transaction.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/container-array-access.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/view-exists.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/application-make.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/container-make.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/abort.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/throw.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/app-make.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/auth.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/custom-eloquent-builder.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/carbon.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/contracts.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/higher-order-collection-proxy-methods.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-relations.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-scopes.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/date-extension.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/gate-facade.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/helpers.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/translator.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/benchmark.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/bug-1760.php');
 
         if (version_compare(LARAVEL_VERSION, '10.20.0', '>=')) {
-            yield from $this->gatherAssertTypes(__DIR__.'/data/model-relations-l10-20.php');
-            yield from $this->gatherAssertTypes(__DIR__.'/data/model-l10-20.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/model-relations-l10-20.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/model-l10-20.php');
         }
 
         //##############################################################################################################
 
         // Console Commands
-        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/FooCommand.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BarCommand.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BazCommand.php');
+        yield from self::gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/FooCommand.php');
+        yield from self::gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BarCommand.php');
+        yield from self::gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BazCommand.php');
     }
 
     /**

--- a/tests/Type/MethodsClassReflectionExtensionTest.php
+++ b/tests/Type/MethodsClassReflectionExtensionTest.php
@@ -7,13 +7,13 @@ class MethodsClassReflectionExtensionTest extends \PHPStan\Testing\TypeInference
     /**
      * @return iterable<mixed>
      */
-    public function dataFileAsserts(): iterable
+    public static function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__.'/data/macros.php');
-        yield from $this->gatherAssertTypes(__DIR__.'/data/redirect-response.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/macros.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/redirect-response.php');
 
         if (version_compare(PHP_VERSION, '8.1.0', '>=') && version_compare(PHP_VERSION, '8.2.0', '<')) {
-            yield from $this->gatherAssertTypes(__DIR__.'/data/macros-php-81.php');
+            yield from self::gatherAssertTypes(__DIR__.'/data/macros-php-81.php');
         }
     }
 

--- a/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
+++ b/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
@@ -73,7 +73,7 @@ class ModelFactoryDynamicStaticMethodReturnTypeExtensionTest extends PHPStanTest
         return [__DIR__.'/../phpstan-tests.neon'];
     }
 
-    public function argumentProvider(): \Generator
+    public static function argumentProvider(): \Generator
     {
         yield [new ConstantIntegerType(1), TrinaryLogic::createNo()];
         yield [new ConstantIntegerType(0), TrinaryLogic::createNo()];


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Resolves #1816

**Changes**
To avoid deprecations in PHPUnit 10, the 'static' keyword has been added to the method.

**Breaking changes**
None.
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
