### PR TITLE
fix: Carbon v3 macro reflection

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Composer\InstalledVersions;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
 use Laravel\Lumen\Application as LumenApplication;
@@ -30,4 +31,8 @@ if ($app instanceof Application) {
 
 if (! defined('LARAVEL_VERSION')) {
     define('LARAVEL_VERSION', $app->version());
+}
+
+if (! defined('CARBON_VERSION')) {
+    define('CARBON_VERSION', InstalledVersions::getVersion('nesbot/carbon'));
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,16 +31,6 @@ parameters:
 			path: src/Properties/ModelAccessorExtension.php
 
 		-
-			message: "#^Constant LARAVEL_VERSION not found\\.$#"
-			count: 1
-			path: src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
-
-		-
-			message: "#^Constant LARAVEL_VERSION not found\\.$#"
-			count: 1
-			path: src/LarastanStubFilesExtension.php
-
-		-
 			message: "#^PHPDoc tag @var assumes the expression with type PHPStan\\\\Type\\\\Type\\|null is always PHPStan\\\\Type\\\\ObjectType but it's error\\-prone and dangerous\\.$#"
 			count: 1
 			path: src/ReturnTypes/RelationCollectionExtension.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,11 @@
 includes:
-    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
-    - phpstan-baseline.neon
+  - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+  - phpstan-baseline.neon
 parameters:
-    level: 8
-    phpVersion: 80000
-    paths:
-        - src
-    bootstrapFiles:
-        - bootstrap.php
+  level: 8
+  phpVersion: 80000
+  paths:
+    - src
+  bootstrapFiles:
+    - bootstrap.php
+  reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,3 +6,5 @@ parameters:
     phpVersion: 80000
     paths:
         - src
+    bootstrapFiles:
+        - bootstrap.php

--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -75,6 +75,7 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                 $classNames[] = Builder::class;
             }
         } elseif ($this->hasIndirectTraitUse($classReflection, CarbonMacro::class)) {
+            /** @phpstan-ignore-next-line Version is not constant */
             if (version_compare(CARBON_VERSION, '3.0.0', '>=')) {
                 $classNames = [FactoryImmutable::class];
                 $macroTraitProperty = 'notUsed';

--- a/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
@@ -48,6 +48,7 @@ class CollectionGenericStaticMethodDynamicMethodReturnTypeExtension implements D
             'splitIn', 'values', 'wrap', 'zip',
         ];
 
+        /** @phpstan-ignore-next-line Version is not constant */
         if (version_compare(LARAVEL_VERSION, '9.48.0', '<')) {
             $methods[] = 'countBy';
         }

--- a/tests/Type/data/carbon.php
+++ b/tests/Type/data/carbon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Carbon;
+use Carbon\Carbon;
 
 use function PHPStan\Testing\assertType;
 


### PR DESCRIPTION
Hello!

Carbon v3 switched from a static property to an instance property: https://github.com/briannesbitt/Carbon/commit/a12231089585d602c01bb4efa7c25f10bdbad0e2

This PR updates the macro extension to handle this change and should fix the pipeline.

Thanks!
