### PR TITLE
fix: incorrect phpdocs and stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.0",
         "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.0",
         "phpmyadmin/sql-parser": "^5.9.0",
-        "phpstan/phpstan": "^1.11.2"
+        "phpstan/phpstan": "^1.12.2"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",

--- a/e2e/filamentphp-filament.baseline.neon
+++ b/e2e/filamentphp-filament.baseline.neon
@@ -11,6 +11,46 @@ parameters:
 			path: ../../e2e/packages/actions/src/Commands/MakeImporterCommand.php
 
 		-
+			message: "#^Parameter \\#1 \\$related of method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\) expects class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, string given\\.$#"
+			count: 1
+			path: ../../e2e/packages/actions/src/Exports/Models/Export.php
+
+		-
+			message: "#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\)$#"
+			count: 2
+			path: ../../e2e/packages/actions/src/Exports/Models/Export.php
+
+		-
+			message: "#^Parameter \\#1 \\$related of method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\) expects class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, string given\\.$#"
+			count: 1
+			path: ../../e2e/packages/actions/src/Imports/Models/Import.php
+
+		-
+			message: "#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\)$#"
+			count: 2
+			path: ../../e2e/packages/actions/src/Imports/Models/Import.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:\\$mountedActions\\.$#"
+			count: 2
+			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:\\$mountedActionsData\\.$#"
+			count: 6
+			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:getMountedAction\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: ../../e2e/packages/forms/src/Commands/MakeFormCommand.php
@@ -21,6 +61,51 @@ parameters:
 			path: ../../e2e/packages/forms/src/Components/FileUpload.php
 
 		-
+			message: "#^Access to an undefined property Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:\\$mountedFormComponentActions\\.$#"
+			count: 2
+			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:\\$mountedFormComponentActionsData\\.$#"
+			count: 6
+			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getCachedForms\\(\\)\\.$#"
+			count: 1
+			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getMountedFormComponentAction\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:\\$mountedInfolistActions\\.$#"
+			count: 2
+			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:\\$mountedInfolistActionsData\\.$#"
+			count: 6
+			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:getMountedInfolistAction\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: ../../e2e/packages/panels/src/Commands/MakeResourceCommand.php
@@ -29,3 +114,38 @@ parameters:
 			message: "#^Unable to resolve the template type TMapValue in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),string\\>\\:\\:map\\(\\)$#"
 			count: 1
 			path: ../../e2e/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableActions\\.$#"
+			count: 2
+			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableActionsData\\.$#"
+			count: 6
+			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
+
+		-
+			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableBulkAction\\.$#"
+			count: 1
+			path: ../../e2e/packages/tables/src/Testing/TestsBulkActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/tables/src/Testing/TestsBulkActions.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/tables/src/Testing/TestsColumns.php
+
+		-
+			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
+			count: 2
+			path: ../../e2e/packages/tables/src/Testing/TestsRecords.php

--- a/e2e/monicahq-monica.baseline.neon
+++ b/e2e/monicahq-monica.baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#2 \\$callback of method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\AddressBookSubscription\\>\\:\\:chunkById\\(\\) expects callable\\(Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, int\\)\\: mixed, Closure\\(Illuminate\\\\Database\\\\Eloquent\\\\Collection\\)\\: void given\\.$#"
+			count: 1
+			path: ../../e2e/app/Domains/Contact/DavClient/Jobs/UpdateAddressBooks.php
+
+		-
 			message: "#^Parameter \\#1 \\$value of method Illuminate\\\\Support\\\\Collection\\<int,array\\<string, int\\|string\\>\\>\\:\\:prepend\\(\\) expects array\\{id\\: int, name\\: string\\}, array\\{id\\: null, name\\: ''\\} given\\.$#"
 			count: 1
 			path: ../../e2e/app/Domains/Contact/ManageContactImportantDates/Web/ViewHelpers/ContactImportantDatesViewHelper.php

--- a/stubs/10.0.0/Contracts/Database/Eloquent.stub
+++ b/stubs/10.0.0/Contracts/Database/Eloquent.stub
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Contracts\Database\Query\Builder as BaseContract;
 
 /**
- * @mixin \Illuminate\Database\Eloquent\Builder
+ * @mixin \Illuminate\Database\Eloquent\Builder<*>
  */
 interface Builder extends BaseContract
 {}

--- a/stubs/common/Contracts/Queue.stub
+++ b/stubs/common/Contracts/Queue.stub
@@ -2,4 +2,10 @@
 
 namespace Illuminate\Contracts\Queue;
 
+interface Factory {}
+
+interface Monitor {}
+
 interface QueueableCollection {}
+
+interface Queue {}

--- a/stubs/common/Contracts/Redis.stub
+++ b/stubs/common/Contracts/Redis.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace Illuminate\Contracts\Redis;
+
+interface Factory {}

--- a/stubs/common/Database/Database.stub
+++ b/stubs/common/Database/Database.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Database;
+
+class Connection implements ConnectionInterface {}
+
+interface ConnectionInterface {}
+
+interface ConnectionResolverInterface {}
+
+/**
+ * @mixin \Illuminate\Database\Connection
+ */
+class DatabaseManager implements ConnectionResolverInterface {}
+

--- a/stubs/common/Log/Logger.stub
+++ b/stubs/common/Log/Logger.stub
@@ -4,8 +4,12 @@ namespace Psr\Log {
     interface LoggerInterface {}
 }
 
-namespace Illuminate\Log {
+namespace Monolog {
+    interface ResettableInterface {}
+    class Logger implements \Psr\Log\LoggerInterface, \Monolog\ResettableInterface {}
+}
 
+namespace Illuminate\Log {
     /**
      * @mixin \Illuminate\Log\LogManager
      * @mixin \Monolog\Logger

--- a/stubs/common/Pagination.stub
+++ b/stubs/common/Pagination.stub
@@ -5,7 +5,7 @@ namespace Illuminate\Pagination;
 /**
  * @template TValue
  *
- * @mixin \Illuminate\Support\Collection<mixed, TValue>
+ * @mixin \Illuminate\Support\Collection<array-key, TValue>
  */
 abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlable
 {
@@ -68,7 +68,7 @@ class LengthAwarePaginator extends AbstractPaginator implements \Illuminate\Cont
 /**
  * @template TValue
  *
- * @mixin \Illuminate\Support\Collection<mixed, TValue>
+ * @mixin \Illuminate\Support\Collection<array-key, TValue>
  */
 abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\Htmlable
 {

--- a/stubs/common/Queue/Queue.stub
+++ b/stubs/common/Queue/Queue.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Queue;
+
+abstract class Queue {}
+
+/**
+ * @mixin \Illuminate\Contracts\Queue\Queue
+ */
+class QueueManager implements \Illuminate\Contracts\Queue\Factory, \Illuminate\Contracts\Queue\Monitor {}

--- a/stubs/common/Redis/Connection.stub
+++ b/stubs/common/Redis/Connection.stub
@@ -1,9 +1,13 @@
 <?php
 
-namespace Illuminate\Redis\Connections;
+namespace Illuminate\Redis {
+    class RedisManager implements \Illuminate\Contracts\Redis\Factory {}
+}
 
-/**
- * @mixin \Redis
- */
-abstract class Connection
-{}
+namespace Illuminate\Redis\Connections {
+    /**
+     * @mixin \Redis
+     */
+    abstract class Connection {}
+}
+


### PR DESCRIPTION
Hello!

This fixes some incorrect phpdocs and stubs as a result of PHPStan 1.12.0 having stricter type checks.

This fixes what can be fixed in the failing nightly ci jobs, the other failures in the job will have to be fixed by PHPStan (see my https://github.com/phpstan/phpstan/issues/11591#issuecomment-2321280743).

Thanks!
