### PR TITLE
Update `report` parameter in `rescue` stub to match laravel

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -87,17 +87,6 @@ function url($path = null, $parameters = [], $secure = null) {}
 
 /**
  * @template TValue
- * @template TDefault
- *
- * @param callable(): TValue $callback
- * @param TDefault|(callable(\Throwable): TDefault) $rescue
- * @param bool|callable $report
- * @return TValue|TDefault
- */
-function rescue(callable $callback, $rescue = null, $report = true) {}
-
-/**
- * @template TValue
  * @param int|array<int, int> $times
  * @param callable(int): TValue $callback
  * @param int|callable(int, \Exception): int $sleepMilliseconds

--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -87,6 +87,17 @@ function url($path = null, $parameters = [], $secure = null) {}
 
 /**
  * @template TValue
+ * @template TDefault
+ *
+ * @param callable(): TValue $callback
+ * @param TDefault|(callable(\Throwable): TDefault) $rescue
+ * @param bool|callable $report
+ * @return TValue|TDefault
+ */
+function rescue(callable $callback, $rescue = null, $report = true) {}
+
+/**
+ * @template TValue
  * @param int|array<int, int> $times
  * @param callable(int): TValue $callback
  * @param int|callable(int, \Exception): int $sleepMilliseconds

--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -91,7 +91,7 @@ function url($path = null, $parameters = [], $secure = null) {}
  *
  * @param callable(): TValue $callback
  * @param TDefault|(callable(\Throwable): TDefault) $rescue
- * @param bool $report
+ * @param bool|callable $report
  * @return TValue|TDefault
  */
 function rescue(callable $callback, $rescue = null, $report = true) {}


### PR DESCRIPTION
This updates the `rescue` function `report` parameter. It supports both `bool` and `callable`.