### PR TITLE
Add support for restoreOrCreate and createOrRestore SoftDelete macros.

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -105,7 +105,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         if ($ref === null) {
             // Special case for `SoftDeletes` trait
             if (
-                in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed', 'restore'], true) &&
+                in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed', 'restore', 'createOrRestore', 'restoreOrCreate'], true) &&
                 array_key_exists(SoftDeletes::class, $modelReflection->getTraits(true))
             ) {
                 $ref = $this->reflectionProvider->getClass(SoftDeletes::class)->getMethod($methodName, new OutOfClassScope());
@@ -116,6 +116,16 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
                         $classReflection,
                         ParametersAcceptorSelector::selectSingle($ref->getVariants())->getParameters(),
                         new IntegerType(),
+                        ParametersAcceptorSelector::selectSingle($ref->getVariants())->isVariadic()
+                    );
+                }
+
+                if ($methodName === 'restoreOrCreate' || $methodName === 'createOrRestore') {
+                    return new EloquentBuilderMethodReflection(
+                        $methodName,
+                        $classReflection,
+                        ParametersAcceptorSelector::selectSingle($ref->getVariants())->getParameters(),
+                        $modelType,
                         ParametersAcceptorSelector::selectSingle($ref->getVariants())->isVariadic()
                     );
                 }

--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -547,5 +547,7 @@ class Scope {}
  * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()
  * @method static bool restore()
+ * @method static static restoreOrCreate(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
+ * @method static static createOrRestore(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
  */
 trait SoftDeletes {}

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -538,5 +538,6 @@ class Scope {}
  * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()
  * @method static bool restore()
+ * @method static static restoreOrCreate(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
  */
 trait SoftDeletes {}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -73,6 +73,10 @@ class GeneralTypeTest extends TypeInferenceTestCase
             yield from self::gatherAssertTypes(__DIR__.'/data/query-builder-l10-24.php');
         }
 
+        if (version_compare(LARAVEL_VERSION, '10.44.0', '>=')) {
+            yield from self::gatherAssertTypes(__DIR__.'/data/bug-1819.php');
+        }
+
         //##############################################################################################################
 
         // Console Commands

--- a/tests/Type/data/bug-1819.php
+++ b/tests/Type/data/bug-1819.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bug1819;
+
+use App\User;
+use function PHPStan\Testing\assertType;
+
+function testCreateOrRestore(): void
+{
+    assertType('App\User', User::createOrRestore(['id' => 1]));
+}

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -471,3 +471,8 @@ trait HasBar
         return self::find(static::decodeHashId($id))->first();
     }
 }
+
+function testRestoreOrCreate(): void
+{
+    assertType('App\User', User::restoreOrCreate(['id' => 1]));
+}


### PR DESCRIPTION
- [x] Added or updated tests

closes https://github.com/larastan/larastan/issues/1819

**Changes**
Added support for 2 missing macros on the SoftDeletes trait; `restoreOrCreate` and `createOrRestore`. `createOrRestore` was added in Laravel 10.44.0 whereas `restoreOrCreate` has existed since `9.x`.

