### PR TITLE
Add missing typehints to query builder stub

### DIFF
--- a/stubs/10.0.0/QueryBuilder.stub
+++ b/stubs/10.0.0/QueryBuilder.stub
@@ -13,7 +13,7 @@ class Builder
      * @param  string  $as
      * @param  \Closure|string  $first
      * @param  string|null  $operator
-     * @param  string|null  $second
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @param  string  $type
      * @param  bool  $where
      * @return $this
@@ -25,7 +25,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array<string|int, mixed>  $column
+     * @param  \Closure|string|array<string|int, mixed>|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -46,7 +46,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|model-property|array<model-property|int, mixed>  $column
+     * @param  \Closure|model-property|array<model-property|int, mixed>|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -106,7 +106,7 @@ class Builder
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string|array<string>  $columns
+     * @param  string|array<string>|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -116,7 +116,7 @@ class Builder
     /**
      * Add a "where not null" clause to the query.
      *
-     * @param  string|array<string>  $columns
+     * @param  string|array<string>|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @param  string  $boolean
      * @return $this
      */

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -68,6 +68,10 @@ class GeneralTypeTest extends TypeInferenceTestCase
             yield from self::gatherAssertTypes(__DIR__.'/data/model-l10-20.php');
         }
 
+        if (version_compare(LARAVEL_VERSION, '10.24.0', '>=')) {
+            yield from self::gatherAssertTypes(__DIR__.'/data/query-builder-l10-24.php');
+        }
+
         //##############################################################################################################
 
         // Console Commands

--- a/tests/Type/data/query-builder-l10-24.php
+++ b/tests/Type/data/query-builder-l10-24.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QueryBuilder;
+
+use Illuminate\Support\Facades\DB;
+
+use function PHPStan\Testing\assertType;
+
+function testJoinSubExpressionParameter(): void
+{
+    $subQuery = DB::table('addresses')
+        ->select(['id', 'user_id']);
+
+    $builder = DB::table('users')
+        ->joinSub($subQuery, 'addresses', 'users.user_id', '=', DB::raw('addresses.user_id'));
+
+    assertType('Illuminate\Database\Query\Builder', $builder);
+}
+
+function testWhereExpressionParameter(): void
+{
+    $builder = DB::table('users')
+        ->where(DB::raw('id'), '=', 1);
+
+    assertType('Illuminate\Database\Query\Builder', $builder);
+}
+
+function testOrWhereExpressionParameter(): void
+{
+    $builder = DB::table('users')
+        ->where(DB::raw('id'), '=', 1)
+        ->orWhere(DB::raw('id'), '=', 2);
+
+    assertType('Illuminate\Database\Query\Builder', $builder);
+}
+
+function testWhereNullExpressionParameter(): void
+{
+    $builder = DB::table('users')
+        ->whereNull(DB::raw('email_verified_at'));
+
+    assertType('Illuminate\Database\Query\Builder', $builder);
+}
+
+function testWhereNotNullExpressionParameter(): void
+{
+    $builder = DB::table('users')
+        ->whereNotNull(DB::raw('email_verified_at'));
+
+    assertType('Illuminate\Database\Query\Builder', $builder);
+}

--- a/tests/Type/data/query-builder.php
+++ b/tests/Type/data/query-builder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EloquentBuilder;
+namespace QueryBuilder;
 
 use Illuminate\Support\Facades\DB;
 


### PR DESCRIPTION

- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Add missing query expression typehints to laravel 10 query builder stub.

See:
- https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Query/Builder.php
  - https://github.com/laravel/framework/pull/46160
  - https://github.com/laravel/framework/pull/48386

**Breaking changes**

None
