### PR TITLE
route name existence rule

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -468,6 +468,7 @@ services:
             dispatchableClass: Illuminate\Foundation\Events\Dispatchable
         tags:
             - phpstan.rules.rule
+
     - Larastan\Larastan\Properties\Schema\PhpMyAdminDataTypeToPhpTypeConverter
 
     -
@@ -559,3 +560,5 @@ rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessValueFunctionCallsRule
     - Larastan\Larastan\Rules\DeferrableServiceProviderMissingProvidesRule
     - Larastan\Larastan\Rules\ConsoleCommand\UndefinedArgumentOrOptionRule
+    - Larastan\Larastan\Rules\RouteNameExistenceRule
+    

--- a/src/Rules/RouteNameExistenceRule.php
+++ b/src/Rules/RouteNameExistenceRule.php
@@ -1,0 +1,80 @@
+<?php 
+
+namespace Larastan\Larastan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Illuminate\Routing\Router;
+use Larastan\Larastan\Concerns;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use Larastan\Larastan\Internal\ConsoleApplicationResolver;
+/**
+ * @implements Rule<FuncCall>
+ */
+class RouteNameExistenceRule implements Rule
+{
+
+
+	use Concerns\HasContainer;
+
+    /**
+     * @var array<int|string,int>
+     */
+    static ?array $namedRoutes = null;
+    /** @var array<string> */
+    protected array $methods = ['route', 'to_route'];
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+        $name = $node->name;
+
+        if (! $name instanceof Name) {
+            return [];
+        }
+
+        $functionName = $scope->resolveName($name);
+
+        if (! in_array($functionName, $this->methods)) {
+            return [];
+        }
+
+		$args = $node->getArgs();
+
+		if (count($args) === 0) {
+			return [];
+		}
+
+        $argType = $scope->getType($args[0]->value);
+        $constantStrings = $argType->getConstantStrings();
+
+        if (!$constantStrings) {
+            return [];
+        }
+
+        if (!self::$namedRoutes) {
+            $router = $this->resolve('router');
+            self::$namedRoutes = array_flip(array_keys($router->getRoutes()->getRoutesByName()));
+        }
+        dump(self::$namedRoutes);
+        $routeName = $constantStrings[0]->getValue();
+
+        if (array_key_exists($routeName, self::$namedRoutes)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message("Route name: \"{$routeName}\" does not exist'")
+                ->identifier('larastan.routeNameDoesNotExists')
+                ->build(),
+        ];
+	}
+
+}

--- a/src/Rules/RouteNameExistenceRule.php
+++ b/src/Rules/RouteNameExistenceRule.php
@@ -1,0 +1,80 @@
+<?php 
+
+namespace Larastan\Larastan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Illuminate\Routing\Router;
+use Larastan\Larastan\Concerns;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use Larastan\Larastan\Internal\ConsoleApplicationResolver;
+/**
+ * @implements Rule<FuncCall>
+ */
+class RouteNameExistenceRule implements Rule
+{
+
+
+	use Concerns\HasContainer;
+
+    /**
+     * @var array<int|string,int>
+     */
+    static ?array $namedRoutes = null;
+    /** @var array<string> */
+    protected array $methods = ['route', 'to_route'];
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+        $name = $node->name;
+
+        if (! $name instanceof Name) {
+            return [];
+        }
+
+        $functionName = $scope->resolveName($name);
+
+        if (! in_array($functionName, $this->methods)) {
+            return [];
+        }
+
+		$args = $node->getArgs();
+
+		if (count($args) === 0) {
+			return [];
+		}
+
+        $argType = $scope->getType($args[0]->value);
+        $constantStrings = $argType->getConstantStrings();
+
+        if (!$constantStrings) {
+            return [];
+        }
+
+        if (!self::$namedRoutes) {
+            $router = $this->resolve('router');
+            self::$namedRoutes = array_flip(array_keys($router->getRoutes()->getRoutesByName()));
+        }
+
+        $routeName = $constantStrings[0]->getValue();
+
+        if (array_key_exists($routeName, self::$namedRoutes)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message("Route name: \"{$routeName}\" does not exist'")
+                ->identifier('larastan.routeNameDoesNotExists')
+                ->build(),
+        ];
+	}
+
+}

--- a/src/Rules/RouteNameExistenceRule.php
+++ b/src/Rules/RouteNameExistenceRule.php
@@ -70,7 +70,7 @@ class RouteNameExistenceRule implements Rule
         }
 
         return [
-            RuleErrorBuilder::message("Route name: \"{$routeName}\" does not exist'")
+            RuleErrorBuilder::message("Route name: '{$routeName}' does not exist")
                 ->identifier('larastan.routeNameDoesNotExists')
                 ->build(),
         ];

--- a/tests/Rules/RouteNameExistenceRuleTest.php
+++ b/tests/Rules/RouteNameExistenceRuleTest.php
@@ -23,11 +23,13 @@ class RouteNameExistenceRuleTest extends RuleTestCase
     }
 
     /** @test */
-    public function itDoesNotFailForExistingRoutes(): void
+    public function itDoesFailForNonExistingRoutes(): void
     {
+        app('router')->get('/foo123', fn() => 'foo')->name('foo');
+        app('router')->getRoutes()->refreshNameLookups();
         $this->analyse([__DIR__ . '/data/route-calls.php'], [
-            ['06: Route name: "bar" does not exist', 6],
-            ['05: Route name: "foo" does not exist', 5],
+            ["Route name: 'bar' does not exist", 9],
+            ["Route name: 'bar' does not exist", 10],
         ]);
     }
 }

--- a/tests/Rules/RouteNameExistenceRuleTest.php
+++ b/tests/Rules/RouteNameExistenceRuleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Illuminate\Foundation\Application;
+use Larastan\Larastan\Rules\RouteNameExistenceRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use ReflectionClass;
+use Larastan\Larastan\Internal\ConsoleApplicationResolver;
+use function str_replace;
+use function version_compare;
+
+/** @extends RuleTestCase<RouteNameExistenceRule> */
+class RouteNameExistenceRuleTest extends RuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new RouteNameExistenceRule();
+    }
+
+    /** @test */
+    public function itDoesNotFailForExistingRoutes(): void
+    {
+        $this->analyse([__DIR__ . '/data/route-calls.php'], [
+            ['06: Route name: "bar" does not exist', 6],
+            ['05: Route name: "foo" does not exist', 5],
+        ]);
+    }
+}

--- a/tests/Rules/data/route-calls.php
+++ b/tests/Rules/data/route-calls.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/foo123', fn() => 'foo')->name('foo');
+
+route('foo');
+to_route('foo');
+route('bar');
+to_route('bar');
+

--- a/tests/Rules/data/route-calls.php
+++ b/tests/Rules/data/route-calls.php
@@ -4,8 +4,6 @@ namespace Tests\Rules\Data;
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/foo123', fn() => 'foo')->name('foo');
-
 route('foo');
 to_route('foo');
 route('bar');


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Using `route('non_existing_route')` will now give phpstan error: "Route name: \"{$routeName}\" does not exist'"
