### PR TITLE
Make Scope interface generic.

### DIFF
--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -20,7 +20,7 @@ class Builder
      * Register a new global scope.
      *
      * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope<static, TModelClass>|\Closure  $scope
      * @return static
      */
     public function withGlobalScope($identifier, $scope);

--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -28,7 +28,7 @@ class Builder
     /**
      * Remove a registered global scope.
      *
-     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope<static, TModelClass>|string  $scope
      * @return static
      */
     public function withoutGlobalScope($scope);

--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -553,8 +553,6 @@ class Builder
     public function chunk($count, $callback);
 }
 
-class Scope {}
-
 /**
  * @method static \Illuminate\Database\Eloquent\Builder<static> withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -20,7 +20,7 @@ class Builder
      * Register a new global scope.
      *
      * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope<static, TModelClass>|\Closure  $scope
      * @return static
      */
     public function withGlobalScope($identifier, $scope);

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -545,20 +545,6 @@ class Builder
 }
 
 /**
- * @template TModelClass of Model
- */
-class Scope {
-    /**
-     * Apply the scope to a given Eloquent query builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $builder
-     * @param  TModelClass  $model
-     * @return void
-     */
-    public function apply(Builder $builder, Model $model);
-}
-
-/**
  * @method static \Illuminate\Database\Eloquent\Builder<static> withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -28,7 +28,7 @@ class Builder
     /**
      * Remove a registered global scope.
      *
-     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope<static, TModelClass>|string  $scope
      * @return static
      */
     public function withoutGlobalScope($scope);

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -544,7 +544,19 @@ class Builder
     public function chunk($count, $callback);
 }
 
-class Scope {}
+/**
+ * @template TModelClass of Model
+ */
+class Scope {
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $builder
+     * @param  TModelClass  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model);
+}
 
 /**
  * @method static \Illuminate\Database\Eloquent\Builder<static> withTrashed(bool $withTrashed = true)

--- a/stubs/common/EloquentScope.stub
+++ b/stubs/common/EloquentScope.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @template TModelClass of Model
+ */
+class Scope {
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $builder
+     * @param  TModelClass  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model);
+}

--- a/stubs/common/EloquentScope.stub
+++ b/stubs/common/EloquentScope.stub
@@ -3,14 +3,15 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
+ * @template TBuilder of Builder
  * @template TModelClass of Model
  */
 class Scope {
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<TModelClass>  $builder
-     * @param  TModelClass  $model
+     * @param TBuilder $builder
+     * @param TModelClass $model
      * @return void
      */
     public function apply(Builder $builder, Model $model);

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -30,6 +30,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/contracts.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/custom-eloquent-builder.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/custom-eloquent-collection.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/custom-eloquent-scope.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/database-transaction.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-builder.php');

--- a/tests/Type/data/custom-eloquent-scope.php
+++ b/tests/Type/data/custom-eloquent-scope.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Scope;
+
+use function PHPStan\Testing\assertType;
+
+/** @implements Scope<Illuminate\Database\Eloquent\Builder<App\User>,App\User> */
+class UserScope implements Scope
+{
+    public function apply($builder, $model): void
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $builder);
+        assertType('App\User', $model);
+    }
+}
+
+/** @implements Scope<App\PostBuilder<App\Post>,App\Post> */
+class PostScope implements Scope
+{
+    public function apply($builder, $model): void
+    {
+        assertType('App\PostBuilder<App\Post>', $builder);
+        assertType('App\Post', $model);
+    }
+}
+
+/** @implements Scope<App\NonGenericPostBuilder,App\Post> */
+class PostWithNonGenericBuilderScope implements Scope
+{
+    public function apply($builder, $model): void
+    {
+        assertType('App\NonGenericPostBuilder', $builder);
+        assertType('App\Post', $model);
+    }
+}

--- a/tests/application/app/NonGenericPostBuilder.php
+++ b/tests/application/app/NonGenericPostBuilder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @extends Builder<Post>
+ */
+class NonGenericPostBuilder extends Builder
+{
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Make the `Scope` eloquent class generic, so the `apply` method has proper type hinting and extension support.

**Breaking changes**

Not really. I could not find documentation about what you consider "breaking". Are new phpstan errors considered "breaking"? 


----

I need a little guidance or help/contribution as to how to write tests for this change. :) 
