### PR TITLE
fix: Allow custom Laravel bootstrap file path

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,7 +12,7 @@ if (! defined('LARAVEL_START')) {
     define('LARAVEL_START', microtime(true));
 }
 
-if (false !== $applicationPath = $_ENV['LARAVEL_BOOTSTRAP_FILE_PATH'] ?? $_SERVER['LARAVEL_BOOTSTRAP_FILE_PATH'] ?? false) { // Custom path in environment
+if (false !== $applicationPath = getenv('LARAVEL_BOOTSTRAP_FILE_PATH')) { // Custom path in environment
     if (file_exists($applicationPath)) {
         $app = require $applicationPath;
     }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,7 +12,11 @@ if (! defined('LARAVEL_START')) {
     define('LARAVEL_START', microtime(true));
 }
 
-if (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applications and Local Dev
+if (false !== $applicationPath = $_ENV['LARAVEL_BOOTSTRAP_FILE_PATH'] ?? $_SERVER['LARAVEL_BOOTSTRAP_FILE_PATH'] ?? false) { // Custom path in environment
+    if (file_exists($applicationPath)) {
+        $app = require $applicationPath;
+    }
+} elseif (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applications and Local Dev
     $app = require $applicationPath;
 } elseif (file_exists($applicationPath = dirname(__DIR__, 3).'/bootstrap/app.php')) { // Relative path from default vendor dir
     $app = require $applicationPath;


### PR DESCRIPTION
### Changes

There where previous attempts (https://github.com/larastan/larastan/pull/851, https://github.com/larastan/larastan/pull/852, https://github.com/larastan/larastan/pull/857) to make the detection of the Laravel bootstrap file better. However, after reviewing the code and discussions it appears to me that the follow up PR never landed. 

That said, there is no ultimate way to guess where people have their bootstrap file located. For that very reason this PR introduces a similar approach as Laravel uses [here ](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Application.php#L595) for the storage path.

**Added value:**

This PR allows to either define the path statically in your environment

```bash
# ~/.bashrc or ~/.zshrc
export LARAVEL_BOOTSTRAP_FILE_PATH=Framework/bootstrap/app.php
```
or to prepend it to the command.

```console
export LARAVEL_BOOTSTRAP_FILE_PATH=Framework/bootstrap/app.php; ./vendor/bin/phpstan analyse
```

### Breaking changes

I chosed a currently unused var name. No B/C implications, imho.

### Notes
- Not sure where to document this. Keen to add a paragraph where ever you'd like to have it.
