### PR TITLE
feat: return array shape from model only method

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -163,6 +163,10 @@ services:
         class: Larastan\Larastan\Properties\ModelRelationsExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension
+    -
+        class: Larastan\Larastan\ReturnTypes\ModelOnlyDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
         class: Larastan\Larastan\ReturnTypes\ModelFactoryDynamicStaticMethodReturnTypeExtension

--- a/src/ReturnTypes/ModelOnlyDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelOnlyDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+use function array_map;
+use function array_filter;
+use function count;
+
+final class ModelOnlyDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'only';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $fields = $methodCall->getArgs();
+
+        if (count($fields) < 1) {
+            return new ErrorType();
+        }
+
+        if ($fields[0]->value instanceof Array_) {
+            $fields = $fields[0]->value->items;
+        }
+
+        $fields = array_map(static fn ($f) => $f->value, array_filter($fields));
+
+        $model = $scope->getType($methodCall->var);
+        $array = ConstantArrayTypeBuilder::createEmpty();
+
+        foreach ($fields as $field) {
+            if (! $field instanceof String_) {
+                return new ArrayType(new StringType(), new MixedType());
+            }
+
+            $name = $field->value;
+
+            $valueType = $model->hasProperty($name)->yes()
+                ? $model->getProperty($name, $scope)->getReadableType()
+                : new NullType();
+
+            $array->setOffsetValueType(new ConstantStringType($name), $valueType);
+        }
+
+        return $array->getArray();
+    }
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -48,6 +48,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__.'/data/carbon.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/contracts.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/higher-order-collection-proxy-methods.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/model-methods.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/model-relations.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/model-scopes.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/date-extension.php');

--- a/tests/Type/data/model-methods.php
+++ b/tests/Type/data/model-methods.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ModelRelations;
+
+use App\User;
+
+use function PHPStan\Testing\assertType;
+
+/** @var User $user */
+assertType('array{name: string, email: string}', $user->only('name', 'email'));
+assertType('array{name: string, email: string}', $user->only(['name', 'email']));
+assertType('array{name: string, nonexistent: null}', $user->only(['name', 'nonexistent']));
+assertType('array<string, mixed>', $user->only(['name', $foo]));

--- a/tests/Type/data/model-methods.php
+++ b/tests/Type/data/model-methods.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ModelRelations;
+namespace ModelMethods;
 
 use App\User;
 

--- a/tests/Type/data/model-methods.php
+++ b/tests/Type/data/model-methods.php
@@ -11,3 +11,13 @@ assertType('array{name: string, email: string}', $user->only('name', 'email'));
 assertType('array{name: string, email: string}', $user->only(['name', 'email']));
 assertType('array{name: string, nonexistent: null}', $user->only(['name', 'nonexistent']));
 assertType('array<string, mixed>', $user->only(['name', $foo]));
+
+$columns = ['name', 'email'];
+$foo = 'nonexistent';
+assertType('array{name: string, email: string}', $user->only(...$columns));
+assertType('array{name: string, email: string}', $user->only($columns));
+assertType('array{nonexistent: null}', $user->only($foo));
+assertType(
+    'array{name: string, email: string, nonexistent: null}',
+    $user->only([...$columns, $foo]),
+);


### PR DESCRIPTION
- [x] Added or updated tests
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Closes #1645 

**Changes**

Returns the array shape provided to `$model->only()`, credit goes to @simon-tma for writing the extension.

Thanks!
