### PR TITLE
refactor: assertType calls

### DIFF
--- a/tests/Type/data/abort.php
+++ b/tests/Type/data/abort.php
@@ -5,50 +5,34 @@ namespace AbortTests;
 use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 
-class Abort
+function test(?int $foo): void
 {
-    public function testAbort(int $value): void
-    {
-        if ($value > 0) {
-            $operator = '+';
-        } elseif ($value < 0) {
-            $operator = '-';
-        } else {
-            abort(422);
-        }
-
-        // Should not complain about $operator possibly not being defined
-        assertVariableCertainty(
-            \PHPStan\TrinaryLogic::createYes(),
-            $operator
-        );
+    if ($foo > 0) {
+        $operator = '+';
+    } elseif ($value < 0) {
+        $operator = '-';
+    } else {
+        abort(422);
     }
 
-    public function testAbortIf(?int $foo): void
-    {
-        abort_if(! $foo, 500);
+    // Should not complain about $operator possibly not being defined
+    assertVariableCertainty(
+        \PHPStan\TrinaryLogic::createYes(),
+        $operator
+    );
 
-        assertType('int<min, -1>|int<1, max>', $foo);
-    }
+    abort_if(! $foo, 500);
+    assertType('int<min, -1>|int<1, max>', $foo);
 
-    public function testAbortIfWithTypeCheck(int|string $foo = 5): void
-    {
-        abort_if(is_string($foo), 500);
+    /** @var int|string $foo */
+    abort_if(is_string($foo), 500);
+    assertType('int', $foo);
 
-        assertType('int', $foo);
-    }
+    /** @var ?int $foo */
+    abort_unless(! is_null($foo), 500);
+    assertType('int', $foo);
 
-    public function testAbortUnless(?int $foo): void
-    {
-        abort_unless(! is_null($foo), 500);
-
-        assertType('int', $foo);
-    }
-
-    public function testAbortUnlessWithTypeCheck(int|string $foo = 5): void
-    {
-        abort_unless(! is_string($foo), 500);
-
-        assertType('int', $foo);
-    }
+    /** @var int|string $foo */
+    abort_unless(! is_string($foo), 500);
+    assertType('int', $foo);
 }

--- a/tests/Type/data/abstract-manager.php
+++ b/tests/Type/data/abstract-manager.php
@@ -7,9 +7,7 @@ use Illuminate\Support\Manager;
 
 use function PHPStan\Testing\assertType;
 
-abstract class AbstractManager extends Manager
-{
-}
+abstract class AbstractManager extends Manager { }
 
 class RealManager extends AbstractManager
 {
@@ -19,4 +17,7 @@ class RealManager extends AbstractManager
     }
 }
 
-assertType('AbstractManager\RealManager', new RealManager(new Container()));
+function test(): void
+{
+    assertType('AbstractManager\RealManager', new RealManager(new Container()));
+}

--- a/tests/Type/data/app-make.php
+++ b/tests/Type/data/app-make.php
@@ -7,15 +7,8 @@ use Larastan\Larastan\ApplicationResolver;
 
 use function PHPStan\Testing\assertType;
 
-class AppMakeDynamicReturnTypeExtension
+function test(): void
 {
-    public function testResolvesAppMakeStaticCall(): void
-    {
-        assertType(ApplicationResolver::class, App::make(ApplicationResolver::class));
-    }
-
-    public function testResolvesAppMakeWithStaticCall(): void
-    {
-        assertType(ApplicationResolver::class, App::makeWith(ApplicationResolver::class));
-    }
+    assertType(ApplicationResolver::class, App::make(ApplicationResolver::class));
+    assertType(ApplicationResolver::class, App::makeWith(ApplicationResolver::class));
 }

--- a/tests/Type/data/application-make.php
+++ b/tests/Type/data/application-make.php
@@ -4,10 +4,13 @@ namespace ApplicationMake;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo(\Illuminate\Foundation\Application $app, \Illuminate\Contracts\Foundation\Application $app2)
+/** @param class-string<Model> $model */
+function test(Application $app, ApplicationContract $app2, string $model): void
 {
     assertType('Illuminate\Config\Repository', $app->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app->makeWith(Repository::class));
@@ -16,12 +19,8 @@ function doFoo(\Illuminate\Foundation\Application $app, \Illuminate\Contracts\Fo
     assertType('Illuminate\Config\Repository', $app2->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->resolve(Repository::class));
-}
 
-/** @param class-string<Model> $foo */
-function doBar(string $foo, \Illuminate\Foundation\Application $app)
-{
-    assertType('mixed', $app->make($foo));
-    assertType('mixed', $app->makeWith($foo));
-    assertType('mixed', $app->resolve($foo));
+    assertType('mixed', $app->make($model));
+    assertType('mixed', $app->makeWith($model));
+    assertType('mixed', $app->resolve($model));
 }

--- a/tests/Type/data/auth.php
+++ b/tests/Type/data/auth.php
@@ -9,50 +9,15 @@ use Illuminate\Support\Facades\Auth;
 
 use function PHPStan\Testing\assertType;
 
-class AuthExtension
+function test(User $user): void
 {
-    public function testUser(): void
-    {
-        assertType('App\Admin|App\User|null', Auth::user());
-    }
-
-    public function testCheck(): void
-    {
-        assertType('bool', Auth::check());
-    }
-
-    public function testId(): void
-    {
-        assertType('int|string|null', Auth::id());
-    }
-
-    public function testLogout(): void
-    {
-        assertType('null', Auth::guard()->logout());
-    }
-
-    public function testGuard(): void
-    {
-        assertType(StatefulGuard::class, Auth::guard('web'));
-    }
-
-    public function testGuardUser(): void
-    {
-        assertType('App\User|null', Auth::guard('web')->user());
-    }
-
-    public function testGuardAdminUser(): void
-    {
-        assertType('App\Admin|null', Auth::guard('admin')->user());
-    }
-
-    public function testSessionGuard(): void
-    {
-        assertType(SessionGuard::class, Auth::guard('session'));
-    }
-
-    public function testLogin(User $user): void
-    {
-        assertType('null', Auth::guard()->login($user));
-    }
+    assertType('App\Admin|App\User|null', Auth::user());
+    assertType('bool', Auth::check());
+    assertType('int|string|null', Auth::id());
+    assertType('null', Auth::guard()->logout());
+    assertType(StatefulGuard::class, Auth::guard('web'));
+    assertType('App\User|null', Auth::guard('web')->user());
+    assertType('App\Admin|null', Auth::guard('admin')->user());
+    assertType(SessionGuard::class, Auth::guard('session'));
+    assertType('null', Auth::guard()->login($user));
 }

--- a/tests/Type/data/benchmark.php
+++ b/tests/Type/data/benchmark.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Benchmark;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo()
+function test(): void
 {
     assertType('float', Benchmark::measure(fn () => 'Hello World'));
     assertType('array<int, float>', Benchmark::measure([fn () => 'Hello World', fn () => 'Hello World']));

--- a/tests/Type/data/bug-1346.php
+++ b/tests/Type/data/bug-1346.php
@@ -6,14 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 
 use function PHPStan\Testing\assertType;
 
-/**
- * @template TModel of \Illuminate\Database\Eloquent\Model
- */
+/** @template TModel of \Illuminate\Database\Eloquent\Model */
 class DailyQuery
 {
-    /**
-     * @var Builder<TModel>
-     */
+    /** @var Builder<TModel> */
     private Builder $query;
 
     public function daily()

--- a/tests/Type/data/bug-1760.php
+++ b/tests/Type/data/bug-1760.php
@@ -4,31 +4,26 @@ namespace CollectionHelper;
 
 use function PHPStan\Testing\assertType;
 
-/**
- * @template T
- */
+/** @template T */
 class Ok
 {
-    /**
-     * @param  T  $value
-     */
+    /** @param  T  $value */
     public function __construct(public mixed $value)
     {
     }
 }
 
-/**
- * @template T
- */
+/** @template T */
 class Some
 {
-    /**
-     * @param  T  $value
-     */
+    /** @param  T  $value */
     public function __construct(public mixed $value)
     {
     }
 }
 
-assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([new Ok(new Some(42))]));
-assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([42])->map(fn (int $i) => new Ok(new Some($i))));
+function test(): void
+{
+    assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([new Ok(new Some(42))]));
+    assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([42])->map(fn (int $i) => new Ok(new Some($i))));
+}

--- a/tests/Type/data/bug-1819.php
+++ b/tests/Type/data/bug-1819.php
@@ -3,9 +3,10 @@
 namespace Bug1819;
 
 use App\User;
+
 use function PHPStan\Testing\assertType;
 
-function testCreateOrRestore(): void
+function test(): void
 {
     assertType('App\User', User::createOrRestore(['id' => 1]));
 }

--- a/tests/Type/data/carbon.php
+++ b/tests/Type/data/carbon.php
@@ -4,12 +4,8 @@ namespace Carbon;
 
 use function PHPStan\Testing\assertType;
 
-function testCarbonMacroCalledStatically()
+function test(): void
 {
     assertType('string', Carbon::foo());
-}
-
-function testCarbonMacroCalledDynamically()
-{
     assertType('string', Carbon::now()->foo());
 }

--- a/tests/Type/data/collection-filter-arrow-function.php
+++ b/tests/Type/data/collection-filter-arrow-function.php
@@ -4,14 +4,13 @@ namespace CollectionFilter;
 
 use App\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->filter(fn (int $value) => $value > 2));
-
-/** @param EloquentCollection<int, User> $foo */
-function bar(Collection $foo): void
+/** @param EloquentCollection<int, User> $users */
+function test(EloquentCollection $users): void
 {
-    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $foo->filter(fn (User $user) => ! $user->blocked));
+    assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->filter(fn (int $value) => $value > 2));
+    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $users->filter(fn (User $user) => ! $user->blocked));
 }

--- a/tests/Type/data/collection-filter.php
+++ b/tests/Type/data/collection-filter.php
@@ -5,64 +5,12 @@ namespace CollectionFilter;
 use App\Account;
 use App\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
 
-/** @var User $user */
-assertType('Illuminate\Support\Collection<int, non-falsy-string>', collect(['foo', null, '', 'bar', null])->filter());
-
-/** @param Collection<int, mixed> $foo */
-function foo(Collection $foo): void
-{
-    assertType("Illuminate\Support\Collection<int, mixed~0|0.0|''|'0'|array{}|false|null>", $foo->filter());
-}
-
-/**
- * @param  array<int, User>  $attachments
- */
-function storeAttachments(array $attachments): void
-{
-    assertType(
-        'Illuminate\Support\Collection<int, App\Account>',
-        collect($attachments)
-        ->map(function (User $attachment): ?Account {
-            return convertToAccount($attachment);
-        })
-        ->filter()
-    );
-}
-
 function convertToAccount(User $user): ?Account
-{
-    //
-}
-
-assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->filter(function (int $value) {
-    return $value > 2;
-}));
-
-/** @param EloquentCollection<int, User> $foo */
-function bar(Collection $foo): void
-{
-    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $foo->filter(function (User $user): bool {
-        return ! $user->blocked;
-    }));
-}
-
-$accounts = $user->accounts()->active()->get();
-assertType('App\AccountCollection<int, App\Account>', $accounts);
-
-assertType('App\AccountCollection<int, App\Account>', $accounts->filter(function ($account) {
-    return \CollectionStubs\dummyFilter($account);
-}));
-
-$accounts->filter(function ($account) {
-    return dummyFilter($account);
-})
-->map(function ($account) {
-    assertType('App\Account', $account);
-});
+{ }
 
 function dummyFilter($value)
 {
@@ -71,4 +19,43 @@ function dummyFilter($value)
     }
 
     return random_int(0, 1) > 1;
+}
+
+/** @param EloquentCollection<int, User> $users */
+function test(User $user, SupportCollection $users): void
+{
+    assertType("Illuminate\Support\Collection<(int|string), mixed~0|0.0|''|'0'|array{}|false|null>", collect()->filter());
+
+    assertType('Illuminate\Support\Collection<int, non-falsy-string>', collect(['foo', null, '', 'bar', null])->filter());
+
+    assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->filter(function (int $value) {
+        return $value > 2;
+    }));
+
+    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $users->filter(function (User $user): bool {
+        return ! $user->blocked;
+    }));
+
+    assertType(
+        'Illuminate\Support\Collection<int, App\Account>',
+        collect($users->all())
+        ->map(function (User $attachment): ?Account {
+            return convertToAccount($attachment);
+        })
+        ->filter()
+    );
+
+    $accounts = $user->accounts()->active()->get();
+    assertType('App\AccountCollection<int, App\Account>', $accounts);
+
+    assertType('App\AccountCollection<int, App\Account>', $accounts->filter(function ($account) {
+        return \CollectionStubs\dummyFilter($account);
+    }));
+
+    $accounts->filter(function ($account) {
+        return dummyFilter($account);
+    })
+    ->map(function ($account) {
+        assertType('App\Account', $account);
+    });
 }

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -9,209 +9,218 @@ use Illuminate\Support\LazyCollection;
 
 use function PHPStan\Testing\assertType;
 
-/** @var EloquentCollection<int, User> $collection */
-/** @var SupportCollection<string, int> $items */
-/** @var App\TransactionCollection<int, Transaction> $customEloquentCollection */
-/** @var App\UserCollection $secondCustomEloquentCollection */
-/** @var LazyCollection<int, User> $lazyCollection */
-/** @var User $user */
-assertType('Illuminate\Database\Eloquent\Collection<int, int>', EloquentCollection::range(1, 10));
-assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::range(1, 10));
+/**
+ * @param EloquentCollection<int, User> $collection
+ * @param SupportCollection<string, int> $items
+ * @param App\TransactionCollection<int, Transaction> $customEloquentCollection
+ * @param LazyCollection<int, User> $lazyCollection
+ */
+function test(
+    EloquentCollection $collection,
+    SupportCollection $items,
+    App\TransactionCollection $customEloquentCollection,
+    App\UserCollection $secondCustomEloquentCollection,
+    LazyCollection $lazyCollection,
+    User $user,
+): void {
+    assertType('Illuminate\Database\Eloquent\Collection<int, int>', EloquentCollection::range(1, 10));
+    assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::range(1, 10));
 
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
-assertType('Illuminate\Support\Collection<int, mixed>', $items->collapse());
+    assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
+    assertType('Illuminate\Support\Collection<int, mixed>', $items->collapse());
 
-assertType('Illuminate\Database\Eloquent\Collection<int, array<int, App\User|int>>', $collection->crossJoin([1]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, array<int, App\User|int>>', $collection->crossJoin([1]));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
-assertType('App\User|null', $collection->find($user));
-assertType('App\User|null', $collection->find(1));
-assertType('App\User|bool', $collection->find(1, false));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
+    assertType('App\User|null', $collection->find($user));
+    assertType('App\User|null', $collection->find(1));
+    assertType('App\User|bool', $collection->find(1, false));
 
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find($items));
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find([1]));
-assertType('App\Transaction|null', $customEloquentCollection->find($user));
-assertType('App\Transaction|null', $customEloquentCollection->find(1));
-assertType('App\Transaction|bool', $customEloquentCollection->find(1, false));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find($items));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->find([1]));
+    assertType('App\Transaction|null', $customEloquentCollection->find($user));
+    assertType('App\Transaction|null', $customEloquentCollection->find(1));
+    assertType('App\Transaction|bool', $customEloquentCollection->find(1, false));
 
-assertType('App\UserCollection', $secondCustomEloquentCollection->find($items));
-assertType('App\UserCollection', $secondCustomEloquentCollection->find([1]));
-assertType('App\User|null', $secondCustomEloquentCollection->find($user));
-assertType('App\User|null', $secondCustomEloquentCollection->find(1));
-assertType('App\User|bool', $secondCustomEloquentCollection->find(1, false));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->find($items));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->find([1]));
+    assertType('App\User|null', $secondCustomEloquentCollection->find($user));
+    assertType('App\User|null', $secondCustomEloquentCollection->find(1));
+    assertType('App\User|bool', $secondCustomEloquentCollection->find(1, false));
 
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
-assertType('Illuminate\Support\Collection<int, mixed>', $items->flatten());
+    assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
+    assertType('Illuminate\Support\Collection<int, mixed>', $items->flatten());
 
-assertType('Illuminate\Support\Collection<App\User, int>', $collection->flip());
-assertType('Illuminate\Support\Collection<int, string>', $items->flip());
+    assertType('Illuminate\Support\Collection<App\User, int>', $collection->flip());
+    assertType('Illuminate\Support\Collection<int, string>', $items->flip());
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), App\User>>', $collection->groupBy('id'));
-assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), int>>', $items->groupBy('id'));
+    assertType('Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), App\User>>', $collection->groupBy('id'));
+    assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), int>>', $items->groupBy('id'));
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), App\User>', $collection->keyBy(fn (User $user, int $key): string => $user->email));
+    assertType('Illuminate\Database\Eloquent\Collection<(int|string), App\User>', $collection->keyBy(fn (User $user, int $key): string => $user->email));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
-assertType('Illuminate\Support\Collection<int, string>', $items->keys());
+    assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
+    assertType('Illuminate\Support\Collection<int, string>', $items->keys());
 
-assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck(['email']));
-assertType('Illuminate\Support\Collection<(int|string), mixed>', $items->pluck('1'));
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck(['email']));
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', $items->pluck('1'));
 
-assertType('Illuminate\Support\Collection<int, int>', $customEloquentCollection->map(fn (Transaction $transaction): int => $transaction->id));
-assertType('Illuminate\Support\Collection<int, int>', $secondCustomEloquentCollection->map(fn (User $user): int => $user->id));
-assertType('Illuminate\Support\Collection<int, int>', $collection->map(fn (User $user): int => $user->id));
-assertType('Illuminate\Support\Collection<string, int>', $items->map(fn (int $value, string $key): int => $value));
+    assertType('Illuminate\Support\Collection<int, int>', $customEloquentCollection->map(fn (Transaction $transaction): int => $transaction->id));
+    assertType('Illuminate\Support\Collection<int, int>', $secondCustomEloquentCollection->map(fn (User $user): int => $user->id));
+    assertType('Illuminate\Support\Collection<int, int>', $collection->map(fn (User $user): int => $user->id));
+    assertType('Illuminate\Support\Collection<string, int>', $items->map(fn (int $value, string $key): int => $value));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, array<int, int>>', $collection->mapToDictionary(fn (User $u) => [$u->id => $u->id]));
-assertType('App\TransactionCollection<string, array<int, int>>', $customEloquentCollection->mapToDictionary(fn (Transaction $t) => ['foo'=> $t->id]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->mapToDictionary(fn (User $t) => ['foo'=> $t->id]));
-assertType('Illuminate\Support\Collection<string, array<int, int>>', $items->mapToDictionary(fn (int $v) => ['foo' => $v]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, array<int, int>>', $collection->mapToDictionary(fn (User $u) => [$u->id => $u->id]));
+    assertType('App\TransactionCollection<string, array<int, int>>', $customEloquentCollection->mapToDictionary(fn (Transaction $t) => ['foo'=> $t->id]));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->mapToDictionary(fn (User $t) => ['foo'=> $t->id]));
+    assertType('Illuminate\Support\Collection<string, array<int, int>>', $items->mapToDictionary(fn (int $v) => ['foo' => $v]));
 
-assertType('Illuminate\Support\Collection<int, string>', $customEloquentCollection->mapWithKeys(fn (Transaction $transaction): array => [$transaction->id => 'foo']));
-assertType('Illuminate\Support\Collection<int, string>', $secondCustomEloquentCollection->mapWithKeys(fn (User $user): array => [$user->id => 'foo']));
-assertType('Illuminate\Support\Collection<int, int>', $collection->mapWithKeys(fn (User $user): array => [$user->id => $user->id]));
-assertType('Illuminate\Support\Collection<string, int>', $items->mapWithKeys(fn (int $value, string $key): array => ['foo' => $value]));
+    assertType('Illuminate\Support\Collection<int, string>', $customEloquentCollection->mapWithKeys(fn (Transaction $transaction): array => [$transaction->id => 'foo']));
+    assertType('Illuminate\Support\Collection<int, string>', $secondCustomEloquentCollection->mapWithKeys(fn (User $user): array => [$user->id => 'foo']));
+    assertType('Illuminate\Support\Collection<int, int>', $collection->mapWithKeys(fn (User $user): array => [$user->id => $user->id]));
+    assertType('Illuminate\Support\Collection<string, int>', $items->mapWithKeys(fn (int $value, string $key): array => ['foo' => $value]));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User|string>', $collection->mergeRecursive([2 => 'foo']));
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->mergeRecursive([1 => new Transaction()]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->mergeRecursive([1 => new User()]));
-assertType('Illuminate\Support\Collection<string, int>', $items->mergeRecursive(['foo' => 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User|string>', $collection->mergeRecursive([2 => 'foo']));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->mergeRecursive([1 => new Transaction()]));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->mergeRecursive([1 => new User()]));
+    assertType('Illuminate\Support\Collection<string, int>', $items->mergeRecursive(['foo' => 2]));
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), int>', $collection->combine([1]));
-assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollection->combine([1]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
-assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
+    assertType('Illuminate\Database\Eloquent\Collection<(int|string), int>', $collection->combine([1]));
+    assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollection->combine([1]));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
+    assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
-assertType('App\User|null', $collection->pop(1));
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->pop(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
-assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
+    assertType('App\User|null', $collection->pop(1));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->pop(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
+    assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
 
-assertType('App\Role', User::firstOrFail(1)->roles->random());
-assertType('App\RoleCollection<int, App\Role>', User::firstOrFail(1)->roles->random(1));
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
-assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
+    assertType('App\Role', User::firstOrFail(1)->roles->random());
+    assertType('App\RoleCollection<int, App\Role>', User::firstOrFail(1)->roles->random(1));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));
+    assertType('Illuminate\Support\Collection<int, int>', $items->random(3));
 
-assertType('App\User|null', $collection->shift(1));
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->shift(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->shift(2));
-assertType('Illuminate\Support\Collection<int, int>', $items->shift(3));
+    assertType('App\User|null', $collection->shift(1));
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->shift(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->shift(2));
+    assertType('Illuminate\Support\Collection<int, int>', $items->shift(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->sliding(2));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->sliding(3));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
+    assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->sliding(2));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->sliding(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->split(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->split(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->split(2));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->split(3));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->split(1));
+    assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->split(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->split(2));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->split(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->splitIn(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->splitIn(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->splitIn(2));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->splitIn(3));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->splitIn(1));
+    assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->splitIn(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->splitIn(2));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->splitIn(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunk(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunk(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->chunk(2));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->chunk(3));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunk(1));
+    assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunk(2));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->chunk(2));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->chunk(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunkWhile(fn (User $u) => $u->id > 5));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunkWhile(fn (Transaction $t) => $t->id > 5));
-assertType('App\UserCollection', $secondCustomEloquentCollection->chunkWhile(fn (User $t) => $t->id > 5));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $items->chunkWhile(fn ($v) => $v > 5));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunkWhile(fn (User $u) => $u->id > 5));
+    assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunkWhile(fn (Transaction $t) => $t->id > 5));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->chunkWhile(fn (User $t) => $t->id > 5));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $items->chunkWhile(fn ($v) => $v > 5));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->values());
-assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->values());
-assertType('App\UserCollection', $secondCustomEloquentCollection->values());
-assertType('Illuminate\Support\Collection<int, int>', $items->values());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->values());
+    assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->values());
+    assertType('App\UserCollection', $secondCustomEloquentCollection->values());
+    assertType('Illuminate\Support\Collection<int, int>', $items->values());
 
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\User|int>>', $collection->zip([1]));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\Transaction|string>>', $customEloquentCollection->zip(['foo']));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\User|string>>', $secondCustomEloquentCollection->zip(['foo']));
-assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|string>>', $items->zip(['foo', 'bar']));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\User|int>>', $collection->zip([1]));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\Transaction|string>>', $customEloquentCollection->zip(['foo']));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\User|string>>', $secondCustomEloquentCollection->zip(['foo']));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|string>>', $items->zip(['foo', 'bar']));
 
-assertType('Illuminate\Database\Eloquent\Collection<int<0, 1>, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->partition('foo'));
-assertType('App\TransactionCollection<int<0, 1>, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->partition('foo'));
-assertType('App\UserCollection', $secondCustomEloquentCollection->partition('foo'));
-assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collection<string, int>>', $items->partition('foo'));
+    assertType('Illuminate\Database\Eloquent\Collection<int<0, 1>, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->partition('foo'));
+    assertType('App\TransactionCollection<int<0, 1>, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->partition('foo'));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->partition('foo'));
+    assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collection<string, int>>', $items->partition('foo'));
 
-assertType('Illuminate\Support\Collection<int, App\User|int>', $collection->pad(10, 10));
-assertType('Illuminate\Support\Collection<int, App\Transaction|string>', $customEloquentCollection->pad(10, 'foo'));
-assertType('Illuminate\Support\Collection<int, App\User|string>', $secondCustomEloquentCollection->pad(10, 'foo'));
-assertType('Illuminate\Support\Collection<int, int|string>', $items->pad(1, 'bar'));
+    assertType('Illuminate\Support\Collection<int, App\User|int>', $collection->pad(10, 10));
+    assertType('Illuminate\Support\Collection<int, App\Transaction|string>', $customEloquentCollection->pad(10, 'foo'));
+    assertType('Illuminate\Support\Collection<int, App\User|string>', $secondCustomEloquentCollection->pad(10, 'foo'));
+    assertType('Illuminate\Support\Collection<int, int|string>', $items->pad(1, 'bar'));
 
-assertType('Illuminate\Support\Collection<(int|string), int>', $collection->countBy('email'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $customEloquentCollection->countBy('foo'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $secondCustomEloquentCollection->countBy('foo'));
-assertType('Illuminate\Support\Collection<(int|string), int>', $items->countBy('bar'));
+    assertType('Illuminate\Support\Collection<(int|string), int>', $collection->countBy('email'));
+    assertType('Illuminate\Support\Collection<(int|string), int>', $customEloquentCollection->countBy('foo'));
+    assertType('Illuminate\Support\Collection<(int|string), int>', $secondCustomEloquentCollection->countBy('foo'));
+    assertType('Illuminate\Support\Collection<(int|string), int>', $items->countBy('bar'));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->concat([new User()]));
-assertType('App\TransactionCollection<int, App\Transaction|App\User>', $customEloquentCollection->concat([new User()]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->concat([new User()]));
-assertType('Illuminate\Support\Collection<string, App\User|int>', $items->concat([new User()]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->concat([new User()]));
+    assertType('App\TransactionCollection<int, App\Transaction|App\User>', $customEloquentCollection->concat([new User()]));
+    assertType('App\UserCollection', $secondCustomEloquentCollection->concat([new User()]));
+    assertType('Illuminate\Support\Collection<string, App\User|int>', $items->concat([new User()]));
 
-////////////////////////////
-// EnumeratesValues Trait //
-////////////////////////////
+    ////////////////////////////
+    // EnumeratesValues Trait //
+    ////////////////////////////
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', EloquentCollection::make([new User()]));
-assertType('App\TransactionCollection<int, App\Transaction>', TransactionCollection::make([new Transaction()]));
-assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make([1, 2, 3]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', EloquentCollection::make([new User()]));
+    assertType('App\TransactionCollection<int, App\Transaction>', TransactionCollection::make([new Transaction()]));
+    assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make([1, 2, 3]));
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), App\User>', EloquentCollection::wrap([new User()]));
-assertType('App\TransactionCollection<(int|string), App\Transaction>', TransactionCollection::wrap([new Transaction()]));
-assertType('Illuminate\Support\Collection<(int|string), int>', SupportCollection::wrap([1, 2, 3]));
+    assertType('Illuminate\Database\Eloquent\Collection<(int|string), App\User>', EloquentCollection::wrap([new User()]));
+    assertType('App\TransactionCollection<(int|string), App\Transaction>', TransactionCollection::wrap([new Transaction()]));
+    assertType('Illuminate\Support\Collection<(int|string), int>', SupportCollection::wrap([1, 2, 3]));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', EloquentCollection::times(10, fn ($int) => new User));
-assertType('App\TransactionCollection<int, App\Transaction>', TransactionCollection::times(10, fn ($int) => new Transaction));
-assertType('Illuminate\Support\Collection<int, int>', SupportCollection::times(10, fn ($int) => 5));
-assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::times(10, fn ($int) => 5));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', EloquentCollection::times(10, fn ($int) => new User));
+    assertType('App\TransactionCollection<int, App\Transaction>', TransactionCollection::times(10, fn ($int) => new Transaction));
+    assertType('Illuminate\Support\Collection<int, int>', SupportCollection::times(10, fn ($int) => 5));
+    assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::times(10, fn ($int) => 5));
 
-// In runtime it returns `Illuminate\Support\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>`
-// Might be fixed in Laravel or needs a separate extension
-assertType(
-    'Illuminate\Database\Eloquent\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>',
-    $collection->mapToGroups(fn (User $user, int $key): array => ['foo' => $user->id])
-);
+    // In runtime it returns `Illuminate\Support\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>`
+    // Might be fixed in Laravel or needs a separate extension
+    assertType(
+        'Illuminate\Database\Eloquent\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>',
+        $collection->mapToGroups(fn (User $user, int $key): array => ['foo' => $user->id])
+    );
 
-assertType(
-    'Illuminate\Database\Eloquent\Collection<int, int>',
-    $collection->flatMap(function (User $user, int $id) {
-        return [$user->id];
-    })
-);
+    assertType(
+        'Illuminate\Database\Eloquent\Collection<int, int>',
+        $collection->flatMap(function (User $user, int $id) {
+            return [$user->id];
+        })
+    );
 
-assertType(
-    'Illuminate\Support\Collection<int, int>',
-    $items->flatMap(function (int $int) {
-        return [$int * 2];
-    })
-);
+    assertType(
+        'Illuminate\Support\Collection<int, int>',
+        $items->flatMap(function (int $int) {
+            return [$int * 2];
+        })
+    );
 
-assertType(
-    'Illuminate\Support\LazyCollection<int, int>',
-    $lazyCollection->flatMap(function (User $user, int $id) {
-        return [$user->id];
-    })
-);
+    assertType(
+        'Illuminate\Support\LazyCollection<int, int>',
+        $lazyCollection->flatMap(function (User $user, int $id) {
+            return [$user->id];
+        })
+    );
 
-assertType(
-    'Illuminate\Support\LazyCollection<int, int>',
-    LazyCollection::times(10, fn ($int) => 5)->flatMap(fn (int $i) => [$i * 2]),
-);
+    assertType(
+        'Illuminate\Support\LazyCollection<int, int>',
+        LazyCollection::times(10, fn ($int) => 5)->flatMap(fn (int $i) => [$i * 2]),
+    );
 
-assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), array{id: int, type: string}>>', collect([
-    [
-        'id'   => 1,
-        'type' => 'A',
-    ],
-    [
-        'id'   => 1,
-        'type' => 'B',
-    ],
-])->groupBy('type'));
+    assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), array{id: int, type: string}>>', collect([
+        [
+            'id'   => 1,
+            'type' => 'A',
+        ],
+        [
+            'id'   => 1,
+            'type' => 'B',
+        ],
+    ])->groupBy('type'));
+}

--- a/tests/Type/data/collection-helper.php
+++ b/tests/Type/data/collection-helper.php
@@ -4,43 +4,35 @@ namespace CollectionHelper;
 
 use App\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Support\Collection;
+use Traversable;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Support\Collection<(int|string), mixed>', collect());
-assertType('Illuminate\Support\Collection<0, 1>', collect(1));
-assertType('Illuminate\Support\Collection<0, \'foo\'>', collect('foo'));
-assertType('Illuminate\Support\Collection<0, 3.14>', collect(3.14));
-assertType('Illuminate\Support\Collection<0, true>', collect(true));
-assertType('Illuminate\Support\Collection<(int|string), mixed>', collect([]));
-assertType('Illuminate\Support\Collection<int, int>', collect([1, 2, 3]));
-assertType('Illuminate\Support\Collection<int, string>', collect(['foo', 'bar', 'baz']));
-assertType('Illuminate\Support\Collection<int, float>', collect([1.0, 2.0, 3.0]));
-assertType('Illuminate\Support\Collection<int, float|int|string>', collect([1, 'foo', 1.0]));
-assertType("Illuminate\Support\Collection<int, array{string, string, string}>", collect([['a', 'b', 'c']]));
-assertType("Illuminate\Support\Collection<int, array{string, string, string}>", collect([['a', 'b', 'c']])->push(array_fill(0, 3, 'x')));
-assertType("Illuminate\Support\Collection<int, App\User>", collect([new User, new User]));
-assertType("Illuminate\Support\Collection<int, array{App\User, App\User, App\User}>", collect([[new User, new User, new User]]));
-
-/**  @phpstan-param EloquentCollection<int, int> $eloquentCollection */
-function eloquentCollectionInteger(EloquentCollection $eloquentCollection): void
-{
-    assertType('Illuminate\Support\Collection<int, int>', collect($eloquentCollection));
-}
-
-/**  @phpstan-param EloquentCollection<int, User> $eloquentCollection */
-function eloquentCollectionUser(EloquentCollection $eloquentCollection): void
-{
-    assertType('Illuminate\Support\Collection<int, App\User>', collect($eloquentCollection));
-}
-
 /**
- * @phpstan-param \Traversable<int, int> $foo
- *
- * @phpstan-return Collection<int, int>
+ * @param EloquentCollection<int, int> $ints
+ * @param EloquentCollection<int, User> $users
+ * @param Traversable<int, int> $traversable
  */
-function testIterable(\Traversable $foo): void
-{
-    assertType('Illuminate\Support\Collection<int, int>', collect($foo));
+function test(
+    EloquentCollection $ints,
+    EloquentCollection $users,
+    Traversable $traversable
+): void {
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', collect());
+    assertType('Illuminate\Support\Collection<0, 1>', collect(1));
+    assertType('Illuminate\Support\Collection<0, \'foo\'>', collect('foo'));
+    assertType('Illuminate\Support\Collection<0, 3.14>', collect(3.14));
+    assertType('Illuminate\Support\Collection<0, true>', collect(true));
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', collect([]));
+    assertType('Illuminate\Support\Collection<int, int>', collect([1, 2, 3]));
+    assertType('Illuminate\Support\Collection<int, string>', collect(['foo', 'bar', 'baz']));
+    assertType('Illuminate\Support\Collection<int, float>', collect([1.0, 2.0, 3.0]));
+    assertType('Illuminate\Support\Collection<int, float|int|string>', collect([1, 'foo', 1.0]));
+    assertType("Illuminate\Support\Collection<int, array{string, string, string}>", collect([['a', 'b', 'c']]));
+    assertType("Illuminate\Support\Collection<int, array{string, string, string}>", collect([['a', 'b', 'c']])->push(array_fill(0, 3, 'x')));
+    assertType("Illuminate\Support\Collection<int, App\User>", collect([new User, new User]));
+    assertType("Illuminate\Support\Collection<int, array{App\User, App\User, App\User}>", collect([[new User, new User, new User]]));
+    assertType('Illuminate\Support\Collection<int, int>', collect($ints));
+    assertType('Illuminate\Support\Collection<int, App\User>', collect($users));
+    assertType('Illuminate\Support\Collection<int, int>', collect($traversable));
 }

--- a/tests/Type/data/collection-make-static.php
+++ b/tests/Type/data/collection-make-static.php
@@ -5,31 +5,26 @@ namespace CollectionMake;
 use App\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as SupportCollection;
+use Traversable;
 
 use function PHPStan\Testing\assertType;
 
-//assertType('Illuminate\Support\Collection<int|string, mixed>', SupportCollection::make([]));
-assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make([1, 2, 3]));
-assertType('Illuminate\Support\Collection<int, string>', SupportCollection::make(['foo', 'bar', 'baz']));
-assertType('Illuminate\Support\Collection<int, float>', SupportCollection::make([1.0, 2.0, 3.0]));
-assertType('Illuminate\Support\Collection<int, float|int|string>', SupportCollection::make([1, 'foo', 1.0]));
-
-/**  @phpstan-param EloquentCollection<int, \App\User> $eloquentCollection */
-function eloquentCollectionInteger(EloquentCollection $eloquentCollection): void
-{
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($eloquentCollection));
-}
-
-/**  @phpstan-param EloquentCollection<int, User> $eloquentCollection */
-function eloquentCollectionUser(EloquentCollection $eloquentCollection): void
-{
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($eloquentCollection));
-}
-
 /**
- * @phpstan-param \Traversable<int, int> $foo
+ * @param EloquentCollection<int, \App\User> $users
+ * @param Traversable<int, int> $traversable
  */
-function testIterable(\Traversable $foo): void
+function test(EloquentCollection $users, Traversable $traversable): void
 {
-    assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make($foo));
+    // assertType('Illuminate\Support\Collection<int|string, mixed>', SupportCollection::make([]));
+    assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make([1, 2, 3]));
+    assertType('Illuminate\Support\Collection<int, string>', SupportCollection::make(['foo', 'bar', 'baz']));
+    assertType('Illuminate\Support\Collection<int, float>', SupportCollection::make([1.0, 2.0, 3.0]));
+    assertType('Illuminate\Support\Collection<int, float|int|string>', SupportCollection::make([1, 'foo', 1.0]));
+
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($users));
+
+    /** @var EloquentCollection<int, User> $users */
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($users));
+
+    assertType('Illuminate\Support\Collection<int, int>', SupportCollection::make($traversable));
 }

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -8,105 +8,113 @@ use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
 
-/** @var EloquentCollection<int, User> $collection */
-/** @var SupportCollection<string, int> $items */
-/** @var SupportCollection<int, User> $collectionOfUsers */
-/** @var User $user */
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->each(function (User $user, int $key): void {
-}));
+/**
+ * @param EloquentCollection<int, User> $collection
+ * @param SupportCollection<string, int> $items
+ * @param SupportCollection<int, User> $collectionOfUsers
+ */
+function test(
+    EloquentCollection $collection,
+    SupportCollection $items,
+    SupportCollection $collectionOfUsers,
+    User $user,
+): void {
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->each(function (User $user, int $key): void {
+    }));
 
-assertType('Illuminate\Support\Collection<string, int>', $items->each(function (): bool {
-    return false;
-}));
+    assertType('Illuminate\Support\Collection<string, int>', $items->each(function (): bool {
+        return false;
+    }));
 
-assertType('Illuminate\Support\Collection<string, string>', $items->map(function (int $item): string {
-    return (string) $item;
-}));
+    assertType('Illuminate\Support\Collection<string, string>', $items->map(function (int $item): string {
+        return (string) $item;
+    }));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
-assertType('App\User|null', $collection->find($user));
-assertType('App\User|null', $collection->find(1));
-assertType('App\User|bool', $collection->find(1, false));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
+    assertType('App\User|null', $collection->find($user));
+    assertType('App\User|null', $collection->find(1));
+    assertType('App\User|bool', $collection->find(1, false));
 
-assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck('id'));
+    assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck('id'));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->mapInto(User::class));
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->flatMap(function (User $user, int $id): array {
-    return [$user];
-}));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->mapInto(User::class));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->flatMap(function (User $user, int $id): array {
+        return [$user];
+    }));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->tap(function ($collection): void {
-}));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->tap(function ($collection): void {
+    }));
 
-$foo = collect([
-    [
-        'id'   => 1,
-        'type' => 'A',
-    ],
-    [
-        'id'   => 1,
-        'type' => 'B',
-    ],
-]);
+    $foo = collect([
+        [
+            'id'   => 1,
+            'type' => 'A',
+        ],
+        [
+            'id'   => 1,
+            'type' => 'B',
+        ],
+    ]);
 
-$foo
-    ->groupBy('type')
-    ->map(function ($grouped, $groupKey): array {
-        assertType('(int|string)', $groupKey);
-    });
+    $foo
+        ->groupBy('type')
+        ->map(function ($grouped, $groupKey): array {
+            assertType('(int|string)', $groupKey);
+        });
 
-assertType('App\User|null', $collection->first());
-assertType('App\User|bool', $collection->first(null, false));
-assertType('App\User|null', $collection->first(function ($user) {
-    assertType('App\User', $user);
+    assertType('App\User|null', $collection->first());
+    assertType('App\User|bool', $collection->first(null, false));
+    assertType('App\User|null', $collection->first(function ($user) {
+        assertType('App\User', $user);
 
-    return $user->id > 1;
-}));
-assertType('App\User|bool', $collection->first(function (User $user) {
-    assertType('App\User', $user);
+        return $user->id > 1;
+    }));
+    assertType('App\User|bool', $collection->first(function (User $user) {
+        assertType('App\User', $user);
 
-    return $user->id > 1;
-}, function () {
-    return false;
-}));
+        return $user->id > 1;
+    }, function () {
+        return false;
+    }));
 
-assertType('App\User|null', $collection->firstWhere('blocked'));
-assertType('App\User|null', $collection->firstWhere('blocked', true));
-assertType('App\User|null', $collection->firstWhere('blocked', '=', true));
+    assertType('App\User|null', $collection->firstWhere('blocked'));
+    assertType('App\User|null', $collection->firstWhere('blocked', true));
+    assertType('App\User|null', $collection->firstWhere('blocked', '=', true));
 
-assertType('App\User|null', $collection->last());
-assertType('App\User|bool', $collection->last(null, false));
-assertType('App\User|null', $collection->last(function (User $user) {
-    return $user->id > 1;
-}));
-assertType('App\User|bool', $collection->last(function (User $user) {
-    return $user->id > 1;
-}, function () {
-    return false;
-}));
+    assertType('App\User|null', $collection->last());
+    assertType('App\User|bool', $collection->last(null, false));
+    assertType('App\User|null', $collection->last(function (User $user) {
+        return $user->id > 1;
+    }));
+    assertType('App\User|bool', $collection->last(function (User $user) {
+        return $user->id > 1;
+    }, function () {
+        return false;
+    }));
 
-assertType('App\User|null', $collection->get(1));
-assertType('App\User', $collection->get(1, new User()));
+    assertType('App\User|null', $collection->get(1));
+    assertType('App\User', $collection->get(1, new User()));
 
-assertType('App\User|null', $collection->pull(1));
-assertType('App\User', $collection->pull(1, new User()));
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->filter());
+    assertType('App\User|null', $collection->pull(1));
+    assertType('App\User', $collection->pull(1, new User()));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->filter());
 
-assertType('App\User', $collection->random());
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(5));
+    assertType('App\User', $collection->random());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(5));
 
-assertType('App\User', $collectionOfUsers->random());
-assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->random(5));
+    assertType('App\User', $collectionOfUsers->random());
+    assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->random(5));
 
-assertType('App\User|null', $collection->pop());
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->pop(5));
+    assertType('App\User|null', $collection->pop());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->pop(5));
 
-assertType('App\User|null', $collectionOfUsers->pop());
-assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->pop(5));
+    assertType('App\User|null', $collectionOfUsers->pop());
+    assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->pop(5));
 
-assertType('App\User|null', $collection->shift());
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->shift(5));
+    assertType('App\User|null', $collection->shift());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->shift(5));
 
-assertType('App\User|null', $collectionOfUsers->shift());
-assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->shift(5));
+    assertType('App\User|null', $collectionOfUsers->shift());
+    assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->shift(5));
+}

--- a/tests/Type/data/collection-where-not-null.php
+++ b/tests/Type/data/collection-where-not-null.php
@@ -6,28 +6,17 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull());
-assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull());
-assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull(null));
-assertType(
-    'Illuminate\Support\Collection<int, App\User|array{id: string}|stdClass>',
-    collect([new \App\User, new \stdClass, ['id' => 'foo'], 'foo', true, 22])->whereNotNull('id')
-);
-
-/** @param \Illuminate\Database\Eloquent\Collection<int, \App\User> $foo */
-function objectAndParam(EloquentCollection $foo): void
+/** @param EloquentCollection<int, ?\App\User> $foo */
+function test(EloquentCollection $foo): void
 {
+    assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull());
+    assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull());
+    assertType('Illuminate\Support\Collection<int, int|string>', collect([1, 2, null, '', 'hello'])->whereNotNull(null));
+    assertType(
+        'Illuminate\Support\Collection<int, App\User|array{id: string}|stdClass>',
+        collect([new \App\User, new \stdClass, ['id' => 'foo'], 'foo', true, 22])->whereNotNull('id')
+    );
     assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $foo->whereNotNull('blocked'));
-}
-
-/** @param \Illuminate\Database\Eloquent\Collection<int, ?\App\User> $foo */
-function objectOrNullAndParam(EloquentCollection $foo): void
-{
     assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $foo->whereNotNull('blocked'));
-}
-
-/** @param \Illuminate\Database\Eloquent\Collection<int, ?\App\User> $foo */
-function objectOrNull(EloquentCollection $foo): void
-{
     assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $foo->whereNotNull());
 }

--- a/tests/Type/data/conditionable.php
+++ b/tests/Type/data/conditionable.php
@@ -13,41 +13,40 @@ class Foo
     use Conditionable;
 }
 
-assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
-    // do nothing
-}));
-
-assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
-    return null;
-}));
-
-assertType('int', (new Foo())->when(true, function (Foo $foo): int {
-    return rand();
-}));
-
-// Test to make sure the callback has a non-null value.
-(new Foo())->when(User::first(), function (Foo $foo, $user): void {
-    assertType(User::class, $user);
-});
-
-assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
-    // do nothing
-}));
-
-assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
-    return null;
-}));
-
-assertType('int', (new Foo())->unless(true, function (Foo $foo): int {
-    return rand();
-}));
-
 /** @param Builder<User> $query */
-function doFoo(Builder $query): void
+function test(Builder $query): void
 {
+    assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
+        // do nothing
+    }));
+
+    assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
+        return null;
+    }));
+
+    assertType('int', (new Foo())->when(true, function (Foo $foo): int {
+        return rand();
+    }));
+
+    // Test to make sure the callback has a non-null value.
+    (new Foo())->when(User::first(), function (Foo $foo, $user): void {
+        assertType(User::class, $user);
+    });
+
+    assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
+        // do nothing
+    }));
+
+    assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
+        return null;
+    }));
+
+    assertType('int', (new Foo())->unless(true, function (Foo $foo): int {
+        return rand();
+    }));
+
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query->when(true, static function (Builder $query): Builder {
         /** @phpstan-var Builder<User> $query */
-
         return $query->whereNull('name');
     }));
 }

--- a/tests/Type/data/container-array-access.php
+++ b/tests/Type/data/container-array-access.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace ContainerArrayAccess;
 
+use Illuminate\Container\Container;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Container\Container $app */
-assertType('Illuminate\Auth\AuthManager', $app['auth']);
-assertType('Illuminate\Translation\Translator', $app['translator']);
-
-/** @var 'auth'|'translator' $args */
-assertType('Illuminate\Auth\AuthManager|Illuminate\Translation\Translator', $app[$args]);
+/** @param 'auth'|'translator' $arg */
+function test(Container $app, string $arg): void
+{
+    assertType('Illuminate\Auth\AuthManager', $app['auth']);
+    assertType('Illuminate\Translation\Translator', $app['translator']);
+    assertType('Illuminate\Auth\AuthManager|Illuminate\Translation\Translator', $app[$arg]);
+}

--- a/tests/Type/data/container-make.php
+++ b/tests/Type/data/container-make.php
@@ -4,11 +4,17 @@ namespace ContainerMake;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Container\Container;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo(\Illuminate\Container\Container $container, \Illuminate\Contracts\Container\Container $container2)
-{
+/** @param class-string<Model> $model */
+function test(
+    Container $container,
+    ContainerContract $container2,
+    string $model,
+): void {
     assertType('Illuminate\Config\Repository', $container->make(Repository::class));
     assertType('Illuminate\Config\Repository', $container->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $container->resolve(Repository::class));
@@ -16,11 +22,7 @@ function doFoo(\Illuminate\Container\Container $container, \Illuminate\Contracts
     assertType('Illuminate\Config\Repository', $container2->make(Repository::class));
     assertType('Illuminate\Config\Repository', $container2->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $container2->resolve(Repository::class));
-}
 
-/** @param class-string<Model> $foo */
-function doBar(string $foo, \Illuminate\Contracts\Container\Container $container)
-{
     assertType('mixed', $container->make($foo));
     assertType('mixed', $container->makeWith($foo));
     assertType('mixed', $container->resolve($foo));

--- a/tests/Type/data/contracts.php
+++ b/tests/Type/data/contracts.php
@@ -7,12 +7,8 @@ use Illuminate\Contracts\Session\Session;
 
 use function PHPStan\Testing\assertType;
 
-function testApplicationIsLocal(Application $app)
+function test(Application $app, Session $session): void
 {
     assertType('bool', $app->isLocal());
-}
-
-function testSessionAgeFlashData(Session $session)
-{
     assertType('null', $session->ageFlashData());
 }

--- a/tests/Type/data/custom-eloquent-builder.php
+++ b/tests/Type/data/custom-eloquent-builder.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
+function test(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
 {
     assertType('CustomEloquentBuilder\ModelWithCustomBuilder|null', ModelWithCustomBuilder::where('email', 'bar')->first());
     assertType('CustomEloquentBuilder\CustomEloquentBuilder<CustomEloquentBuilder\ModelWithCustomBuilder>', ModelWithCustomBuilder::where('email', 'bar'));

--- a/tests/Type/data/custom-eloquent-collection.php
+++ b/tests/Type/data/custom-eloquent-collection.php
@@ -11,7 +11,7 @@ use App\User;
 
 use function PHPStan\Testing\assertType;
 
-function foo()
+function test(): void
 {
     assertType('App\AccountCollection<int, App\Account>', Account::query()->fromQuery('select * from accounts'));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::query()->fromQuery('select * from accounts'));

--- a/tests/Type/data/database-transaction.php
+++ b/tests/Type/data/database-transaction.php
@@ -8,21 +8,22 @@ use Illuminate\Support\Facades\DB;
 
 use function PHPStan\Testing\assertType;
 
-assertType('int', DB::transaction(fn () => 1));
-assertType('string', DB::transaction(fn () => 'lorem'));
-assertType('float', DB::transaction(fn () => 8.1));
-assertType('bool', DB::transaction(fn () => true));
+function test(): void
+{
+    assertType('int', DB::transaction(fn () => 1));
+    assertType('string', DB::transaction(fn () => 'lorem'));
+    assertType('float', DB::transaction(fn () => 8.1));
+    assertType('bool', DB::transaction(fn () => true));
+    assertType('null', DB::transaction(function () {
+        echo 'ipsum';
+    }));
+    assertType('float|null', DB::transaction(function () {
+        $number = rand();
 
-assertType('null', DB::transaction(function () {
-    echo 'ipsum';
-}));
+        if ($number % 2 === 0) {
+            return null;
+        }
 
-assertType('float|null', DB::transaction(function () {
-    $number = rand();
-
-    if ($number % 2 === 0) {
-        return null;
-    }
-
-    return sqrt($number);
-}));
+        return sqrt($number);
+    }));
+}

--- a/tests/Type/data/date-extension.php
+++ b/tests/Type/data/date-extension.php
@@ -6,8 +6,7 @@ use Illuminate\Support\Facades\Date;
 
 use function PHPStan\Testing\assertType;
 
-/** @param mixed $date */
-function foo($date): void
+function test(mixed $date): void
 {
     assertType('Illuminate\Support\Carbon', Date::create());
     assertType('Illuminate\Support\Carbon', Date::createFromDate());

--- a/tests/Type/data/environment-helper.php
+++ b/tests/Type/data/environment-helper.php
@@ -4,6 +4,9 @@ namespace EnvironmentHelper;
 
 use function PHPStan\Testing\assertType;
 
-assertType('string', app()->environment());
-assertType('bool', app()->environment('local'));
-assertType('bool', app()->environment(['local', 'production']));
+function test(): void
+{
+    assertType('string', app()->environment());
+    assertType('bool', app()->environment('local'));
+    assertType('bool', app()->environment(['local', 'production']));
+}

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Storage;
 
 use function PHPStan\Testing\assertType;
 
-function foo()
+function test(): void
 {
     assertType('Illuminate\Http\Request', Request::instance());
 

--- a/tests/Type/data/form-request.php
+++ b/tests/Type/data/form-request.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace FormRequest;
 
+use Illuminate\Foundation\Http\FormRequest;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Foundation\Http\FormRequest $request */
-assertType('Illuminate\Support\ValidatedInput', $request->safe());
-assertType('array<string, mixed>', $request->safe(['key']));
-assertType('array<string, mixed>', $request->validated());
+function test(FormRequest $request): void
+{
+    assertType('Illuminate\Support\ValidatedInput', $request->safe());
+    assertType('array<string, mixed>', $request->safe(['key']));
+    assertType('array<string, mixed>', $request->validated());
+}

--- a/tests/Type/data/gate-facade.php
+++ b/tests/Type/data/gate-facade.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Gate;
 
 use function PHPStan\Testing\assertType;
 
-function foo(): void
+function test(): void
 {
     assertType('Illuminate\Auth\Access\Gate', Gate::forUser(new User()));
     assertType('Illuminate\Auth\Access\Response', Gate::inspect('foo'));

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -10,17 +10,14 @@ use Throwable;
 
 use function PHPStan\Testing\assertType;
 
-function appHelper()
+function test(?int $value = 0): void
 {
     assertType('Illuminate\Foundation\Application', app());
     assertType('Larastan\Larastan\ApplicationResolver', app(ApplicationResolver::class));
     assertType('Illuminate\Auth\AuthManager', app('auth'));
     assertType('Larastan\Larastan\ApplicationResolver', resolve(ApplicationResolver::class));
     assertType('Illuminate\Auth\AuthManager', resolve('auth'));
-}
 
-function authHelper()
-{
     assertType('Illuminate\Auth\AuthManager', auth());
     assertType('Illuminate\Contracts\Auth\Guard', auth()->guard('web'));
     assertType('Illuminate\Contracts\Auth\StatefulGuard', auth('web'));
@@ -35,29 +32,17 @@ function authHelper()
     assertType('int|string|null', auth('admin')->id());
     assertType('Illuminate\Contracts\Auth\Authenticatable|false', auth()->loginUsingId(1));
     assertType('null', auth()->login(new User()));
-}
 
-function nowAndToday()
-{
     assertType('Illuminate\Support\Carbon', now());
     assertType('Illuminate\Support\Carbon', today());
-}
 
-function redirectHelper()
-{
     assertType('Illuminate\Http\RedirectResponse', redirect('/'));
     assertType('Illuminate\Routing\Redirector', redirect());
-}
 
-function requestHelper()
-{
     assertType('Illuminate\Http\Request', request());
     assertType('mixed', request('foo'));
     assertType('array<string>', request(['foo', 'bar']));
-}
 
-function rescueHelper()
-{
     assertType('string|null', rescue(function () {
         if (mt_rand(0, 1)) {
             throw new Exception();
@@ -101,16 +86,10 @@ function rescueHelper()
 
         return 'ok';
     }, 'failed', false));
-}
 
-function responseHelper()
-{
     assertType('Illuminate\Http\Response', response('foo'));
     assertType('Illuminate\Contracts\Routing\ResponseFactory', response());
-}
 
-function retryHelper()
-{
     assertType('null', retry(3, function () {
     }));
 
@@ -129,20 +108,14 @@ function retryHelper()
     }, 0, function (Exception $e): bool {
         return true;
     }));
-}
 
-function strHelper()
-{
     assertType('Illuminate\Support\Stringable', str('foo'));
     assertType('mixed', str());
 
     assertType('string', Str::replace('foo', 'bar', 'Laravel'));
     assertType('array{string, string}', Str::replace('foo', 'bar', ['Laravel', 'Framework']));
     assertType('array<int|string, string>', Str::replace('foo', 'bar', collect(['Laravel', 'Framework'])));
-}
 
-function tapHelper()
-{
     assertType('App\User', tap(new User(), function (User $user): void {
         $user->name = 'Can Vural';
         $user->save();
@@ -151,32 +124,20 @@ function tapHelper()
     assertType('Illuminate\Support\HigherOrderTapProxy<App\User>', tap(new User()));
     assertType('App\User', tap(new User())->update(['name' => 'Taylor Otwell']));
     assertType('Illuminate\Contracts\Validation\Validator&Illuminate\Validation\Validator', tap(validator([], []))->addReplacers());
-}
 
-function urlHelper()
-{
     assertType('string', url('/path'));
     assertType('Illuminate\Contracts\Routing\UrlGenerator', url());
-}
 
-function validatorHelper()
-{
     assertType('Illuminate\Contracts\Validation\Factory', validator());
     assertType('Illuminate\Contracts\Validation\Validator&Illuminate\Validation\Validator', validator(['foo' => 'bar'], ['foo' => 'required']));
     assertType('array', validator(['foo' => 'bar'], ['foo' => 'required'])->valid());
-}
 
-function valueHelper()
-{
     assertType('App\User|null', value(function (): ?User {
         return User::first();
     }));
 
     assertType('5', value(5));
-}
 
-function transformHelper()
-{
     assertType('array|null', transform(User::first(), fn (User $user) => $user->toArray()));
     assertType('array', transform(User::sole(), fn (User $user) => $user->toArray()));
 
@@ -194,24 +155,12 @@ function transformHelper()
     assertType('null', transform(null, fn () => 1));
     assertType('null', transform('', fn () => 1));
     assertType('null', transform([], fn () => 1));
-}
-
-function filledHelperNullInference()
-{
-    /** @var ?int $value */
-    $value = 0;
 
     if (filled($value)) {
         assertType('int', $value);
     } else {
         assertType('int|null', $value);
     }
-}
-
-function blankHelperNullInference()
-{
-    /** @var ?int $value */
-    $value = 0;
 
     if (blank($value)) {
         assertType('int|null', $value);

--- a/tests/Type/data/higher-order-collection-proxy-methods.php
+++ b/tests/Type/data/higher-order-collection-proxy-methods.php
@@ -9,20 +9,27 @@ use App\OnlyValueGenericCollection;
 use App\Transaction;
 use App\TransactionCollection;
 use App\User;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
 
 /**
- * @param  Collection<int, User>  $users
+ * @param  EloquentCollection<int, User>  $users
  * @param  SupportCollection<int, Importer>  $collection
  * @param  SupportCollection<int, User>  $supportCollectionWithModels
  * @param  OnlyValueGenericCollection<ModelWithOnlyValueGenericCollection>  $onlyValueGenericCollection
  * @param  TransactionCollection<int, Transaction>  $transactionCollection
  */
-function doFoo(Collection $users, User $user, SupportCollection $collection, SupportCollection $supportCollectionWithModels, NonGenericCollection $nonGenericCollection, OnlyValueGenericCollection $onlyValueGenericCollection, TransactionCollection $transactionCollection)
-{
+function test(
+    EloquentCollection $users,
+    User $user,
+    SupportCollection $collection,
+    SupportCollection $supportCollectionWithModels,
+    NonGenericCollection $nonGenericCollection,
+    OnlyValueGenericCollection $onlyValueGenericCollection,
+    TransactionCollection $transactionCollection,
+): void {
     assertType('float', $users->avg->id() + $users->average->id());
     assertType('bool', $users->contains->isActive());
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $users->each->delete());

--- a/tests/Type/data/logger.php
+++ b/tests/Type/data/logger.php
@@ -2,9 +2,11 @@
 
 namespace Logger;
 
+use Illuminate\Log\Logger;
+
 use function PHPStan\Testing\assertType;
 
-function doFoo(\Illuminate\Log\Logger $logger)
+function test(Logger $logger): void
 {
     assertType('array<int, Monolog\Handler\HandlerInterface>', $logger->getHandlers());
 }

--- a/tests/Type/data/macros-php-81.php
+++ b/tests/Type/data/macros-php-81.php
@@ -6,4 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 use function PHPStan\Testing\assertType;
 
-assertType('string', Builder::macroWithEnumDefaultValue());
+function test(): void
+{
+    assertType('string', Builder::macroWithEnumDefaultValue());
+}

--- a/tests/Type/data/macros.php
+++ b/tests/Type/data/macros.php
@@ -17,33 +17,36 @@ use PHPStan\TrinaryLogic;
 use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 
-try {
-    Request::validate([]);
-} catch (ValidationException $e) {
-    $foo = 'foo';
+function test(): void
+{
+    assertType('string', Builder::globalCustomMacro(b: 99));
+    assertType('string', Post::globalCustomMacro(b: 99));
+    assertType('string', PostBuilder::globalCustomMacro(b: 99));
+    assertType('string', User::first()->accounts()->globalCustomMacro(b: 99));
+
+    assertType('string', \Illuminate\Database\Query\Builder::globalCustomDatabaseQueryMacro(b: 99));
+    assertType('string', Post::globalCustomDatabaseQueryMacro(b: 99));
+    assertType('string', PostBuilder::globalCustomDatabaseQueryMacro(b: 99));
+    assertType('string', User::first()->accounts()->globalCustomDatabaseQueryMacro(b: 99));
+
+    assertType('int', Route::facadeMacro());
+    assertType('int', Auth::sessionGuardMacro());
+    assertType('int', Auth::requestGuardMacro());
+
+    assertType('string', collect([])->customCollectionMacro());
+    assertType('string', Collection::customCollectionMacro());
+
+    assertType('string', collect([])->customCollectionMacroString());
+    assertType('string', Collection::customCollectionMacroString());
+
+    assertType('string', Str::trimMacro(''));
+    assertType('string', Str::asciiAliasMacro(''));
+
+    try {
+        Request::validate([]);
+    } catch (ValidationException $e) {
+        $foo = 'foo';
+    }
+
+    assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
 }
-
-assertType('string', Builder::globalCustomMacro(b: 99));
-assertType('string', Post::globalCustomMacro(b: 99));
-assertType('string', PostBuilder::globalCustomMacro(b: 99));
-assertType('string', User::first()->accounts()->globalCustomMacro(b: 99));
-
-assertType('string', \Illuminate\Database\Query\Builder::globalCustomDatabaseQueryMacro(b: 99));
-assertType('string', Post::globalCustomDatabaseQueryMacro(b: 99));
-assertType('string', PostBuilder::globalCustomDatabaseQueryMacro(b: 99));
-assertType('string', User::first()->accounts()->globalCustomDatabaseQueryMacro(b: 99));
-
-assertType('int', Route::facadeMacro());
-assertType('int', Auth::sessionGuardMacro());
-assertType('int', Auth::requestGuardMacro());
-
-assertType('string', collect([])->customCollectionMacro());
-assertType('string', Collection::customCollectionMacro());
-
-assertType('string', collect([])->customCollectionMacroString());
-assertType('string', Collection::customCollectionMacroString());
-
-assertType('string', Str::trimMacro(''));
-assertType('string', Str::asciiAliasMacro(''));
-
-assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -7,7 +7,7 @@ use App\User;
 
 use function PHPStan\Testing\assertType;
 
-function dummy(?int $foo): void {
+function test(?int $foo): void {
     assertType('Database\Factories\UserFactory', User::factory());
     assertType('Database\Factories\UserFactory', User::factory()->new());
     assertType('App\User', User::factory()->createOne());

--- a/tests/Type/data/model-l10-15.php
+++ b/tests/Type/data/model-l10-15.php
@@ -6,12 +6,8 @@ use App\Thread;
 
 use function PHPStan\Testing\assertType;
 
-function testToRawSql()
+function test(): void
 {
     assertType('string', Thread::valid()->toRawSql());
-}
-
-function testDumpRawSql()
-{
     assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid()->dumpRawSql());
 }

--- a/tests/Type/data/model-l10-20.php
+++ b/tests/Type/data/model-l10-20.php
@@ -6,7 +6,7 @@ use App\User;
 
 use function PHPStan\Testing\assertType;
 
-function testCreateOrFirst()
+function test(): void
 {
     assertType('App\User', User::createOrFirst([]));
 }

--- a/tests/Type/data/model-methods.php
+++ b/tests/Type/data/model-methods.php
@@ -6,18 +6,20 @@ use App\User;
 
 use function PHPStan\Testing\assertType;
 
-/** @var User $user */
-assertType('array{name: string, email: string}', $user->only('name', 'email'));
-assertType('array{name: string, email: string}', $user->only(['name', 'email']));
-assertType('array{name: string, nonexistent: null}', $user->only(['name', 'nonexistent']));
-assertType('array<string, mixed>', $user->only(['name', $foo]));
+function test(User $user): void
+{
+    assertType('array{name: string, email: string}', $user->only('name', 'email'));
+    assertType('array{name: string, email: string}', $user->only(['name', 'email']));
+    assertType('array{name: string, nonexistent: null}', $user->only(['name', 'nonexistent']));
+    assertType('array<string, mixed>', $user->only(['name', $foo]));
 
-$columns = ['name', 'email'];
-$foo = 'nonexistent';
-assertType('array{name: string, email: string}', $user->only(...$columns));
-assertType('array{name: string, email: string}', $user->only($columns));
-assertType('array{nonexistent: null}', $user->only($foo));
-assertType(
-    'array{name: string, email: string, nonexistent: null}',
-    $user->only([...$columns, $foo]),
-);
+    $columns = ['name', 'email'];
+    $foo = 'nonexistent';
+    assertType('array{name: string, email: string}', $user->only(...$columns));
+    assertType('array{name: string, email: string}', $user->only($columns));
+    assertType('array{nonexistent: null}', $user->only($foo));
+    assertType(
+        'array{name: string, email: string, nonexistent: null}',
+        $user->only([...$columns, $foo]),
+    );
+}

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -13,22 +13,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 use function PHPStan\Testing\assertType;
 
-function foo(Foo $foo, Bar $bar, Account $account): void
-{
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyRelation);
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyThroughRelation);
-    assertType('ModelPropertiesRelations\Baz|null', $foo->hasOneThroughRelation);
-    assertType('ModelPropertiesRelations\Foo', $bar->belongsToRelation);
-    assertType('mixed', $bar->morphToRelation);
-    assertType('App\Account|App\User', $bar->morphToUnionRelation);
-    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation->first());
-    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation()->find(1));
-    assertType('App\User|null', $account->ownerRelation);
-    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model|null', $foo->relationReturningUnion);
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>|ModelPropertiesRelations\Baz|null', $foo->relationReturningUnion2);
-    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Foo>', $foo->ancestors);
-}
-
 /** @property string $name */
 class Foo extends Model
 {
@@ -99,3 +83,20 @@ class Baz extends Model
 class Ancestors extends HasMany
 {
 }
+
+function test(Foo $foo, Bar $bar, Account $account): void
+{
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyRelation);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyThroughRelation);
+    assertType('ModelPropertiesRelations\Baz|null', $foo->hasOneThroughRelation);
+    assertType('ModelPropertiesRelations\Foo', $bar->belongsToRelation);
+    assertType('mixed', $bar->morphToRelation);
+    assertType('App\Account|App\User', $bar->morphToUnionRelation);
+    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation->first());
+    assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation()->find(1));
+    assertType('App\User|null', $account->ownerRelation);
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model|null', $foo->relationReturningUnion);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>|ModelPropertiesRelations\Baz|null', $foo->relationReturningUnion2);
+    assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Foo>', $foo->ancestors);
+}
+

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -20,8 +20,17 @@ use Illuminate\Support\Stringable;
 
 use function PHPStan\Testing\assertType;
 
-function foo(User $user, Account $account, Role $role, Group $group, Team $team, GuardedModel $guardedModel, Thread $thread, Address $address, RoleUser $roleUser)
-{
+function test(
+    User $user,
+    Account $account,
+    Role $role,
+    Group $group,
+    Team $team,
+    GuardedModel $guardedModel,
+    Thread $thread,
+    Address $address,
+    RoleUser $roleUser,
+): void {
     assertType('*ERROR*', $user->newStyleAttribute); // Doesn't have generic type, so we treat as it doesnt exist
     assertType('int', $user->stringButInt);
     assertType('string', $user->email);

--- a/tests/Type/data/model-relations-l10-20.php
+++ b/tests/Type/data/model-relations-l10-20.php
@@ -2,12 +2,11 @@
 
 namespace ModelRelations;
 
-use App\Account;
 use App\User;
 
 use function PHPStan\Testing\assertType;
 
-function test(User $user, \App\Address $address, Account $account, ExtendsModelWithPropertyAnnotations $model, Tag $tag, User|Account $union)
+function test(User $user): void
 {
     assertType('App\Account', $user->accounts()->createOrFirst([]));
 }

--- a/tests/Type/data/model-scopes.php
+++ b/tests/Type/data/model-scopes.php
@@ -10,61 +10,26 @@ use function PHPStan\Testing\assertType;
 
 class Scopes extends Model
 {
-    /** @var User */
-    private $user;
+    private User $user;
 
-    public function testScopeAfterRelation()
-    {
-        assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\User>', $this->hasOne(User::class)->active());
-    }
-
-    public function testScopeAfterRelationWithHasMany()
-    {
-        assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\User>', $this->hasMany(User::class)->active());
-    }
-
-    public function testScopeAfterQueryBuilderStaticCall()
-    {
-        assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
-    }
-
-    public function testScopeAfterQueryBuilderVariableCall()
-    {
-        $this->user = new User;
-
-        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $this->user->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
-    }
-
-    public function testScopeWithFirst()
-    {
-        $this->user = new User;
-
-        assertType('App\User|null', $this->user->where('name', 'bar')->active()->first());
-    }
-
-    public function testVoidScopeStillReturnsBuilder()
-    {
-        assertType('Illuminate\Database\Eloquent\Builder<ModelScope\Scopes>', $this->withVoidReturn());
-    }
-
-    public function testVoidScopeStillHasGenericBuilder()
-    {
-        assertType('ModelScope\Scopes|null', $this->withVoidReturn()->first());
-    }
-
-    /** @phpstan-param Builder<Scopes> $query */
     public function scopeWithVoidReturn(Builder $query): void
     {
         $query->where('whyuse', 'void');
     }
 
-    public function testScopeThatStartsWithWordWhere()
+    /** @param Builder<Scopes> $query */
+    public function test(User $user, Builder $query): void
     {
-        assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::query()->whereActive());
-    }
+        assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\User>', $this->hasOne(User::class)->active());
+        assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\User>', $this->hasMany(User::class)->active());
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
 
-    public function testScopeDefinedInClassDocBlock(User $user): void
-    {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $this->user->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
+        assertType('App\User|null', $this->user->where('name', 'bar')->active()->first());
+        assertType('Illuminate\Database\Eloquent\Builder<ModelScope\Scopes>', $this->withVoidReturn());
+        assertType('ModelScope\Scopes|null', $this->withVoidReturn()->first());
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::query()->whereActive());
+
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->someScope());
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::query()->someScope());
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->where('foo')->someScope());

--- a/tests/Type/data/optional-helper.php
+++ b/tests/Type/data/optional-helper.php
@@ -7,24 +7,21 @@ use StdClass;
 use function optional;
 use function PHPStan\Testing\assertType;
 
-assertType('mixed', optional(['foo' => 'bar']));
-
-assertType('int', optional('1', function (string $value): int {
-    return 1;
-}));
-
-assertType('null', optional(null, function (string $value): int {
-    return 1;
-}));
-
-assertType('mixed', optional(new StdClass()));
-assertType('mixed', optional(new StdClass())->foo);
-
 class Foo
 {
-    public function doFoo(): void
-    {
-    }
+    public function doFoo(): void { }
 }
 
-assertType('mixed', optional(new Foo)->doFoo());
+function test(): void
+{
+    assertType('mixed', optional(['foo' => 'bar']));
+    assertType('int', optional('1', function (string $value): int {
+        return 1;
+    }));
+    assertType('null', optional(null, function (string $value): int {
+        return 1;
+    }));
+    assertType('mixed', optional(new StdClass()));
+    assertType('mixed', optional(new StdClass())->foo);
+    assertType('mixed', optional(new Foo)->doFoo());
+}

--- a/tests/Type/data/paginator-extension.php
+++ b/tests/Type/data/paginator-extension.php
@@ -8,25 +8,28 @@ use App\User;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
-assertType('array<App\User>', User::paginate()->all());
-assertType('array<App\User>', User::paginate()->items());
-assertType('App\User|null', User::paginate()[0]);
+function test(): void
+{
+    assertType('Illuminate\Pagination\LengthAwarePaginator<App\User>', User::paginate());
+    assertType('array<App\User>', User::paginate()->all());
+    assertType('array<App\User>', User::paginate()->items());
+    assertType('App\User|null', User::paginate()[0]);
 
-assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
-assertType('array<App\User>', User::simplePaginate()->all());
-assertType('array<App\User>', User::simplePaginate()->items());
-assertType('App\User|null', User::simplePaginate()[0]);
+    assertType('Illuminate\Pagination\Paginator<App\User>', User::simplePaginate());
+    assertType('array<App\User>', User::simplePaginate()->all());
+    assertType('array<App\User>', User::simplePaginate()->items());
+    assertType('App\User|null', User::simplePaginate()[0]);
 
-assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
-assertType('array<App\User>', User::cursorPaginate()->all());
-assertType('array<App\User>', User::cursorPaginate()->items());
-assertType('App\User|null', User::cursorPaginate()[0]);
+    assertType('Illuminate\Pagination\CursorPaginator<App\User>', User::cursorPaginate());
+    assertType('array<App\User>', User::cursorPaginate()->all());
+    assertType('array<App\User>', User::cursorPaginate()->items());
+    assertType('App\User|null', User::cursorPaginate()[0]);
 
-assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());
+    assertType('ArrayIterator<(int|string), App\User>', User::query()->paginate()->getIterator());
 
-// HasMany
-assertType('Illuminate\Pagination\LengthAwarePaginator<App\Account>', (new User())->accounts()->paginate());
+    // HasMany
+    assertType('Illuminate\Pagination\LengthAwarePaginator<App\Account>', (new User())->accounts()->paginate());
 
-// BelongsToMany
-assertType('Illuminate\Pagination\LengthAwarePaginator<App\Post>', (new User())->posts()->paginate());
+    // BelongsToMany
+    assertType('Illuminate\Pagination\LengthAwarePaginator<App\Post>', (new User())->posts()->paginate());
+}

--- a/tests/Type/data/query-builder-l10-24.php
+++ b/tests/Type/data/query-builder-l10-24.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\DB;
 
 use function PHPStan\Testing\assertType;
 
-function testJoinSubExpressionParameter(): void
+function test(): void
 {
     $subQuery = DB::table('addresses')
         ->select(['id', 'user_id']);
@@ -17,35 +17,23 @@ function testJoinSubExpressionParameter(): void
         ->joinSub($subQuery, 'addresses', 'users.user_id', '=', DB::raw('addresses.user_id'));
 
     assertType('Illuminate\Database\Query\Builder', $builder);
-}
 
-function testWhereExpressionParameter(): void
-{
     $builder = DB::table('users')
         ->where(DB::raw('id'), '=', 1);
 
     assertType('Illuminate\Database\Query\Builder', $builder);
-}
 
-function testOrWhereExpressionParameter(): void
-{
     $builder = DB::table('users')
         ->where(DB::raw('id'), '=', 1)
         ->orWhere(DB::raw('id'), '=', 2);
 
     assertType('Illuminate\Database\Query\Builder', $builder);
-}
 
-function testWhereNullExpressionParameter(): void
-{
     $builder = DB::table('users')
         ->whereNull(DB::raw('email_verified_at'));
 
     assertType('Illuminate\Database\Query\Builder', $builder);
-}
 
-function testWhereNotNullExpressionParameter(): void
-{
     $builder = DB::table('users')
         ->whereNotNull(DB::raw('email_verified_at'));
 

--- a/tests/Type/data/query-builder.php
+++ b/tests/Type/data/query-builder.php
@@ -8,10 +8,9 @@ use Illuminate\Support\Facades\DB;
 
 use function PHPStan\Testing\assertType;
 
-function testPluckReturnType()
+function test(): void
 {
     $record = DB::table('user')->pluck('email', 'id');
     assertType('Illuminate\Support\Collection<(int|string), mixed>', $record);
+    assertType('Illuminate\Support\LazyCollection<int, mixed>', DB::table('user')->cursor());
 }
-
-assertType('Illuminate\Support\LazyCollection<int, mixed>', DB::table('user')->cursor());

--- a/tests/Type/data/redirect-response.php
+++ b/tests/Type/data/redirect-response.php
@@ -6,5 +6,8 @@ use Illuminate\Http\RedirectResponse;
 
 use function PHPStan\Testing\assertType;
 
-assertType(RedirectResponse::class, redirect()->back()->withSuccess(true));
-assertType(RedirectResponse::class, redirect()->back()->withCookie('foo'));
+function test(): void
+{
+    assertType(RedirectResponse::class, redirect()->back()->withSuccess(true));
+    assertType(RedirectResponse::class, redirect()->back()->withCookie('foo'));
+}

--- a/tests/Type/data/request-header.php
+++ b/tests/Type/data/request-header.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace RequestHeader;
 
+use Illuminate\Http\Request;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Http\Request $request */
-assertType('array<string, array<int, string|null>>', $request->header());
-assertType('string|null', $request->header('key'));
-assertType('string', $request->header('key', 'default'));
+function test(Request $request): void
+{
+    assertType('array<string, array<int, string|null>>', $request->header());
+    assertType('string|null', $request->header('key'));
+    assertType('string', $request->header('key', 'default'));
+}

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace RequestObject;
 
+use Illuminate\Http\Request;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Http\Request $request */
-assertType('array<int, Illuminate\Http\UploadedFile>', $request->file());
-assertType('array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|null', $request->file('foo'));
-assertType('array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|stdClass', $request->file('foo', new \stdClass()));
-
-assertType('Illuminate\Routing\Route|null', $request->route());
-assertType('object|string|null', $request->route('foo'));
-assertType('object|string|null', $request->route('foo', 'bar'));
+function test(Request $request): void
+{
+    assertType('array<int, Illuminate\Http\UploadedFile>', $request->file());
+    assertType('array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|null', $request->file('foo'));
+    assertType('array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|stdClass', $request->file('foo', new \stdClass()));
+    assertType('Illuminate\Routing\Route|null', $request->route());
+    assertType('object|string|null', $request->route('foo'));
+    assertType('object|string|null', $request->route('foo', 'bar'));
+}

--- a/tests/Type/data/request-user.php
+++ b/tests/Type/data/request-user.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace RequestObject;
 
+use Illuminate\Http\Request;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Http\Request $request */
-assertType('App\Admin|App\User|null', $request->user());
-assertType('App\User|null', $request->user('web'));
-assertType('App\Admin|null', $request->user('admin'));
+function test(Request $request): void
+{
+    assertType('App\Admin|App\User|null', $request->user());
+    assertType('App\User|null', $request->user('web'));
+    assertType('App\Admin|null', $request->user('admin'));
+}

--- a/tests/Type/data/route.php
+++ b/tests/Type/data/route.php
@@ -9,10 +9,9 @@ use Illuminate\Support\Facades\Route as RouteFacade;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Routing\Route', RouteFacade::get('/awesome', 'foobar')->middleware('foobar'));
-
-function foo(Route $route)
+function test(Route $route): void
 {
+    assertType('Illuminate\Routing\Route', RouteFacade::get('/awesome', 'foobar')->middleware('foobar'));
     assertType('Illuminate\Routing\Route', $route->middleware('foobar'));
     assertType('array<string>', $route->middleware());
 }

--- a/tests/Type/data/tappable.php
+++ b/tests/Type/data/tappable.php
@@ -11,13 +11,16 @@ class TappableClass
     use Tappable;
 }
 
-assertType(
-    'Tappable\TappableClass',
-    (new TappableClass())->tap(function (TappableClass $tappable) {
-    }),
-);
+function test(): void
+{
+    assertType(
+        'Tappable\TappableClass',
+        (new TappableClass())->tap(function (TappableClass $tappable) {
+        }),
+    );
 
-assertType(
-    'Illuminate\Support\HigherOrderTapProxy<Tappable\TappableClass>',
-    (new TappableClass())->tap(),
-);
+    assertType(
+        'Illuminate\Support\HigherOrderTapProxy<Tappable\TappableClass>',
+        (new TappableClass())->tap(),
+    );
+}

--- a/tests/Type/data/throw.php
+++ b/tests/Type/data/throw.php
@@ -6,66 +6,41 @@ use Illuminate\Validation\ValidationException;
 
 use function PHPStan\Testing\assertType;
 
-class ThrowTest
+function test(?int $foo): void
 {
-    public function testThrowIfTryCatch(?int $foo): void
-    {
-        try {
-            throw_if(! $foo, ValidationException::withMessages(['$foo is null']));
+    try {
+        throw_if(! $foo, ValidationException::withMessages(['$foo is null']));
 
-            assertType('int<min, -1>|int<1, max>', $foo);
-        } catch (\Exception $e) {
-        }
-
-        assertType('int|null', $foo);
+        assertType('int<min, -1>|int<1, max>', $foo);
+    } catch (\Exception $e) {
     }
 
-    public function testThrowIfWithTypeCheck(int|string $foo = 5): void
-    {
-        throw_if(is_string($foo), new \Exception('$foo is a string'));
+    assertType('int|null', $foo);
 
-        assertType('int', $foo);
-    }
+    throw_unless(! is_null($foo), ValidationException::withMessages(['$foo is null']));
+    assertType('int', $foo);
 
-    public function testThrowUnless(?int $foo): void
-    {
-        throw_unless(! is_null($foo), ValidationException::withMessages(['$foo is null']));
+    /** @var int|string $foo */
+    throw_if(is_string($foo), new \Exception('$foo is a string'));
+    assertType('int', $foo);
 
-        assertType('int', $foo);
-    }
+    /** @var int|string $foo */
+    throw_unless(! is_string($foo), new \Exception('$foo is a string'));
+    assertType('int', $foo);
 
-    public function testThrowUnlessWithTypeCheck(int|string $foo = 5): void
-    {
-        throw_unless(! is_string($foo), new \Exception('$foo is a string'));
+    /** @var int|string $foo */
+    throw_if(is_string($foo));
+    assertType('int', $foo);
 
-        assertType('int', $foo);
-    }
+    /** @var int|string $foo */
+    throw_if(is_string($foo), 'Exception message');
+    assertType('int', $foo);
 
-    public function testThrowIfWithoutSecondArgument(int|string $foo = 5): void
-    {
-        throw_if(is_string($foo));
+    /** @var int|string $foo */
+    throw_unless(! is_string($foo));
+    assertType('int', $foo);
 
-        assertType('int', $foo);
-    }
-
-    public function testThrowIfWithStringArgument(int|string $foo = 5): void
-    {
-        throw_if(is_string($foo), 'Exception message');
-
-        assertType('int', $foo);
-    }
-
-    public function testThrowUnlessWithoutSecondArgument(int|string $foo = 5): void
-    {
-        throw_unless(! is_string($foo));
-
-        assertType('int', $foo);
-    }
-
-    public function testThrowUnlessWithStringArgument(int|string $foo = 5): void
-    {
-        throw_unless(! is_string($foo), 'Exception message');
-
-        assertType('int', $foo);
-    }
+    /** @var int|string $foo */
+    throw_unless(! is_string($foo), 'Exception message');
+    assertType('int', $foo);
 }

--- a/tests/Type/data/translate.php
+++ b/tests/Type/data/translate.php
@@ -2,14 +2,17 @@
 
 declare(strict_types=1);
 
-namespace EloquentBuilder;
+namespace Translate;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Contracts\Translation\Translator', trans());
-assertType('(array|string)', trans('foo'));
-assertType('(array|string)', trans('Hi :name', ['name' => 'Niek']));
+function test(): void
+{
+    assertType('Illuminate\Contracts\Translation\Translator', trans());
+    assertType('(array|string)', trans('foo'));
+    assertType('(array|string)', trans('Hi :name', ['name' => 'Niek']));
 
-assertType('null', __());
-assertType('(array|string)', __('foo'));
-assertType('(array|string)', __('Hi :name', ['name' => 'Niek']));
+    assertType('null', __());
+    assertType('(array|string)', __('foo'));
+    assertType('(array|string)', __('Hi :name', ['name' => 'Niek']));
+}

--- a/tests/Type/data/translator.php
+++ b/tests/Type/data/translator.php
@@ -7,8 +7,8 @@ use Illuminate\Translation\Translator;
 
 use function PHPStan\Testing\assertType;
 
-/** @var Translator $trans */
-assertType('(array|string)', $trans->get('language.string'));
-
-/** @var TranslatorContract $transContract */
-assertType('(array|string)', $transContract->get('language.string'));
+function test(Translator $trans, TranslatorContract $transContract): void
+{
+    assertType('(array|string)', $trans->get('language.string'));
+    assertType('(array|string)', $transContract->get('language.string'));
+}

--- a/tests/Type/data/validator.php
+++ b/tests/Type/data/validator.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace ValidatorSafe;
 
+use Illuminate\Validation\Validator;
+
 use function PHPStan\Testing\assertType;
 
-/** @var \Illuminate\Validation\Validator $validator */
-assertType('Illuminate\Support\ValidatedInput', $validator->safe());
-assertType('array<string, mixed>', $validator->safe(['key']));
+function test(Validator $validator): void
+{
+    assertType('Illuminate\Support\ValidatedInput', $validator->safe());
+    assertType('array<string, mixed>', $validator->safe(['key']));
+}

--- a/tests/Type/data/view-exists.php
+++ b/tests/Type/data/view-exists.php
@@ -4,9 +4,11 @@ namespace IlluminateView;
 
 use function PHPStan\Testing\assertType;
 
-/** @var string $view */
-if (view()->exists($view)) {
-    assertType('view-string', $view);
-}
+function test(string $view): void
+{
+    if (view()->exists($view)) {
+        assertType('view-string', $view);
+    }
 
-assertType('string', $view);
+    assertType('string', $view);
+}

--- a/tests/Type/data/view.php
+++ b/tests/Type/data/view.php
@@ -4,7 +4,10 @@ namespace IlluminateView;
 
 use function PHPStan\Testing\assertType;
 
-assertType('Illuminate\Contracts\View\Factory', view());
-assertType('Illuminate\View\View', view('foo'));
-assertType('Illuminate\View\View', view('foo')->with('bar', 'baz'));
-assertType('Illuminate\View\View', view('foo')->withFoo('bar'));
+function test(): void
+{
+    assertType('Illuminate\Contracts\View\Factory', view());
+    assertType('Illuminate\View\View', view('foo'));
+    assertType('Illuminate\View\View', view('foo')->with('bar', 'baz'));
+    assertType('Illuminate\View\View', view('foo')->withFoo('bar'));
+}

--- a/tests/Type/data/where-relation.php
+++ b/tests/Type/data/where-relation.php
@@ -10,17 +10,14 @@ class Field extends Model
 {
 }
 
-class WhereRelationTest
+function test(): void
 {
-    private function getFieldsFromOrder(): void
-    {
-        $query = Field::query();
-        assertType('Illuminate\Database\Eloquent\Builder<WhereRelation\Field>', $query);
+    $query = Field::query();
+    assertType('Illuminate\Database\Eloquent\Builder<WhereRelation\Field>', $query);
 
-        $query = $query->whereRelation('orderTypes', 'order_types.id', '=', 1);
-        assertType('Illuminate\Database\Eloquent\Builder<WhereRelation\Field>', $query);
+    $query = $query->whereRelation('orderTypes', 'order_types.id', '=', 1);
+    assertType('Illuminate\Database\Eloquent\Builder<WhereRelation\Field>', $query);
 
-        $collection = $query->get();
-        assertType('Illuminate\Database\Eloquent\Collection<int, WhereRelation\Field>', $collection);
-    }
+    $collection = $query->get();
+    assertType('Illuminate\Database\Eloquent\Collection<int, WhereRelation\Field>', $collection);
 }


### PR DESCRIPTION
Hello!

This PR goes through and refactors all the `assertType` tests for consistency in the codebase:

- all `assertType` calls are now inside a function instead of in the top level
- the name for all these functions is `test`, I felt this was a better representation of what it actually is for than `foo`/`dummy`
  - where it makes sense, some calls are inside a `test<Description>` method 
- any types needed inside the function are passed as parameters

Thanks!