### PR TITLE
fix eloquent generics documentation

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -45,7 +45,7 @@ In order for Larastan to recognize Model relationships:
 If the above conditions are not met, then adding the `@return` docblock can help
 
 ```php
-/** @return BelongsTo<User, $this> */
+/** @return BelongsTo<User, self> */
 public function user(): BelongsTo
 {
     return $this->belongsTo(User::class);


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The documentation mention, we should be using `BelongsTo<Model, $this>` but when I use it, I got this error (stripped own FQDN)

```
Method Absence::user() should return
Illuminate\Database\Eloquent\Relations\BelongsTo<User, $this(Absence)> but returns  
Illuminate\Database\Eloquent\Relations\BelongsTo<User, Absence>
```

After changing `$this` to `self` it works well.

**Breaking changes**

None
