### PR TITLE
feat: infer nullable type information by filled/blank function calls

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -169,3 +169,23 @@ function optional($value = null, callable $callback = null) {}
  * @return ($value is empty ? TDefault : TReturn)
  */
 function transform($value, callable $callback, $default = null): mixed {}
+
+/**
+ * Determine if a value is "filled".
+ *
+ * @phpstan-assert-if-true !=null $value
+ *
+ * @param  mixed  $value
+ * @return bool
+ */
+function filled($value) {}
+
+/**
+ * Determine if the given value is "blank".
+ *
+ * @phpstan-assert-if-false !=null $value
+ *
+ * @param  mixed  $value
+ * @return bool
+ */
+function blank($value) {}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -189,3 +189,27 @@ function transformHelper()
     assertType('null', transform('', fn () => 1));
     assertType('null', transform([], fn () => 1));
 }
+
+function filledHelperNullInference()
+{
+    /** @var ?int $value */
+    $value = 0;
+
+    if (filled($value)) {
+        assertType('int', $value);
+    } else {
+        assertType('int|null', $value);
+    }
+}
+
+function blankHelperNullInference()
+{
+    /** @var ?int $value */
+    $value = 0;
+
+    if (blank($value)) {
+        assertType('int|null', $value);
+    } else {
+        assertType('int', $value);
+    }
+}


### PR DESCRIPTION
The result value of the `blank` and `filled` helpers imply some type information that is currently not supported by Larastan. To be precise, the `blank` helper will return `true` on null while the `filled` will return `false`. This enhanced type inference is especially usefull when working with nullable Eloquent attributes:

```php
if (filled($model->value)) {
  executeSomething($model->value);
}
```

Currently, PHPStan will report errors as `null` can't be passed to `executeSomething`. But the value can never be null because of a `true` result of the `filled` check. The new stubs help PHPStan to narrow the types of values passed to `filled` and `blank` functions.

Resolves #1290 

**Changes**

Added `blank` and `filled` helpers to the helper stubs

**Breaking changes**

None