### PR TITLE
feat: return all auth models when no guard is specified

### DIFF
--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -8,17 +8,31 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 trait LoadsAuthModel
 {
-    /** @phpstan-return class-string|null */
-    private function getAuthModel(ConfigRepository $config, ?string $guard = null): ?string
+    /** @phpstan-return list<class-string> */
+    private function getAuthModels(ConfigRepository $config, ?string $guard = null): array
     {
-        if (
-            ($guard === null && ! ($guard = $config->get('auth.defaults.guard'))) ||
-            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
-            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
-        ) {
-            return null;
+        $guards = $config->get('auth.guards');
+        $providers = $config->get('auth.providers');
+
+        if (! is_array($guards) || ! is_array($providers)) {
+            return [];
         }
 
-        return $authModel;
+        return array_reduce(
+            is_null($guard) ? array_keys($guards) : [$guard],
+            function ($carry, $guardName) use ($guards, $providers) {
+                $provider = $guards[$guardName]['provider'] ?? null;
+                $authModel = $providers[$provider]['model'] ?? null;
+
+                if (! $authModel || in_array($authModel, $carry, strict: true)) {
+                    return $carry;
+                }
+
+                $carry[] = $authModel;
+
+                return $carry;
+            },
+            initial: [],
+        );
     }
 }

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -44,10 +44,12 @@ final class Auths implements PipeContract
         $config = $this->resolve('config');
 
         if ($config !== null && in_array($classReflectionName, $this->classes, true)) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
 
-            if ($authModel !== null) {
-                $found = $passable->sendToPipeline($authModel);
+            foreach ($authModels as $authModel) {
+                if ($found = $passable->sendToPipeline($authModel)) {
+                    break;
+                }
             }
         } elseif ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
             $found = $passable->sendToPipeline(

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -48,16 +48,21 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
         }
 
-        if ($authModel === null) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(...array_map(
+                fn (string $authModel): Type => new ObjectType($authModel),
+                $authModels,
+            )),
+        );
     }
 }

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -39,16 +39,21 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
         }
 
-        if ($authModel === null) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(...array_map(
+                fn (string $authModel): Type => new ObjectType($authModel),
+                $authModels,
+            )),
+        );
     }
 }

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -42,18 +42,23 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): ?Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
             $guard = $this->getGuardFromMethodCall($scope, $methodCall);
-            $authModel = $this->getAuthModel($config, $guard);
+            $authModels = $this->getAuthModels($config, $guard);
         }
 
-        if ($authModel === null) {
+        if (count($authModels) === 0) {
             return null;
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(...array_map(
+                fn (string $authModel): Type => new ObjectType($authModel),
+                $authModels,
+            )),
+        );
     }
 
     private function getGuardFromMethodCall(Scope $scope, MethodCall $methodCall): ?string

--- a/src/ReturnTypes/RequestUserExtension.php
+++ b/src/ReturnTypes/RequestUserExtension.php
@@ -49,18 +49,23 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
             $guard = $this->getGuardFromMethodCall($scope, $methodCall);
-            $authModel = $this->getAuthModel($config, $guard);
+            $authModels = $this->getAuthModels($config, $guard);
         }
 
-        if ($authModel === null) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(...array_map(
+                fn (string $authModel): Type => new ObjectType($authModel),
+                $authModels,
+            )),
+        );
     }
 
     private function getGuardFromMethodCall(Scope $scope, MethodCall $methodCall): ?string

--- a/tests/Type/data/auth.php
+++ b/tests/Type/data/auth.php
@@ -13,7 +13,7 @@ class AuthExtension
 {
     public function testUser(): void
     {
-        assertType('App\User|null', Auth::user());
+        assertType('App\Admin|App\User|null', Auth::user());
     }
 
     public function testCheck(): void

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -24,7 +24,7 @@ function authHelper()
     assertType('Illuminate\Auth\AuthManager', auth());
     assertType('Illuminate\Contracts\Auth\Guard', auth()->guard('web'));
     assertType('Illuminate\Contracts\Auth\StatefulGuard', auth('web'));
-    assertType('App\User|null', auth()->user());
+    assertType('App\Admin|App\User|null', auth()->user());
     assertType('bool', auth()->check());
     assertType('App\User|null', auth()->guard('web')->user());
     assertType('App\User|null', auth('web')->user());

--- a/tests/Type/data/request-user.php
+++ b/tests/Type/data/request-user.php
@@ -7,6 +7,6 @@ namespace RequestObject;
 use function PHPStan\Testing\assertType;
 
 /** @var \Illuminate\Http\Request $request */
-assertType('App\User|null', $request->user());
+assertType('App\Admin|App\User|null', $request->user());
 assertType('App\User|null', $request->user('web'));
 assertType('App\Admin|null', $request->user('admin'));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Hello!

This PR revives #1232 by @mirucon which was closed when the `master` branch was deleted.

The motivation for this PR is that the "default" guard in a Laravel application is **not** constant but is rather used by Laravel to store the currently *chosen* guard.

Calling `Auth::shouldUse` / `Auth::setDefaultDriver` overwrites the default given in the config file:
https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Auth/AuthManager.php#L201-L225

For example, I work on a large codebase with multiple guards and we use a middleware to set the "default" guard depending on the route. The result is that calling `Auth::user()` in different locations in the codebase results in *a different auth model returned*.

As this config change occurs at runtime, the best thing to do is to just return all possible auth models when there is no guard specified.

#### Note

As with the original author, I'm not too familiar with how the `Pipes\Auths` is used. Currently, I break after the first found model but perhaps I should continue to loop through all of the models? There don't seem to be any tests for the pipe classes.


**Breaking changes**

There might be a slight BC at level 7 when you can't call method on union types that don't exist on both types.

Thanks!