### PR TITLE
fix: return $this from builder methods

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -16,10 +16,9 @@ use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 
 use function array_key_exists;
 use function in_array;
@@ -113,7 +112,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             } elseif ($methodName === 'restoreOrCreate' || $methodName === 'createOrRestore') {
                 $returnType = $modelType;
             } else {
-                $returnType = new GenericObjectType($classReflection->getName(), [$modelType]);
+                $returnType = new ThisType($classReflection);
             }
 
             return new EloquentBuilderMethodReflection(
@@ -134,10 +133,8 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
         if (in_array($methodName, $this->builderHelper->passthru, true)) {
             $returnType = $parametersAcceptor->getReturnType();
-        } elseif ($classReflection->isGeneric()) {
-            $returnType = new GenericObjectType($classReflection->getName(), [$modelType]);
         } else {
-            $returnType = new ObjectType($classReflection->getName());
+            $returnType = new ThisType($classReflection);
         }
 
         return new EloquentBuilderMethodReflection(

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -36,8 +36,11 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
     /** @var array<string, MethodReflection> */
     private array $cache = [];
 
-    public function __construct(private BuilderHelper $builderHelper, private ReflectionProvider $reflectionProvider, private EloquentBuilderForwardsCallsExtension $eloquentBuilderForwardsCallsExtension)
-    {
+    public function __construct(
+        private BuilderHelper $builderHelper,
+        private ReflectionProvider $reflectionProvider,
+        private EloquentBuilderForwardsCallsExtension $eloquentBuilderForwardsCallsExtension,
+    ) {
     }
 
     /**
@@ -76,99 +79,11 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             return null;
         }
 
-        $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
-
         if (in_array($methodName, ['increment', 'decrement'], true)) {
-            $methodReflection = $classReflection->getNativeMethod($methodName);
-
-            return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection
-            {
-                private ClassReflection $classReflection;
-
-                private string $methodName;
-
-                private MethodReflection $methodReflection;
-
-                public function __construct(ClassReflection $classReflection, string $methodName, MethodReflection $methodReflection)
-                {
-                    $this->classReflection  = $classReflection;
-                    $this->methodName       = $methodName;
-                    $this->methodReflection = $methodReflection;
-                }
-
-                public function getDeclaringClass(): ClassReflection
-                {
-                    return $this->classReflection;
-                }
-
-                public function isStatic(): bool
-                {
-                    return false;
-                }
-
-                public function isPrivate(): bool
-                {
-                    return false;
-                }
-
-                public function isPublic(): bool
-                {
-                    return true;
-                }
-
-                public function getDocComment(): string|null
-                {
-                    return null;
-                }
-
-                public function getName(): string
-                {
-                    return $this->methodName;
-                }
-
-                public function getPrototype(): ClassMemberReflection
-                {
-                    return $this;
-                }
-
-                /** @return ParametersAcceptor[] */
-                public function getVariants(): array
-                {
-                    return $this->methodReflection->getVariants();
-                }
-
-                public function isDeprecated(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function getDeprecatedDescription(): string|null
-                {
-                    return null;
-                }
-
-                public function isFinal(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function isInternal(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function getThrowType(): Type|null
-                {
-                    return null;
-                }
-
-                public function hasSideEffects(): TrinaryLogic
-                {
-                    return TrinaryLogic::createYes();
-                }
-            };
+            return $this->counterMethodReflection($classReflection, $methodName);
         }
 
+        $builderName                = $this->builderHelper->determineBuilderName($classReflection->getName());
         $builderReflection          = $this->reflectionProvider->getClass($builderName)->withTypes([new ObjectType($classReflection->getName())]);
         $genericBuilderAndModelType = new GenericObjectType($builderName, [new ObjectType($classReflection->getName())]);
 
@@ -229,5 +144,88 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
 
             return $traverse($type);
         });
+    }
+
+    private function counterMethodReflection(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        $methodReflection = $classReflection->getNativeMethod($methodName);
+
+        return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection
+        {
+            public function __construct(private ClassReflection $classReflection, private string $methodName, private MethodReflection $methodReflection)
+            {
+            }
+
+            public function getDeclaringClass(): ClassReflection
+            {
+                return $this->classReflection;
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): string|null
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->methodName;
+            }
+
+            public function getPrototype(): ClassMemberReflection
+            {
+                return $this;
+            }
+
+            /** @return ParametersAcceptor[] */
+            public function getVariants(): array
+            {
+                return $this->methodReflection->getVariants();
+            }
+
+            public function isDeprecated(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): string|null
+            {
+                return null;
+            }
+
+            public function isFinal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function isInternal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getThrowType(): Type|null
+            {
+                return null;
+            }
+
+            public function hasSideEffects(): TrinaryLogic
+            {
+                return TrinaryLogic::createYes();
+            }
+        };
     }
 }

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -35,19 +35,14 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
         $builderReflection = $this->reflectionProvider->getClass(EloquentBuilder::class);
+        $hasNativeMethod   = $builderReflection->hasNativeMethod($methodReflection->getName());
 
         // Don't handle dynamic wheres
-        if (
-            Str::startsWith($methodReflection->getName(), 'where') &&
-            ! $builderReflection->hasNativeMethod($methodReflection->getName())
-        ) {
+        if (Str::startsWith($methodReflection->getName(), 'where') && ! $hasNativeMethod) {
             return false;
         }
 
-        if (
-            Str::startsWith($methodReflection->getName(), 'find') &&
-            $builderReflection->hasNativeMethod($methodReflection->getName())
-        ) {
+        if (Str::startsWith($methodReflection->getName(), 'find') && $hasNativeMethod) {
             return false;
         }
 
@@ -61,7 +56,7 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
             return false;
         }
 
-        return $builderReflection->hasNativeMethod($methodReflection->getName());
+        return $hasNativeMethod;
     }
 
     public function getTypeFromMethodCall(

--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -16,23 +16,6 @@ class Builder
      */
     public function make(array $attributes = []);
 
-    /**
-     * Register a new global scope.
-     *
-     * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
-     * @return static
-     */
-    public function withGlobalScope($identifier, $scope);
-
-    /**
-     * Remove a registered global scope.
-     *
-     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return static
-     */
-    public function withoutGlobalScope($scope);
-
     /** @phpstan-return TModelClass */
     public function getModel();
 
@@ -190,7 +173,7 @@ class Builder
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -202,7 +185,7 @@ class Builder
      * @param  string  $relation
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orHas($relation, $operator = '>=', $count = 1);
 
@@ -212,7 +195,7 @@ class Builder
      * @param  string  $relation
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', \Closure $callback = null);
 
@@ -220,7 +203,7 @@ class Builder
      * Add a relationship count / exists condition to the query with an "or".
      *
      * @param  string  $relation
-     * @return static
+     * @return $this
      */
     public function orDoesntHave($relation);
 
@@ -231,7 +214,7 @@ class Builder
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return static
+     * @return $this
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and');
 
@@ -252,7 +235,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function whereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -265,7 +248,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function withWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -276,7 +259,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -287,7 +270,7 @@ class Builder
      * @param  \Closure|string|array<int, string>|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return $this
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null);
 
@@ -302,7 +285,7 @@ class Builder
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', \Closure $callback = null);
 
@@ -315,7 +298,7 @@ class Builder
      * @param  string|array<string>  $types
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1);
 
@@ -328,7 +311,7 @@ class Builder
      * @param  string|array<string>  $types
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', \Closure $callback = null);
 
@@ -339,7 +322,7 @@ class Builder
      * @template TChildModel of Model
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
-     * @return static
+     * @return $this
      */
     public function orDoesntHaveMorph($relation, $types);
 
@@ -353,7 +336,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function whereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -367,7 +350,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orWhereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -379,7 +362,7 @@ class Builder
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, \Closure $callback = null);
 
@@ -391,7 +374,7 @@ class Builder
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, \Closure $callback = null);
 
@@ -399,7 +382,7 @@ class Builder
      * Merge the where constraints from another query to the current query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $from
-     * @return static
+     * @return $this
      */
     public function mergeConstraintsFrom(\Illuminate\Database\Eloquent\Builder $from);
 
@@ -408,7 +391,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function orWhereDoesntHave($relation, \Closure $callback = null);
 
@@ -417,7 +400,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function whereDoesntHave($relation, \Closure $callback = null);
 
@@ -539,7 +522,7 @@ class Builder
      * @param  \Closure|string|array<mixed>|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return $this
      */
     public function whereRelation($relation, $column, $operator = null, $value = null);
 

--- a/stubs/10.0.0/QueryBuilder.stub
+++ b/stubs/10.0.0/QueryBuilder.stub
@@ -313,27 +313,6 @@ class Builder
     public function decrement($column, $amount = 1, array $extra = []);
 
     /**
-     * Get the raw SQL representation of the query with embedded bindings.
-     *
-     * @return string
-     */
-    public function toRawSql();
-
-    /**
-     * Dump the raw current SQL with embedded bindings.
-     *
-     * @return $this
-     */
-    public function dumpRawSql();
-
-    /**
-     * Die and dump the current SQL with embedded bindings.
-     *
-     * @return never
-     */
-    public function ddRawSql();
-
-    /**
      * Get a lazy collection for the given query.
      *
      * @phpstan-return \Illuminate\Support\LazyCollection<int, mixed>

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -16,23 +16,6 @@ class Builder
      */
     public function make(array $attributes = []);
 
-    /**
-     * Register a new global scope.
-     *
-     * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
-     * @return static
-     */
-    public function withGlobalScope($identifier, $scope);
-
-    /**
-     * Remove a registered global scope.
-     *
-     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return static
-     */
-    public function withoutGlobalScope($scope);
-
     /** @phpstan-return TModelClass */
     public function getModel();
 
@@ -181,7 +164,7 @@ class Builder
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -193,7 +176,7 @@ class Builder
      * @param  string  $relation
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orHas($relation, $operator = '>=', $count = 1);
 
@@ -203,7 +186,7 @@ class Builder
      * @param  string  $relation
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', \Closure $callback = null);
 
@@ -211,7 +194,7 @@ class Builder
      * Add a relationship count / exists condition to the query with an "or".
      *
      * @param  string  $relation
-     * @return static
+     * @return $this
      */
     public function orDoesntHave($relation);
 
@@ -222,7 +205,7 @@ class Builder
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return static
+     * @return $this
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and');
 
@@ -256,7 +239,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function withWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -267,7 +250,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -278,7 +261,7 @@ class Builder
      * @param  \Closure|string|array<int, string>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return $this
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null);
 
@@ -293,7 +276,7 @@ class Builder
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', \Closure $callback = null);
 
@@ -306,7 +289,7 @@ class Builder
      * @param  string|array<string>  $types
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1);
 
@@ -319,7 +302,7 @@ class Builder
      * @param  string|array<string>  $types
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', \Closure $callback = null);
 
@@ -330,7 +313,7 @@ class Builder
      * @template TChildModel of Model
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
-     * @return static
+     * @return $this
      */
     public function orDoesntHaveMorph($relation, $types);
 
@@ -344,7 +327,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function whereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -358,7 +341,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return static
+     * @return $this
      */
     public function orWhereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1);
 
@@ -370,7 +353,7 @@ class Builder
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, \Closure $callback = null);
 
@@ -382,7 +365,7 @@ class Builder
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, \Closure $callback = null);
 
@@ -390,7 +373,7 @@ class Builder
      * Merge the where constraints from another query to the current query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $from
-     * @return static
+     * @return $this
      */
     public function mergeConstraintsFrom(\Illuminate\Database\Eloquent\Builder $from);
 
@@ -399,7 +382,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function orWhereDoesntHave($relation, \Closure $callback = null);
 
@@ -408,7 +391,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return static
+     * @return $this
      */
     public function whereDoesntHave($relation, \Closure $callback = null);
 
@@ -530,7 +513,7 @@ class Builder
      * @param  \Closure|string|array<mixed>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return $this
      */
     public function whereRelation($relation, $column, $operator = null, $value = null);
 

--- a/tests/Type/data/bug-1346.php
+++ b/tests/Type/data/bug-1346.php
@@ -18,6 +18,6 @@ class DailyQuery
 
     public function daily()
     {
-        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $this->query->select());
+        assertType('Illuminate\Database\Eloquent\Builder<TModel of Illuminate\Database\Eloquent\Model (class Bug1346\DailyQuery, argument)>', $this->query->select());
     }
 }

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -432,7 +432,7 @@ function testJoinSubAllowsEloquentBuilder()
  */
 function testQueryBuilderOnEloquentBuilderWithBaseModel(EloquentBuilder $query): void
 {
-    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query->select());
+    assertType('Illuminate\Database\Eloquent\Builder<TModelClass of Illuminate\Database\Eloquent\Model (function EloquentBuilder\testQueryBuilderOnEloquentBuilderWithBaseModel(), argument)>', $query->select());
 }
 
 function testPaginate()

--- a/tests/Type/data/model-scopes.php
+++ b/tests/Type/data/model-scopes.php
@@ -70,4 +70,18 @@ class Scopes extends Model
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->where('foo')->someScope());
         assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $user->where('foo')->someScope()->get());
     }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    public function testScopeReturnStatic(Builder $query): Builder
+    {
+        $query = $query->where('foo', 'bar')
+            ->orWhereNull('foo');
+
+        assertType('Illuminate\Database\Eloquent\Builder<static(ModelScope\Scopes)>', $query);
+
+        return $query;
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Related to #1871 and #1870 (but does not fully solve). Closes #1676. Should close #1538 (but will want to confirm).

**Changes**
Hello!

This PR updates the Builder methods to properly return `$this` (previously there was a mix of $this, static, and self) instead of creating new object classes.

I also included some slight refactors to simplify and improve the readability of the code---this includes things like removing duplicated code, returning early, reducing the number of indentation levels, etc. However, I've carefully segregated the changes into their own commits to make reviewing the changes easier---if the whole diff is a little hard to follow the individual commits should help to walk through the changes made.

Breaking changes

If users have specified the return type to be `static` or `self` they might need to update to `$this` (depending on their phpstan level).

Thanks!