### PR TITLE
Fix UnusedViewsRule not providing an existing file path to RuleErrorBuilder

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Guide
 
+- The UnusedViewsRule has been changed to specify the absolute path of the unused view, rather than the view name. This may mean that baselines will need regenerating to account for this change.
+
 ## Upgrading to `2.7.0` from `2.6.5`
 
 ### Organization Change
@@ -89,7 +91,7 @@ Fix the docblock.
 
 ### Property App\\Http\\Middleware\\TrustProxies::\$headers \(string\) does not accept default value of type int
 
-Fix the docblock. 
+Fix the docblock.
 
 ```diff
 -    * @var string

--- a/src/Rules/UnusedViewsRule.php
+++ b/src/Rules/UnusedViewsRule.php
@@ -70,8 +70,10 @@ final class UnusedViewsRule implements Rule
 
         $errors = [];
         foreach ($unusedViews as $file) {
+            $path = $view->getFinder()->find($file);
+
             $errors[] = RuleErrorBuilder::message('This view is not used in the project.')
-                ->file($file.'.blade.php')
+                ->file($path)
                 ->line(0)
                 ->build();
         }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes
 
closes https://github.com/larastan/larastan/issues/1725

**Changes**

The `UnusedViewsRule` now uses the `ViewFinderInterface` to specify the full path to the unused view, rather than the short name. This is to resolve a constraint with a future version of PHPStan that will require all `RuleErrorBuilder->file()` calls to be absolute paths to existing files.

**Breaking changes**

It's likely that any past baselines that were generated including an `UnusedViewsRule` violation will need regenerating as the reported path will change. Not alot we can do about that though as it's a necessary change for a future version of phpstan.
