### PR TITLE
fix: infinite mixin recursion through class_alias

### DIFF
--- a/src/Reflection/ReflectionHelper.php
+++ b/src/Reflection/ReflectionHelper.php
@@ -12,6 +12,8 @@ use function array_key_exists;
 
 final class ReflectionHelper
 {
+    private static MixinPropertiesClassReflectionExtension|null $mixinPropertiesClassReflectionExtension = null;
+
     /**
      * Does the given class or any of its ancestors have an `@property*` annotation with the given name?
      */
@@ -27,10 +29,17 @@ final class ReflectionHelper
             }
         }
 
+        if (self::$mixinPropertiesClassReflectionExtension === null) {
+            /** @phpstan-ignore-next-line */
+            self::$mixinPropertiesClassReflectionExtension = (new MixinPropertiesClassReflectionExtension([]));
+        }
+
         /** @phpstan-ignore-next-line */
-        return (new MixinPropertiesClassReflectionExtension([$classReflection->getName()]))
+        return self::$mixinPropertiesClassReflectionExtension
             ->hasProperty($classReflection, $propertyName);
     }
+
+    private static MixinMethodsClassReflectionExtension|null $mixinMethodsClassReflectionExtension = null;
 
     /**
      * Does the given class or any of its ancestors have an `@method*` annotation with the given name?
@@ -47,8 +56,13 @@ final class ReflectionHelper
             }
         }
 
+        if (self::$mixinMethodsClassReflectionExtension === null) {
+            /** @phpstan-ignore-next-line */
+            self::$mixinMethodsClassReflectionExtension = new MixinMethodsClassReflectionExtension([]);
+        }
+
         /** @phpstan-ignore-next-line */
-        return (new MixinMethodsClassReflectionExtension([$classReflection->getName()]))
+        return self::$mixinMethodsClassReflectionExtension
             ->hasMethod($classReflection, $methodName);
     }
 }

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Error;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
 
+use function count;
 use function version_compare;
 
 class IntegrationTest extends PHPStanTestCase
@@ -22,6 +23,7 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__ . '/data/model-properties.php'];
         yield [__DIR__ . '/data/blade-view.php'];
         yield [__DIR__ . '/data/helpers.php'];
+        yield [__DIR__ . '/data/bug-1883.php', ['Call to an undefined static method RedisFacade::noSuchMethod().']];
 
         if (! version_compare(LARAVEL_VERSION, '10.0.0', '>=')) {
             return;
@@ -37,8 +39,20 @@ class IntegrationTest extends PHPStanTestCase
 
         if ($expectedErrors === null) {
             $this->assertNoErrors($errors);
-        } else { // @phpcs:ignore
-            // TODO: compare errors
+        } else {
+            $this->assertSameErrorMessages($expectedErrors, $errors);
+        }
+    }
+
+    /**
+     *  @param string[] $expectedErrors
+     *  @param Error[]  $errors
+     */
+    private function assertSameErrorMessages(array $expectedErrors, array $errors): void
+    {
+        $this->assertCount(count($expectedErrors), $errors);
+        foreach ($errors as $index => $error) {
+            $this->assertSame($expectedErrors[$index], $error->getMessage());
         }
     }
 

--- a/tests/Integration/data/bug-1883.php
+++ b/tests/Integration/data/bug-1883.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @mixin RedisAlias
+ */
+class RedisFacade extends Facade
+{
+}
+
+
+function test(): void
+{
+    RedisFacade::noSuchMethod();
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -61,3 +61,9 @@ class CustomCollectionMacro
 if (version_compare(PHP_VERSION, '8.1.0', '>=') && version_compare(PHP_VERSION, '8.2.0', '<')) {
     include_once 'enum-definition.php';
 }
+
+class RedisFacade
+{
+}
+
+class_alias(RedisFacade::class, RedisAlias::class);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #1883

**Changes**

In MixinPropertiesClassReflectionExtension, there's a mechanism to prevent infinite mixin recursion. However, within ReflectionHelper, because a new instance of MixinPropertiesClassReflectionExtension is created each time, it wasn't functioning correctly.
In https://github.com/larastan/larastan/pull/1839, an attempt was made to prevent infinite recursion where a class is mixin is applied to itself, but it failed to prevent infinite recursion when mixin was applied via class_alias. This PR addresses this issue by modifying the code to reuse MixinPropertiesClassReflectionExtension instances instead of creating new ones each time, thus effectively preventing recursion over a wider range of mixin scenarios.

**Breaking changes**

Probably No
