### PR TITLE
fix: make TGet covariant on Attribute stub

### DIFF
--- a/stubs/common/Attribute.stub
+++ b/stubs/common/Attribute.stub
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent\Casts;
 
 /**
- * @template TGet
+ * @template-covariant TGet
  * @template TSet
  */
 class Attribute
@@ -11,14 +11,14 @@ class Attribute
     /**
      * The attribute accessor.
      *
-     * @var callable(): TGet
+     * @var (callable(mixed=, array<string, mixed>=): TGet)|null
      */
     public $get;
 
     /**
      * The attribute mutator.
      *
-     * @var callable(TSet): mixed
+     * @var (callable(TSet, array<string, mixed>=): mixed)|null
      */
     public $set;
 
@@ -27,17 +27,17 @@ class Attribute
      *
      * @template TMakeGet
      * @template TMakeSet
-     * @param  (callable(mixed, mixed): TMakeGet)|null  $get
-     * @param  (callable(TMakeSet, mixed=): mixed)|null  $set
+     * @param  (callable(mixed=, array<string, mixed>=): TMakeGet)|null  $get
+     * @param  (callable(TMakeSet, array<string, mixed>=): mixed)|null  $set
      * @return Attribute<TMakeGet, TMakeSet>
      */
-    public static function make(callable $get = null, callable $set = null);
+    public static function make(?callable $get = null, ?callable $set = null);
 
     /**
      * Create a new attribute accessor.
      *
      * @template T
-     * @param  callable(mixed, mixed=): T  $get
+     * @param  callable(mixed=, array<string, mixed>=): T  $get
      * @return Attribute<T, never>
      */
     public static function get(callable $get);
@@ -46,7 +46,7 @@ class Attribute
      * Create a new attribute mutator.
      *
      * @template T
-     * @param  callable(T, mixed=): mixed $set
+     * @param  callable(T, array<string, mixed>=): mixed $set
      * @return Attribute<never, T>
      */
     public static function set(callable $set);


### PR DESCRIPTION
- [x] Added or updated tests

**Changes**
Hello!

I'm using the PHPStan [bleeding edge](https://phpstan.org/config-reference#bleeding-edge) config, and I started getting the following errors with the Model Attributes:

```php
    /** @return Attribute<string|null, never> */
    protected function surveyedName(): Attribute
    {
        return Attribute::get(function (): ?string {
            if (! $this->surveyable_type) {
                return null;
            }

            return Str::of($this->surveyable_type)
                ->replace('.', ' ')
                ->title()
                ->toString();
        });
    }
```

```
  148    Method <class>::surveyedName() should return Illuminate\Database\Eloquent\Casts\Attribute<string|null, never> but returns                        
         Illuminate\Database\Eloquent\Casts\Attribute<string|null, never>.                                                                                                    
         🪪  return.type                                                                                                                                                      
         💡 Template type TGet on class Illuminate\Database\Eloquent\Casts\Attribute is not covariant. Learn more: https://phpstan.org/blog/whats-up-with-template-covariant  
```

This PR updates the `TGet` template to be covariant and fixes some other issues with the stub.


Thanks!

**Breaking changes**
None
