### PR TITLE
Add support for model attributes property

### DIFF
--- a/stubs/common/Model.stub
+++ b/stubs/common/Model.stub
@@ -8,6 +8,11 @@ namespace Illuminate\Database\Eloquent;
 abstract class Model implements \JsonSerializable, \ArrayAccess
 {
     /**
+     * @var array<string, mixed>
+     */
+    protected $attributes = [];
+
+    /**
      * @var array<string, string>
      */
     protected $casts = [];


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The `$attributes` array is used to configure the default model attribute values. This PR adds its type as doc block annotation to the `Model.stub` file.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
