### PR TITLE
[3.x] feat: add support for config array shapes

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -175,6 +175,11 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: Larastan\Larastan\ReturnTypes\ConfigDynamicStaticMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
         class: Larastan\Larastan\ReturnTypes\AuthExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
@@ -254,6 +259,11 @@ services:
 
     -
         class: Larastan\Larastan\ReturnTypes\Helpers\CollectExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+
+    -
+        class: Larastan\Larastan\ReturnTypes\Helpers\ConfigDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
@@ -554,6 +564,9 @@ services:
 
     -
         class: Larastan\Larastan\Support\HigherOrderCollectionProxyHelper
+
+    -
+        class: Larastan\Larastan\Support\ConfigHelper
 
 rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule

--- a/src/ReturnTypes/ConfigDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ConfigDynamicStaticMethodReturnTypeExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Support\Facades\Config;
+use Larastan\Larastan\Support\ConfigHelper;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+use function in_array;
+
+/** @internal */
+final class ConfigDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function __construct(private ConfigHelper $configHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return Config::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['get', 'getMany', 'array', 'all'], true);
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        return $this->configHelper->determineConfigType($methodReflection, $methodCall, $scope);
+    }
+}

--- a/src/ReturnTypes/Helpers/ConfigDynamicFunctionReturnTypeExtension.php
+++ b/src/ReturnTypes/Helpers/ConfigDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes\Helpers;
+
+use Larastan\Larastan\Support\ConfigHelper;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class ConfigDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function __construct(private ConfigHelper $configHelper)
+    {
+    }
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'config';
+    }
+
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope,
+    ): Type|null {
+        return $this->configHelper->determineConfigType($functionReflection, $functionCall, $scope);
+    }
+}

--- a/src/Support/ConfigHelper.php
+++ b/src/Support/ConfigHelper.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Support;
+
+use Larastan\Larastan\Concerns\HasContainer;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use stdClass;
+
+use function array_map;
+use function count;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+
+final class ConfigHelper
+{
+    use HasContainer;
+
+    public function determineConfigType(
+        FunctionReflection|MethodReflection $reflection,
+        FuncCall|StaticCall $call,
+        Scope $scope,
+    ): Type|null {
+        $repository = $this->getContainer()->get('config');
+
+        if (! $repository) {
+            return null;
+        }
+
+        if ($reflection->getName() === 'all') {
+            return $this->getTypeFromValue($repository->all());
+        }
+
+        $args    = $call->getArgs();
+        $key     = $args[0]->value ?? null;
+        $default = $args[1]->value ?? null;
+
+        if (! $key) {
+            return null;
+        }
+
+        $keyType = $scope->getType($key);
+
+        if ($keyType->isArray()->yes()) {
+            // helper function called with array to set values
+            if ($reflection->getName() === 'config') {
+                return null;
+            }
+
+            $constantArrays = $keyType->getConstantArrays();
+
+            if (count($constantArrays) !== count($keyType->getArrays())) {
+                return null;
+            }
+
+            return TypeCombinator::union(...array_map(
+                function ($constantArray) use ($repository): Type {
+                    $array = $this->getArrayFromConstantArrayType($constantArray);
+
+                    if (! $array) {
+                        return new MixedType();
+                    }
+
+                    return $this->getTypeFromValue($repository->get($array));
+                },
+                $constantArrays,
+            ));
+        }
+
+        if (! $keyType->isString()->yes()) {
+            return null;
+        }
+
+        $constantStrings = $keyType->getConstantStrings();
+
+        if (! count($constantStrings)) {
+            return null;
+        }
+
+        $defaultType = $default ? $scope->getType($default) : new NullType();
+
+        // default might be a closure
+        if (count($defaultType->getConstantScalarValues()) !== 1) {
+            return null;
+        }
+
+        $configType = TypeCombinator::union(...array_map(
+            function ($key) use ($repository): Type {
+                $default = new stdClass();
+                $value   = $repository->get($key->getValue(), $default);
+
+                if ($value === $default) {
+                    return new MixedType();
+                }
+
+                return $this->getTypeFromValue($value);
+            },
+            $constantStrings,
+        ));
+
+        if ($reflection->getName() === 'array') {
+            return $configType;
+        }
+
+        return TypeCombinator::union($configType, $defaultType);
+    }
+
+    private function getTypeFromValue(mixed $value, bool $constant = false): Type
+    {
+        // Not using `$scope->getTypeFromValue()` as we don't
+        // want array values to be constant types given
+        // that the value can change for different envs.
+        return match (true) {
+            is_int($value) => $constant ? new ConstantIntegerType($value) : new IntegerType(),
+            is_float($value) => $constant ? new ConstantFloatType($value) : new FloatType(),
+            is_bool($value) => $constant ? new ConstantBooleanType($value) : new BooleanType(),
+            is_string($value) => $constant ? new ConstantStringType($value) : new StringType(),
+            is_array($value) => (function () use ($value) {
+                $arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+
+                if (count($value) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+                    $arrayBuilder->degradeToGeneralArray(true);
+                }
+
+                foreach ($value as $k => $v) {
+                    $arrayBuilder->setOffsetValueType(
+                        $this->getTypeFromValue($k, constant: true),
+                        $this->getTypeFromValue($v),
+                    );
+                }
+
+                return $arrayBuilder->getArray();
+            })(),
+            is_object($value) => new ObjectType($value::class),
+            default => new MixedType(),
+        };
+    }
+
+    /** @return array<int|string, mixed>|null */
+    private function getArrayFromConstantArrayType(ConstantArrayType $type): array|null
+    {
+        $keys   = $type->getKeyTypes();
+        $values = $type->getValueTypes();
+
+        $array = [];
+
+        foreach ($keys as $index => $key) {
+            $valueType = $values[$index];
+
+            $arrays  = $valueType->getConstantArrays();
+            $scalars = $valueType->getConstantScalarValues();
+
+            if (count($arrays)) {
+                $value = $this->getArrayFromConstantArrayType($arrays[0]);
+            } elseif (count($scalars)) {
+                $value = $scalars[0];
+            } else {
+                return null;
+            }
+
+            $array[$key->getValue()] = $value;
+        }
+
+        return $array;
+    }
+}

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -4,6 +4,7 @@ namespace Helpers;
 
 use App\User;
 use Exception;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Larastan\Larastan\ApplicationResolver;
 use Throwable;
@@ -174,13 +175,30 @@ function test(?int $value = 0): void
     assertType('bool|string', env('foo', ''));
 
     assertType('true', literal(true));
-    assertType('int<0, 10>', literal(random_int(0,10)));
+    assertType('int<0, 10>', literal(random_int(0, 10)));
     assertType("object{bar: 'bar'}&stdClass", literal(bar: "bar"));
     assertType("object{foo: 22, bar: 'bar'}&stdClass", literal(foo: 22, bar: "bar"));
-    assertType("object{foo: int<0, 5>, bar: 'bar'}&stdClass", literal(foo: random_int(0,5), bar: "bar"));
-    assertType("object{}&stdClass", literal(new \stdClass));
+    assertType("object{foo: int<0, 5>, bar: 'bar'}&stdClass", literal(foo: random_int(0, 5), bar: "bar"));
+    assertType("object{}&stdClass", literal(new \stdClass()));
     assertType("object{}&stdClass", literal());
     assertType("object{0: 'bar', 1: 'foo'}&stdClass", literal('bar', 'foo'));
     assertType("object{0: 4, bar: 'foo'}&stdClass", literal(4, bar:'foo'));
     assertType("App\User", literal(new User()));
+
+    assertType('Illuminate\Config\Repository', config());
+    assertType('null', config(['auth.defaults' => 'bar']));
+    assertType('array{guard: string, passwords: string}|null', config('auth.defaults'));
+    assertType('array{guard: string, passwords: string}', Config::array('auth.defaults'));
+    assertType('string|null', config('auth.defaults.guard'));
+    assertType("'bar'|array{guard: string, passwords: string}", config('auth.defaults', 'bar'));
+    $var = 'auth.defaults';
+    assertType('array{guard: string, passwords: string}|null', config($var));
+    assertType('array{guard: string, passwords: string}|null', Config::get('auth.defaults'));
+    assertType('array{auth.defaults: array{guard: string, passwords: string}, auth.guards.web: array{driver: string, provider: string}}', Config::get(['auth.defaults', 'auth.guards.web']));
+    assertType('array{auth.defaults: array{guard: string, passwords: string}, auth.guards.web: array{driver: string, provider: string}}', Config::getMany(['auth.defaults' => 'baz', 'auth.guards.web' => 'foo']));
+    /** @var 'auth.defaults'|'auth.guards.web' $var */
+    assertType('array{driver: string, provider: string}|array{guard: string, passwords: string}|null', Config::get($var));
+    assertType('array{driver: string, provider: string}|array{guard: string, passwords: string}|null', config($var));
+    assertType('mixed', config('nonexistent'));
+    assertType('mixed', config('auth.null'));
 }

--- a/tests/application/config/auth.php
+++ b/tests/application/config/auth.php
@@ -48,4 +48,5 @@ return [
 
     'password_timeout' => 10800,
 
+    'null' => null,
 ];


### PR DESCRIPTION
- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Hello!

I got tired of having to do this number when accessing config values:

```php
            /** @var array{datacenter_id: int, worker_id: int, epoch: string} $config */
            $config = config('laraflake');
```

So I decided to add support for config array shapes (if they exist):

```php
    assertType('array{guard: string, passwords: string}|null', config('auth.defaults'));
```

Thanks! 

**Breaking changes**
None