### PR TITLE
feat: detect usage of env() function outside of config folder

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -356,3 +356,31 @@ parameters:
 - `@includeUnless` Blade directive.
 - `@includeWhen` Blade directive.
 - `@includeFirst` Blade directive.
+
+## NoEnvCallsOutsideOfConfig
+
+Checks for `env` calls out side of the config directory which returns null
+when the config is cached.
+
+#### Examples
+
+```php
+env(...);
+```
+
+Will result in the following error:
+
+```
+Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.")
+```
+
+#### Configuration
+
+This rule is disabled by default. To enable, add:
+
+```neon
+parameters:
+    noEnvCallsOutsideOfConfig: true
+```
+
+to your `phpstan.neon` file.

--- a/extension.neon
+++ b/extension.neon
@@ -12,6 +12,7 @@ parameters:
     bootstrapFiles:
         - bootstrap.php
     checkOctaneCompatibility: false
+    noEnvCallsOutsideOfConfig: false
     noModelMake: true
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
@@ -27,6 +28,7 @@ parameters:
 
 parametersSchema:
     checkOctaneCompatibility: bool()
+    noEnvCallsOutsideOfConfig: bool()
     noModelMake: bool()
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
@@ -40,6 +42,8 @@ parametersSchema:
     checkUnusedViews: bool()
 
 conditionalTags:
+    Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule:
+        phpstan.rules.rule: %noEnvCallsOutsideOfConfig%
     Larastan\Larastan\Rules\NoModelMakeRule:
         phpstan.rules.rule: %noModelMake%
     Larastan\Larastan\Rules\NoUnnecessaryCollectionCallRule:
@@ -375,6 +379,9 @@ services:
 
     -
         class: Larastan\Larastan\Rules\OctaneCompatibilityRule
+
+    -
+        class: Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule
 
     -
         class: Larastan\Larastan\Rules\NoModelMakeRule

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutChangesToGlobalState="true"
     bootstrap="phpunit-bootstrap.php"
     colors="true"
     failOnRisky="true"
     failOnWarning="true"
-    verbose="true"
 >
-  <testsuites>
-    <testsuite name="Test Suite">
-      <directory>./tests</directory>
-    </testsuite>
-  </testsuites>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Larastan\Larastan\Concerns\HasContainer;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Catches `env()` calls outside of the config directory.
+ *
+ * @implements Rule<FuncCall>
+ */
+class NoEnvCallsOutsideOfConfigRule implements Rule
+{
+    use HasContainer;
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /** @return array<int, RuleError> */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $node->name;
+
+        if (! $name instanceof Name) {
+            return [];
+        }
+
+        if ($scope->resolveName($name) !== 'env') {
+            return [];
+        }
+
+        if (! $this->isCalledOutsideOfConfig($node, $scope)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message("Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.")
+                ->identifier('rules.noEnvCallsOutsideOfConfig')
+                ->line($node->getLine())
+                ->file($scope->getFile())
+                ->build(),
+        ];
+    }
+
+    protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
+    {
+        return str_starts_with($scope->getFile(), config_path()) === false;
+    }
+}

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Illuminate\Foundation\Application;
+use Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use ReflectionClass;
+
+/** @extends RuleTestCase<NoEnvCallsOutsideOfConfigRule> */
+class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
+{
+    protected function setUp(): void
+    {
+        $this->overrideConfigPath(__DIR__.'/data/config');
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoEnvCallsOutsideOfConfigRule();
+    }
+
+    /** @test */
+    public function itDoesNotFailForEnvCallsInsideConfigDirectory(): void
+    {
+        $this->analyse([__DIR__.'/data/config/env-calls.php'], []);
+    }
+
+    /** @test */
+    public function itReportsEnvCallsOutsideOfConfigDirectory(): void
+    {
+        $this->analyse([__DIR__.'/data/env-calls.php'], [
+            ["Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.", 7],
+            ["Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.", 8],
+        ]);
+    }
+
+
+    protected function overrideConfigPath(string $path): void
+    {
+        $app = Application::getInstance();
+
+        if (version_compare(LARAVEL_VERSION, '10.0.0', '>=')) {
+            $app->useConfigPath($path);
+
+            return;
+        }
+
+        $reflectionClass = new ReflectionClass($app);
+        $property = $reflectionClass->getProperty('basePath');
+        $property->setAccessible(true);
+
+        $property->setValue($app, str_replace('/config', '', $path));
+    }
+}

--- a/tests/Rules/data/config/env-calls.php
+++ b/tests/Rules/data/config/env-calls.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+env('foo');
+\env('bar');

--- a/tests/Rules/data/env-calls.php
+++ b/tests/Rules/data/env-calls.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+use function Foo\Bar\env as scopedEnv;
+
+env('foo');
+\env('bar');
+
+// no report for namespaced calls
+\Foo\Bar\env('bar');
+scopedEnv('foo');


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Closes #1695.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Hello!

This PR adds a rule to report any `env` calls outside the config directory. Currently it just checks for a `config` directory in the file name where the call is located. A more robust solution might be to use the container to grab the configured config path? However this is more complicated and I wasn't sure how exactly to do such a thing.

Thanks!


<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
