### PR TITLE
fix: illegal offset type

### DIFF
--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -26,7 +26,12 @@ trait LoadsAuthModel
         return array_reduce(
             $guard === null ? array_keys($guards) : [$guard],
             static function ($carry, $guardName) use ($guards, $providers) {
-                $provider  = $guards[$guardName]['provider'] ?? null;
+                $provider = $guards[$guardName]['provider'] ?? null;
+
+                if (! $provider) {
+                    return $carry;
+                }
+
                 $authModel = $providers[$provider]['model'] ?? null;
 
                 if (! $authModel || in_array($authModel, $carry, strict: true)) {


### PR DESCRIPTION
Hello!

This fixes the illegal offset type in LoadsAuthModel and closes #1887.

Thanks!