### PR TITLE
fix: add default migration arguments

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -273,9 +273,14 @@ final class SchemaAggregator
                 $defaultsMap = [
                     'softDeletes' => 'deleted_at',
                     'softDeletesTz' => 'deleted_at',
+                    'softDeletesDatetime' => 'deleted_at',
                     'dropSoftDeletes' => 'deleted_at',
                     'dropSoftDeletesTz' => 'deleted_at',
                     'uuid' => 'uuid',
+                    'id' => 'id',
+                    'ulid' => 'ulid',
+                    'ipAddress' => 'ip_address',
+                    'macAddress' => 'mac_address',
                 ];
                 if (! array_key_exists($firstMethodCall->name->name, $defaultsMap)) {
                     continue;
@@ -487,6 +492,7 @@ final class SchemaAggregator
 
             case 'biginteger':
             case 'increments':
+            case 'id':
             case 'integer':
             case 'integerincrements':
             case 'mediumincrements':
@@ -522,6 +528,7 @@ final class SchemaAggregator
             case 'text':
             case 'time':
             case 'timestamp':
+            case 'ulid':
             case 'uuid':
             case 'binary':
                 $table->setColumn(new SchemaColumn($columnName, 'string', $nullable));

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -156,6 +156,29 @@ class MigrationHelperTest extends PHPStanTestCase
     }
 
     /** @test */
+    public function it_can_handle_migrations_with_default_arguments(): void
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_default_arguments'], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(11, $tables['users']->columns);
+        self::assertSame('int', $tables['users']->columns['id']->readableType);
+        self::assertSame('string', $tables['users']->columns['ip_address']->readableType);
+        self::assertSame('string', $tables['users']->columns['custom_ip_address']->readableType);
+        self::assertSame('string', $tables['users']->columns['mac_address']->readableType);
+        self::assertSame('string', $tables['users']->columns['custom_mac_address']->readableType);
+        self::assertSame('string', $tables['users']->columns['uuid']->readableType);
+        self::assertSame('string', $tables['users']->columns['custom_uuid']->readableType);
+        self::assertSame('string', $tables['users']->columns['ulid']->readableType);
+        self::assertSame('string', $tables['users']->columns['custom_ulid']->readableType);
+        self::assertSame('string', $tables['users']->columns['deleted_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['custom_soft_deletes']->readableType);
+    }
+
+    /** @test */
     public function it_can_handle_connection_before_schema_create(): void
     {
         $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_schema_connection'], $this->fileHelper, false, $this->reflectionProvider);

--- a/tests/Unit/data/migration_with_default_arguments/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migration_with_default_arguments/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationWithSchemaConnection;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->id();
+            $table->ipAddress();
+            $table->ipAddress('custom_ip_address');
+            $table->macAddress();
+            $table->macAddress('custom_mac_address');
+            $table->uuid();
+            $table->uuid('custom_uuid');
+            $table->ulid();
+            $table->ulid('custom_ulid');
+            $table->softDeletes();
+            $table->softDeletes('custom_soft_deletes');
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests

Hello!

This PR adds support for some of the methods that have default column names.

Closes #1975 

Thanks!