### PR TITLE
fix: child builders with non generic parents

### DIFF
--- a/tests/Integration/data/eloquent-builder-l10.php
+++ b/tests/Integration/data/eloquent-builder-l10.php
@@ -4,6 +4,7 @@ namespace EloquentBuilderLaravel10;
 
 use App\Post;
 use App\User;
+use App\Team;
 use Illuminate\Support\Facades\DB;
 
 User::query()->where(DB::raw('1'), 1)->get();
@@ -13,3 +14,6 @@ User::query()->orderBy(Post::query()->select('id')->whereColumn('user_id', 'user
 User::query()->orderByDesc(Post::query()->select('id')->whereColumn('user_id', 'users.id'));
 
 User::query()->get()->pluck('computed');
+
+/** @see https://github.com/larastan/larastan/issues/1952 */
+Team::query()->where('name', 'Team A')->orderBy('name')->get();

--- a/tests/Type/data/custom-eloquent-builder.php
+++ b/tests/Type/data/custom-eloquent-builder.php
@@ -49,6 +49,10 @@ function doFoo(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
     assertType('Illuminate\Database\Eloquent\Collection<int, CustomEloquentBuilder\ModelWithCustomBuilderAndDocBlocks>', ModelWithCustomBuilderAndDocBlocks::all());
     assertType('CustomEloquentBuilder\CustomBuilder2<CustomEloquentBuilder\ModelWithCustomBuilderAndDocBlocks>', ModelWithCustomBuilderAndDocBlocks::query());
     assertType('CustomEloquentBuilder\NonGenericBuilder', $nonGenericBuilder->skip(5));
+
+    assertType('CustomEloquentBuilder\ModelWithNonGenericBuilder|null', ModelWithNonGenericBuilder::where('email', 'bar')->first());
+    assertType('CustomEloquentBuilder\ChildNonGenericBuilder', ModelWithNonGenericBuilder::where('email', 'bar')->orderBy('email'));
+    assertType('Illuminate\Database\Eloquent\Collection<int, CustomEloquentBuilder\ModelWithNonGenericBuilder>', ModelWithNonGenericBuilder::get());
 }
 
 /**
@@ -166,11 +170,11 @@ class ModelWithNonGenericBuilder extends Model
 {
     /**
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return NonGenericBuilder
+     * @return ChildNonGenericBuilder
      */
-    public function newEloquentBuilder($query): NonGenericBuilder
+    public function newEloquentBuilder($query): ChildNonGenericBuilder
     {
-        return new NonGenericBuilder($query);
+        return new ChildNonGenericBuilder($query);
     }
 }
 
@@ -178,5 +182,9 @@ class ModelWithNonGenericBuilder extends Model
  * @extends Builder<ModelWithNonGenericBuilder>
  */
 class NonGenericBuilder extends Builder
+{
+}
+
+class ChildNonGenericBuilder extends NonGenericBuilder
 {
 }

--- a/tests/application/app/ChildTeamBuilder.php
+++ b/tests/application/app/ChildTeamBuilder.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App;
+
+class ChildTeamBuilder extends TeamBuilder
+{
+}

--- a/tests/application/app/Team.php
+++ b/tests/application/app/Team.php
@@ -12,4 +12,21 @@ class Team extends Model
      * @var string
      */
     protected $keyType = 'string';
+
+    /**
+     * @return ChildTeamBuilder
+     */
+    public static function query(): ChildTeamBuilder
+    {
+        return parent::query();
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return ChildTeamBuilder
+     */
+    public function newEloquentBuilder($query): ChildTeamBuilder
+    {
+        return new ChildTeamBuilder($query);
+    }
 }

--- a/tests/application/app/TeamBuilder.php
+++ b/tests/application/app/TeamBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/** @extends Builder<Team> */
+class TeamBuilder extends Builder
+{
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Closes #1952 

Hello!

This PR updates the `EloquentBuilderForwardsCallsExtension` to continue iterating up the builder parents to find the active model template instead of just checking the immediate parent.

Thanks!

**Breaking changes**

N/A