### PR TITLE
fix: check relation parent instead of string in name for many/morph

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Properties;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Larastan\Larastan\Concerns;
@@ -114,7 +120,13 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
                 $relatedModelClassNames = $relatedModel->getObjectClassNames();
             }
 
-            if (Str::contains($type->getObjectClassNames()[0], 'Many')) {
+            if (
+                (new ObjectType(BelongsToMany::class))->isSuperTypeOf($type)->yes()
+                || (new ObjectType(HasMany::class))->isSuperTypeOf($type)->yes()
+                || (new ObjectType(HasManyThrough::class))->isSuperTypeOf($type)->yes()
+                || (new ObjectType(MorphMany::class))->isSuperTypeOf($type)->yes()
+                || (new ObjectType(MorphToMany::class))->isSuperTypeOf($type)->yes()
+            ) {
                 $types = [];
 
                 foreach ($relatedModelClassNames as $relatedModelClassName) {
@@ -126,7 +138,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
                 }
             }
 
-            if (Str::endsWith($type->getObjectClassNames()[0], 'MorphTo')) {
+            if ((new ObjectType(MorphTo::class))->isSuperTypeOf($type)->yes()) {
                 // There was no generic type, or it was just Model
                 // so we will return mixed to avoid errors.
                 if ($relatedModel->getObjectClassNames()[0] === Model::class) {

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -24,6 +24,7 @@ function foo(Foo $foo, Bar $bar, Account $account): void
     assertType('App\User|null', $account->ownerRelation);
     assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model|null', $foo->relationReturningUnion);
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>|ModelPropertiesRelations\Baz|null', $foo->relationReturningUnion2);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Foo>', $foo->ancestors);
 }
 
 /** @property string $name */
@@ -50,6 +51,12 @@ class Foo extends Model
     public function relationReturningUnion2(): HasMany|BelongsTo
     {
         return $this->name === 'foo' ? $this->hasMany(Bar::class) : $this->belongsTo(Baz::class);
+    }
+
+    /** @return Ancestors<Foo> */
+    public function ancestors(): Ancestors
+    {
+        //
     }
 }
 
@@ -78,5 +85,9 @@ class Bar extends Model
 }
 
 class Baz extends Model
+{
+}
+
+class Ancestors extends HasMany
 {
 }


### PR DESCRIPTION
**Changes**

Hello! 

Please see https://github.com/staudenmeir/laravel-adjacency-list/issues/216 for context. Some packages don't follow the convention of using `Many` or `MorphTo` in the relation class name and so the string check breaks. This PR checks for the parent relation to be more robust.

Thanks!