### PR TITLE
fix: float not assignable to decimal cast

### DIFF
--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -100,7 +100,7 @@ class ModelCastHelper
         $attributeType = match ($cast) {
             'int', 'integer', 'timestamp' => new IntegerType(),
             'real', 'float', 'double' => new FloatType(),
-            'decimal' => TypeCombinator::intersect(new StringType(), new AccessoryNumericStringType()),
+            'decimal' => TypeCombinator::intersect(new StringType(), new AccessoryNumericStringType(), new FloatType()),
             'string' => new StringType(),
             'bool', 'boolean' => TypeCombinator::union(new BooleanType(), new ConstantIntegerType(0), new ConstantIntegerType(1)),
             'object' => new ObjectType('stdClass'),


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Closes #1869

**Changes**
Hello!

This PR updates the Eloquent `decimal` writable type to accept `float`.

I also tried to cleanup the file a bit by using the `::class` constant instead of the entire raw class string, but feel free to pop that off if you don't like it.

Thanks!