### PR TITLE
fix: handle model property aliases

### DIFF
--- a/src/Types/ModelProperty/GenericModelPropertyType.php
+++ b/src/Types/ModelProperty/GenericModelPropertyType.php
@@ -68,6 +68,10 @@ class GenericModelPropertyType extends StringType
                 return AcceptsResult::createNo();
             }
 
+            if (str_contains($givenString, ' as ')) {
+                $givenString = explode(' as ', $givenString)[0];
+            }
+
             if (str_contains($givenString, '.')) {
                 $parts = explode('.', $givenString);
 

--- a/tests/Integration/data/model-property-model.php
+++ b/tests/Integration/data/model-property-model.php
@@ -105,3 +105,8 @@ function acceptsUserOrAccountProperty(string $accountModelProperty): void
 
 acceptsUserOrAccountProperty('id'); // id exists in both models
 acceptsUserOrAccountProperty('email'); // email exists only in User
+
+function testModelPropertyAlias(): void
+{
+    \App\User::find(1, ['id as user_id', 'users.name as user_name']);
+}


### PR DESCRIPTION
When a model property is aliased, the alias should be removed before

- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Hello!

This closes #1998 

Thanks!