### PR TITLE
Add support for `whereNot` and `orWhereNot`

### DIFF
--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -5,8 +5,8 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
- * @property-read static $orWhereNot
  * @property-read static $whereNot
+ * @property-read static $orWhereNot
  */
 class Builder
 {

--- a/stubs/10.0.0/EloquentBuilder.stub
+++ b/stubs/10.0.0/EloquentBuilder.stub
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
+ * @property-read static $orWhereNot
+ * @property-read static $whereNot
  */
 class Builder
 {

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
+ * @property-read static $orWhereNot
  * @property-read static $whereNot
  */
 class Builder

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -5,8 +5,8 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
- * @property-read static $orWhereNot
  * @property-read static $whereNot
+ * @property-read static $orWhereNot
  */
 class Builder
 {

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 /**
  * @template TModelClass of Model
  * @property-read static $orWhere
+ * @property-read static $whereNot
  */
 class Builder
 {

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -103,6 +103,8 @@ function test(
 
     assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid());
     assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid()->orWhere->valid());
+    assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid()->orWhereNot->valid());
+    assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid()->whereNot->valid());
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::with(['accounts' => function ($relation) {
         return $relation->where('active', true);
     }]));


### PR DESCRIPTION
✅ Added or updated tests
✅ Documented user facing changes

**Changes**

This PR adds support for all HigherOrderBuilder proxies. Currently Larastan only supports `orWhere` but there are two more: https://github.com/laravel/framework/blob/e2d55af66635941d931b8e89af17553625c9699d/src/Illuminate/Database/Eloquent/Builder.php#L26-L28

The change was fairly simple, I followed the previous addition of `orWhere` from 2021: https://github.com/larastan/larastan/pull/884

**Breaking changes**

No breaking changes as far as I know
