### PR TITLE
fix: HasOneThrough relation being recognized as a collection

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -123,9 +124,14 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
             if (
                 (new ObjectType(BelongsToMany::class))->isSuperTypeOf($type)->yes()
                 || (new ObjectType(HasMany::class))->isSuperTypeOf($type)->yes()
-                || (new ObjectType(HasManyThrough::class))->isSuperTypeOf($type)->yes()
+                || (
+                    (new ObjectType(HasManyThrough::class))->isSuperTypeOf($type)->yes()
+                    // HasOneThrough extends HasManyThrough
+                    && ! (new ObjectType(HasOneThrough::class))->isSuperTypeOf($type)->yes()
+                )
                 || (new ObjectType(MorphMany::class))->isSuperTypeOf($type)->yes()
                 || (new ObjectType(MorphToMany::class))->isSuperTypeOf($type)->yes()
+                || Str::contains($type->getObjectClassNames()[0], 'Many') // fallback
             ) {
                 $types = [];
 
@@ -138,7 +144,10 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
                 }
             }
 
-            if ((new ObjectType(MorphTo::class))->isSuperTypeOf($type)->yes()) {
+            if (
+                (new ObjectType(MorphTo::class))->isSuperTypeOf($type)->yes()
+                || Str::endsWith($type->getObjectClassNames()[0], 'MorphTo') // fallback
+            ) {
                 // There was no generic type, or it was just Model
                 // so we will return mixed to avoid errors.
                 if ($relatedModel->getObjectClassNames()[0] === Model::class) {

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 use function PHPStan\Testing\assertType;
@@ -16,6 +17,7 @@ function foo(Foo $foo, Bar $bar, Account $account): void
 {
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyRelation);
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyThroughRelation);
+    assertType('ModelPropertiesRelations\Baz|null', $foo->hasOneThroughRelation);
     assertType('ModelPropertiesRelations\Foo', $bar->belongsToRelation);
     assertType('mixed', $bar->morphToRelation);
     assertType('App\Account|App\User', $bar->morphToUnionRelation);
@@ -40,6 +42,12 @@ class Foo extends Model
     public function hasManyThroughRelation(): HasManyThrough
     {
         return $this->hasManyThrough(Bar::class, User::class);
+    }
+
+    /** @return HasOneThrough<Baz> */
+    public function hasOneThroughRelation(): HasOneThrough
+    {
+        return $this->hasOneThrough(Baz::class, User::class);
     }
 
     public function relationReturningUnion(): HasMany|BelongsTo


### PR DESCRIPTION
Fixes (and adds a test for) the HasOneThrough regression caused by #1835. I also decided to readd the string checks at the end in case there are third party extensions that extend Relation for some reason.

Thanks!
