### PR TITLE
Add typehint to `env` when specifying default value

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -197,6 +197,6 @@ function blank($value) {}
  *
  * @param  string  $key
  * @param  TDefault  $default
- * @return ($default is null ? mixed : TDefault)
+ * @return bool|string|TDefault
  */
 function env($key, $default = null) {}

--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -189,3 +189,14 @@ function filled($value) {}
  * @return bool
  */
 function blank($value) {}
+
+/**
+ * Gets the value of an environment variable.
+ *
+ * @template TDefault
+ *
+ * @param  string  $key
+ * @param  TDefault  $default
+ * @return ($default is null ? mixed : TDefault)
+ */
+function env($key, $default = null) {}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -168,7 +168,8 @@ function test(?int $value = 0): void
         assertType('int', $value);
     }
 
-    assertType('int', env('SESSION_LIFETIME', 120));
-    assertType('string', env('APP_NAME', 'Laravel'));
-    assertType('mixed', env('APP_NAME'));
+    assertType('bool|string|null', env('foo'));
+    assertType('bool|string|null', env('foo', null));
+    assertType('bool|int|string', env('foo', 120));
+    assertType('bool|string', env('foo', ''));
 }

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -167,4 +167,8 @@ function test(?int $value = 0): void
     } else {
         assertType('int', $value);
     }
+
+    assertType('int', env('SESSION_LIFETIME', 120));
+    assertType('string', env('APP_NAME', 'Laravel'));
+    assertType('mixed', env('APP_NAME'));
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

This PR adds a generic value to the `env()` helper when a second parameter is specified with a default value. When this value is non-null, it will be used as the `env()` return type.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

I am not sure this is a breaking change, please advise.
