### PR TITLE
Fix not respecting return type of overridden Request::user() method.

### DIFF
--- a/src/ReturnTypes/RequestUserExtension.php
+++ b/src/ReturnTypes/RequestUserExtension.php
@@ -10,7 +10,6 @@ use Larastan\Larastan\Concerns\LoadsAuthModel;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -39,7 +38,11 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope,
-    ): Type {
+    ): Type|null {
+        if ($methodReflection->getDeclaringClass()->getName() !== Request::class) {
+            return null;
+        }
+
         $config     = $this->getContainer()->get('config');
         $authModels = [];
 
@@ -49,7 +52,7 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
         }
 
         if (count($authModels) === 0) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+            return null;
         }
 
         return TypeCombinator::addNull(

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -21,6 +21,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/benchmark.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1346.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1565.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1718.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1760.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1830.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/carbon.php');

--- a/tests/Type/data/bug-1718.php
+++ b/tests/Type/data/bug-1718.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bug1718;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\User;
+use function PHPStan\Testing\assertType;
+
+class AuthedRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return parent::user() instanceof User;
+    }
+
+    public function user($guard = null): User
+    {
+        $user = parent::user($guard);
+        if (!$user instanceof User) {
+            abort(403);
+        }
+
+        return $user;
+    }
+}
+
+function test(AuthedRequest $request, FormRequest $formRequest): void
+{
+    assertType('App\User', $request->user());
+    assertType('App\Admin|App\User|null', $formRequest->user());
+}


### PR DESCRIPTION
- [x] Added or updated tests

closes https://github.com/larastan/larastan/issues/1718

**Changes**

Change RequestUserExtension to use the specific type of an overridden `Request::user()` method

