### PR TITLE
Fixed return type of overridden Request::user() method.

### DIFF
--- a/src/ReturnTypes/RequestUserExtension.php
+++ b/src/ReturnTypes/RequestUserExtension.php
@@ -40,6 +40,10 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
+        if ($methodReflection->getDeclaringClass()->getName() !== Request::class) {
+            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+        }
+
         $config     = $this->getContainer()->get('config');
         $authModels = [];
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -60,6 +60,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/view-exists.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/view.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/where-relation.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1718.php');
 
         if (version_compare(LARAVEL_VERSION, '10.15.0', '>=')) {
             yield from self::gatherAssertTypes(__DIR__ . '/data/model-l10-15.php');

--- a/tests/Type/data/bug-1718.php
+++ b/tests/Type/data/bug-1718.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bug1718;
+
+use Illuminate\Http\Request;
+use App\User;
+use function PHPStan\Testing\assertType;
+
+class NewRequest extends Request
+{
+    public function authorize(): bool
+    {
+        return parent::user() instanceof User;
+    }
+
+    public function user($guard = null): User
+    {
+        $user = parent::user($guard);
+        if (!$user instanceof User) {
+            abort(403);
+        }
+
+        return $user;
+    }
+}
+
+function test(NewRequest $newRequest, Request $request): void
+{
+    assertType('App\User', $newRequest->user());
+    assertType('App\Admin|App\User|null', $request->user());
+}


### PR DESCRIPTION
- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Resolves #1718 

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Change RequestUserExtension to use the specific type of an overridden Request::user() method
