### PR TITLE
fix: model `first` not checking model properties

### DIFF
--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -101,7 +101,7 @@ class Builder
     /**
      * Execute the query and get the first result.
      *
-     * @param  array<model-property<TModelClass>|int, mixed>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @return TModelClass|null
      */
     public function first($columns = ['*']);

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -101,7 +101,7 @@ class Builder
     /**
      * Execute the query and get the first result.
      *
-     * @param  array<model-property<TModelClass>|int, mixed>|string  $columns
+     * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @return TModelClass|null
      */
     public function first($columns = ['*']);

--- a/tests/Rules/ModelPropertyRuleTest.php
+++ b/tests/Rules/ModelPropertyRuleTest.php
@@ -66,6 +66,9 @@ class ModelPropertyRuleTest extends RuleTestCase
                 'Property \'foo\' does not exist in App\\User model.',
                 32,
             ],
+            ["Property 'foo' does not exist in App\\User model.", 53],
+            ["Property 'bar' does not exist in App\\User model.", 53],
+            ["Property 'foo' does not exist in App\\User model.", 54],
         ]);
     }
 

--- a/tests/Rules/data/model-property-builder.php
+++ b/tests/Rules/data/model-property-builder.php
@@ -49,3 +49,6 @@ function getKey(): string
 
     return 'bar';
 }
+
+\App\User::query()->first(['foo', 'bar']);
+\App\User::query()->first('foo');


### PR DESCRIPTION
- [x] Added or updated tests

**Changes**
Closes #1824 

This corrects the eloquent builder stubs for the `first` method.

Also, I noticed that the `select` method wasn't working---it looks like this is only defined on the QueryBuilder which doesn't have the model generics

Thanks!