### PR TITLE
Add stubs for Collection->pop and Collection->shift

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -39,6 +39,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @return static<array-key, TCombineValue>
      */
     public function combine($values);
+
+    /**
+     * Get and remove the last N items from the collection.
+     *
+     * @param  int  $count
+     * @return ($count is 1 ? TValue|null : static<int, TValue>)
+     */
+    public function pop($count = 1);
+
+    /**
+     * Get and remove the first N items from the collection.
+     *
+     * @param  int  $count
+     * @return ($count is 1 ? TValue|null : static<int, TValue>)
+     */
+    public function shift($count = 1);
 }
 
 /**

--- a/tests/Type/data/collection-generic-static-methods-l948.php
+++ b/tests/Type/data/collection-generic-static-methods-l948.php
@@ -80,21 +80,11 @@ assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollec
 assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
 assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
-assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>|null', $collection->pop(1));
-assertType('App\Transaction|App\TransactionCollection<int, App\Transaction>|null', $customEloquentCollection->pop(2));
-assertType('App\User|App\UserCollection|null', $secondCustomEloquentCollection->pop(2));
-assertType('Illuminate\Support\Collection<int, int>|int|null', $items->pop(3));
-
 assertType('App\RoleCollection', User::firstOrFail(1)->roles->random());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
 assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
 assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
 assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
-
-assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>|null', $collection->shift(1));
-assertType('App\Transaction|App\TransactionCollection<int, App\Transaction>|null', $customEloquentCollection->shift(2));
-assertType('App\User|App\UserCollection|null', $secondCustomEloquentCollection->shift(2));
-assertType('Illuminate\Support\Collection<int, int>|int|null', $items->shift(3));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
 assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));

--- a/tests/Type/data/collection-generic-static-methods-l948.php
+++ b/tests/Type/data/collection-generic-static-methods-l948.php
@@ -80,11 +80,21 @@ assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollec
 assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
 assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
+assertType('App\User|null', $collection->pop(1));
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->pop(2));
+assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
+assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
+
 assertType('App\RoleCollection', User::firstOrFail(1)->roles->random());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
 assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
 assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
 assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
+
+assertType('App\User|null', $collection->shift(1));
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->shift(2));
+assertType('App\UserCollection', $secondCustomEloquentCollection->shift(2));
+assertType('Illuminate\Support\Collection<int, int>', $items->shift(3));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
 assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -80,21 +80,11 @@ assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollec
 assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
 assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
-assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>|null', $collection->pop(1));
-assertType('App\Transaction|App\TransactionCollection<int, App\Transaction>|null', $customEloquentCollection->pop(2));
-assertType('App\User|App\UserCollection|null', $secondCustomEloquentCollection->pop(2));
-assertType('Illuminate\Support\Collection<int, int>|int|null', $items->pop(3));
-
 assertType('App\User', $collection->random());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
 assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
 assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
 assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
-
-assertType('App\User|Illuminate\Database\Eloquent\Collection<int, App\User>|null', $collection->shift(1));
-assertType('App\Transaction|App\TransactionCollection<int, App\Transaction>|null', $customEloquentCollection->shift(2));
-assertType('App\User|App\UserCollection|null', $secondCustomEloquentCollection->shift(2));
-assertType('Illuminate\Support\Collection<int, int>|int|null', $items->shift(3));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
 assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -80,11 +80,21 @@ assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollec
 assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
 assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
+assertType('App\User|null', $collection->pop(1));
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->pop(2));
+assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
+assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
+
 assertType('App\User', $collection->random());
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
 assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
 assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
 assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
+
+assertType('App\User|null', $collection->shift(1));
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->shift(2));
+assertType('App\UserCollection', $secondCustomEloquentCollection->shift(2));
+assertType('Illuminate\Support\Collection<int, int>', $items->shift(3));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
 assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -98,3 +98,15 @@ assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection
 
 assertType('App\User', $collectionOfUsers->random());
 assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->random(5));
+
+assertType('App\User|null', $collection->pop());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->pop(5));
+
+assertType('App\User|null', $collectionOfUsers->pop());
+assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->pop(5));
+
+assertType('App\User|null', $collection->shift());
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->shift(5));
+
+assertType('App\User|null', $collectionOfUsers->shift());
+assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->shift(5));


### PR DESCRIPTION
If a `$count` of 1 is provided, these methods return a value or null.

If any other `$count` is provided, these methods return a collection.

- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Adds stubs for `Collection->pop()` and `Collection->shift()` that adds a conditional return type on the `$count`

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
