### PR TITLE
Add stub for Str::replace

### DIFF
--- a/stubs/common/Support/Str.stub
+++ b/stubs/common/Support/Str.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Traversable;
+
+class Str
+{
+    /**
+     * @template TKey of scalar
+     * @template TSubject of string|iterable<string>|Traversable<TKey,string>
+     * @param string|iterable<string> $search
+     * @param string|iterable<string> $replace
+     * @param TSubject $subject
+     * @param bool $caseSensitive
+     * @return ($subject is Traversable ? array<TKey,string> : TSubject)
+     */
+    public static function replace($search, $replace, $subject, $caseSensitive = true) {}
+}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -4,6 +4,7 @@ namespace Helpers;
 
 use App\User;
 use Exception;
+use Illuminate\Support\Str;
 use Larastan\Larastan\ApplicationResolver;
 use Throwable;
 
@@ -134,6 +135,10 @@ function strHelper()
 {
     assertType('Illuminate\Support\Stringable', str('foo'));
     assertType('mixed', str());
+
+    assertType('string', Str::replace('foo', 'bar', 'Laravel'));
+    assertType('array{string, string}', Str::replace('foo', 'bar', ['Laravel', 'Framework']));
+    assertType('array<int|string, string>', Str::replace('foo', 'bar', collect(['Laravel', 'Framework'])));
 }
 
 function tapHelper()


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Reopen of #1702 with rebase to 2.x branch, Traversable support and added tests.

**Changes**

In Laravel 10.16 the signature of the Str::replace method has changed, where the return type is now string|string[] instead of string. This MR will improve this behavior, according to the $subject parameter sets a specific return type.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
No breaking changes.
