### PR TITLE
Add model timestamps as array

### DIFF
--- a/stubs/common/Database/Eloquent/HasTimestamps.stub
+++ b/stubs/common/Database/Eloquent/HasTimestamps.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HasTimestamps
+{
+    /**
+     * Indicates if the model should be timestamped,
+     * or includes the timestamp fields which should be used
+     *
+     * @var bool|array<string>
+     */
+    public $timestamps;
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -33,6 +33,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/database-transaction.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-builder.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-traits.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/environment-helper.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/facades.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');

--- a/tests/Type/data/eloquent-traits.php
+++ b/tests/Type/data/eloquent-traits.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EloquentTraitStubs;
+
+use Illuminate\Database\Eloquent\Concerns\HasTimestamps;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+    use HasTimestamps;
+}
+
+assertType('array<string>|bool', (new Foo())->timestamps);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
This PR enables editing the timestamps property on an Eloquent model. This property can be set to a boolean value—true if both created_at and updated_at are used, or false if they are not. Additionally, developers can specify either created_at, updated_at, both, or neither by providing an array. Laravel will handle these settings appropriately. This PR introduces the capability to accept an array for the timestamps property.
<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None to my knowledge
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
