### PR TITLE
chore: add tests for SupportCollection firstWhere

### DIFF
--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -74,6 +74,9 @@ assertType('App\User|bool', $collection->first(function (User $user) {
 assertType('App\User|null', $collection->firstWhere('blocked'));
 assertType('App\User|null', $collection->firstWhere('blocked', true));
 assertType('App\User|null', $collection->firstWhere('blocked', '=', true));
+assertType('App\User|null', $collectionOfUsers->firstWhere('name', 'Taylor'));
+assertType('array{id: int, type: string}|null', $foo->firstWhere('type', 'A'));
+assertType('string|null', $foo->firstWhere('type', 'A')['type'] ?? null);
 
 assertType('App\User|null', $collection->last());
 assertType('App\User|bool', $collection->last(null, false));


### PR DESCRIPTION
**Changes**

This adds tests for the SupportCollection `firstWhere` method and subsequently closes #1832 as the method is working as expected.

Thanks!