### PR TITLE
Fixed issue where collections with invalid templates configured would cause a fatal error.

### DIFF
--- a/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
@@ -109,6 +109,10 @@ class CollectionGenericStaticMethodDynamicMethodReturnTypeExtension implements D
 
         $genericTypes = $returnTypeClassReflection->typeMapToList($returnTypeClassReflection->getActiveTemplateTypeMap());
 
+        if ($genericTypes === []) {
+            return new ObjectType($classReflection->getName());
+        }
+
         // If the key type is gonna be a model, we change it to string
         if ((new ObjectType(Model::class))->isSuperTypeOf($genericTypes[0])->yes()) {
             $genericTypes[0] = new StringType();

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -20,6 +20,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__.'/data/auth.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/benchmark.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/bug-1346.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/bug-1565.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/bug-1760.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/bug-1830.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/carbon.php');

--- a/tests/Type/data/bug-1565.php
+++ b/tests/Type/data/bug-1565.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bug1565;
+
+use Illuminate\Support\Collection;
+
+use function PHPStan\Testing\assertType;
+
+class TestCollection extends Collection
+{
+    public function map(callable $callback): static
+    {
+        $keys = array_keys($this->items);
+
+        $items = array_map($callback, $this->items, $keys);
+
+        return new static(array_combine($keys, $items));
+    }
+
+    public function toArray(): array
+    {
+        return $this->map(fn($block) => $block->toArray())->values()->all();
+    }
+}
+
+function test(TestCollection $collection): void
+{
+    assertType('mixed', $collection->random());
+    assertType('Bug1565\TestCollection', $collection->map(fn ($val) => 'string'));
+}


### PR DESCRIPTION
- [x] Added or updated tests

closes https://github.com/larastan/larastan/issues/1565

**Changes**

Fixes a long standing issue where custom collections that don't specify `@extends` cause crashes when calling functions on them that are handled by `CollectionGenericStaticMethodDynamicMethodReturnTypeExtension`.

Comments in the report suggest adding a rule to enforce that collections always have `@extends` but this seems superfluous as phpstan already reports this at a sufficiently high level. 


