### PR TITLE
docs: document model relationships

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -40,8 +40,9 @@ protected function isTrue(): Attribute
 In order for Larastan to recognize Model relationships:
 - the return type must be defined
 - the method must be `public`
-- the class argument must be a literal string (not a variable)
-- if the above conditions are not met, then adding the `@return` docblock can help
+- the relationship method argument must be a literal string (not a variable)
+
+If the above conditions are not met, then adding the `@return` docblock can help
 
 ```php
 /** @return BelongsTo<User, $this> */

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,7 +1,6 @@
 # Features
 
-All features that are specific to Laravel applications 
-are listed here.
+All features that are specific to Laravel applications are listed here.
 
 ## Laravel 9 Attributes
 
@@ -36,3 +35,24 @@ protected function isTrue(): Attribute
 }
 ```
 
+## Model Relationships
+
+In order for Larastan to recognize Model relationships:
+- the return type must be defined
+- the method must be `public`
+- the class argument must be a literal string (not a variable)
+- if the above conditions are not met, then adding the `@return` docblock can help
+
+```php
+/** @return BelongsTo<User, $this> */
+public function user(): BelongsTo
+{
+    return $this->belongsTo(User::class);
+}
+
+/** @return HasMany<Post> */
+public function posts(): HasMany
+{
+    return $this->hasMany(Post::class);
+}
+```


### PR DESCRIPTION
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Related to #1902 

Hello!

This documents that model relationships must be `public` and have their return type defined to be recognized as a relationship to help avoid future confusion.

Thanks!


