### PR TITLE
Prevent error Argument #2 ($array) must be of type array

### DIFF
--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -128,13 +128,15 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                 $refProperty = $macroClassReflection->getNativeReflection()->getProperty($macroTraitProperty);
                 $refProperty->setAccessible(true);
 
-                $found = array_key_exists($methodName, $refProperty->getValue());
+                $refPropertyValue = (array) $refProperty->getValue();
+
+                $found = array_key_exists($methodName, $refPropertyValue);
 
                 if (! $found) {
                     continue;
                 }
 
-                $macroDefinition = $refProperty->getValue()[$methodName];
+                $macroDefinition = $refPropertyValue[$methodName];
 
                 if (is_string($macroDefinition)) {
                     if (str_contains($macroDefinition, '::')) {


### PR DESCRIPTION
This PR will fix the following error when checking model macros:

`Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in ~/vendor/larastan/larastan/src/Methods/MacroMethodsClassReflectionExtension.php:135
`