### PR TITLE
feat: convert array-key to int|string for collection keys

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 
 /**
- * @template TKey of array-key
+ * @template TKey of int|string
  * @template TValue
  *
  * @implements \ArrayAccess<TKey, TValue>
@@ -59,7 +59,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Push all of the given items onto the collection.
      *
-     * @template TConcatKey of array-key
+     * @template TConcatKey of int|string
      * @template TConcatValue
      *
      * @param  iterable<TConcatKey, TConcatValue>  $source
@@ -70,7 +70,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 }
 
 /**
- * @template TKey of array-key
+ * @template TKey of int|string
  * @template TValue
  *
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>

--- a/stubs/common/Contracts/Support.stub
+++ b/stubs/common/Contracts/Support.stub
@@ -6,7 +6,7 @@ interface Htmlable
 {}
 
 /**
- * @template TKey of array-key
+ * @template TKey of int|string
  * @template TValue
  */
 interface Arrayable

--- a/stubs/common/EloquentCollection.stub
+++ b/stubs/common/EloquentCollection.stub
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Support\Collection as BaseCollection;
 
 /**
- * @template TKey of array-key
+ * @template TKey of int|string
  * @template TModel of \Illuminate\Database\Eloquent\Model
  *
  * @extends \Illuminate\Support\Collection<TKey, TModel>

--- a/stubs/common/Enumerable.stub
+++ b/stubs/common/Enumerable.stub
@@ -3,13 +3,22 @@
 namespace Illuminate\Support;
 
 /**
- * @template TKey of array-key
+ * @template TKey of int|string
  * @template TValue
  *
  * @extends \IteratorAggregate<TKey, TValue>
  */
 interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable
 {
+    /**
+     * Search the collection for a given value and return the corresponding key if successful.
+     *
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @param  bool  $strict
+     * @return TKey|bool
+     */
+    public function search($value, $strict = false);
+
     /**
     * Get one or a specified number of items randomly from the collection.
     *
@@ -29,4 +38,15 @@ interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable
     * @return static<array-key, TCombineValue>
     */
    public function combine($values);
+
+   /**
+    * Push all of the given items onto the collection.
+    *
+    * @template TConcatKey of int|string
+    * @template TConcatValue
+    *
+    * @param  iterable<TConcatKey, TConcatValue>  $source
+    * @return static<TKey|TConcatKey, TValue|TConcatValue>
+    */
+   public function concat($source);
 }

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -1,8 +1,11 @@
 <?php
 
+namespace CollectionGenericStaticMethods;
+
 use App\Transaction;
 use App\TransactionCollection;
 use App\User;
+use App\UserCollection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\LazyCollection;
@@ -11,8 +14,8 @@ use function PHPStan\Testing\assertType;
 
 /** @var EloquentCollection<int, User> $collection */
 /** @var SupportCollection<string, int> $items */
-/** @var App\TransactionCollection<int, Transaction> $customEloquentCollection */
-/** @var App\UserCollection $secondCustomEloquentCollection */
+/** @var TransactionCollection<int, Transaction> $customEloquentCollection */
+/** @var UserCollection $secondCustomEloquentCollection */
 /** @var LazyCollection<int, User> $lazyCollection */
 /** @var User $user */
 assertType('Illuminate\Database\Eloquent\Collection<int, int>', EloquentCollection::range(1, 10));
@@ -161,7 +164,7 @@ assertType('Illuminate\Support\Collection<(int|string), int>', $items->countBy('
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->concat([new User()]));
 assertType('App\TransactionCollection<int, App\Transaction|App\User>', $customEloquentCollection->concat([new User()]));
 assertType('App\UserCollection', $secondCustomEloquentCollection->concat([new User()]));
-assertType('Illuminate\Support\Collection<string, App\User|int>', $items->concat([new User()]));
+assertType('Illuminate\Support\Collection<int|string, App\User|int>', $items->concat([new User()]));
 
 ////////////////////////////
 // EnumeratesValues Trait //
@@ -223,3 +226,7 @@ assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Colle
         'type' => 'B',
     ],
 ])->groupBy('type'));
+
+/** @var \Illuminate\Support\Enumerable<int, \App\User> $enumerableUsers */
+
+assertType('bool|int', $enumerableUsers->search(fn(User $user) => $user->id === 1));

--- a/tests/Type/data/collection-make-static.php
+++ b/tests/Type/data/collection-make-static.php
@@ -17,13 +17,13 @@ assertType('Illuminate\Support\Collection<int, float|int|string>', SupportCollec
 /**  @phpstan-param EloquentCollection<int, \App\User> $eloquentCollection */
 function eloquentCollectionInteger(EloquentCollection $eloquentCollection): void
 {
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($eloquentCollection));
+    assertType('Illuminate\Support\Collection<int|string, mixed>', SupportCollection::make($eloquentCollection));
 }
 
 /**  @phpstan-param EloquentCollection<int, User> $eloquentCollection */
 function eloquentCollectionUser(EloquentCollection $eloquentCollection): void
 {
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', SupportCollection::make($eloquentCollection));
+    assertType('Illuminate\Support\Collection<int|string, mixed>', SupportCollection::make($eloquentCollection));
 }
 
 /**

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -326,7 +326,7 @@ function testOldestToBaseWithQueryExpression()
 
 function testPluckToBaseWithQueryExpression()
 {
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', User::query()
+    assertType('Illuminate\Support\Collection<int|string, mixed>', User::query()
         ->whereNull('name')
         ->pluck(\Illuminate\Support\Facades\DB::raw('created_at'))
         ->toBase()


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

PHPStan has a bug around creating union types with benevolent union types. `array-key` in this case. So this PR changes `array-key` to `int|string` which should be the same behavior.

Fixes #1794 

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
