### PR TITLE
fix: wrong trigger RelationExistenceRule with return union type in relation method

### DIFF
--- a/tests/Rules/data/relation-existence-rule.php
+++ b/tests/Rules/data/relation-existence-rule.php
@@ -62,3 +62,23 @@ declare(strict_types=1);
 \App\User::first()->group()->whereRelation('foo', 'id');
 \App\User::query()->whereRelation('accounts.foo', 'id');
 \App\Post::query()->whereRelation('users.transactions.foo', 'id');
+
+\App\User::query()->has('unionTypeRelation');
+\App\User::query()->orHas('unionTypeRelation');
+\App\User::query()->doesntHave('unionTypeRelation');
+\App\User::query()->orDoesntHave('unionTypeRelation');
+\App\User::query()->whereHas('unionTypeRelation');
+\App\User::query()->withWhereHas('unionTypeRelation');
+\App\User::query()->orWhereHas('unionTypeRelation');
+\App\User::query()->whereDoesntHave('unionTypeRelation');
+\App\User::query()->orWhereDoesntHave('unionTypeRelation');
+
+\App\User::first()->group()->has('unionTypeRelation');
+\App\User::first()->group()->orHas('unionTypeRelation');
+\App\User::first()->group()->doesntHave('unionTypeRelation');
+\App\User::first()->group()->orDoesntHave('unionTypeRelation');
+\App\User::first()->group()->whereHas('unionTypeRelation');
+\App\User::first()->group()->withWhereHas('unionTypeRelation');
+\App\User::first()->group()->orWhereHas('unionTypeRelation');
+\App\User::first()->group()->whereDoesntHave('unionTypeRelation');
+\App\User::first()->group()->orWhereDoesntHave('unionTypeRelation');

--- a/tests/application/app/Group.php
+++ b/tests/application/app/Group.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Traits\NestedSoftDeletes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -23,5 +24,10 @@ class Group extends Model
     public function users(): HasMany
     {
         return $this->hasMany(User::class);
+    }
+
+    public function unionTypeRelation(): BelongsTo|Post
+    {
+        return $this->belongsTo(Post::class);
     }
 }

--- a/tests/application/app/User.php
+++ b/tests/application/app/User.php
@@ -248,4 +248,9 @@ class User extends Authenticatable
             fn ($value) => 5,
         );
     }
+
+    public function unionTypeRelation(): BelongsTo|Post
+    {
+        return $this->belongsTo(Post::class);
+    }
 }


### PR DESCRIPTION
Sometimes i need declare union type for my relation methods, for better autocomplete in IDE. For example:
model User has method/relation `deals`, and i declare next method:

```php
public function deals(): HasMany|Deal
{
   return $this->hasMany(Deal::class);
}
```

So now i can use next code, and have autocomplete for Deal model scopes:

```php
$userDeals = $user->deals()->dealScope()->get();
```

- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

When relation return union type, RelationExistenceRule can understand now this, and not trigger error.
