### PR TITLE
fix: check if class exists before calling reflectionProvider getClass

### DIFF
--- a/src/Methods/Passable.php
+++ b/src/Methods/Passable.php
@@ -56,6 +56,10 @@ final class Passable implements PassableContract
 
     public function searchOn(string $class): bool
     {
+        if (! $this->reflectionProvider->hasClass($class)) {
+            return false;
+        }
+
         $classReflection = $this->reflectionProvider->getClass($class);
 
         $found = $classReflection->hasNativeMethod($this->methodName);
@@ -93,6 +97,10 @@ final class Passable implements PassableContract
 
     public function sendToPipeline(string $class, bool $staticAllowed = false): bool
     {
+        if (! $this->reflectionProvider->hasClass($class)) {
+            return false;
+        }
+
         $classReflection = $this->reflectionProvider->getClass($class);
 
         $this->setStaticAllowed($this->staticAllowed ?: $staticAllowed);


### PR DESCRIPTION
Hello!

This closes #2035 by first checking if a class exists before calling `BetterReflectionProvider::getClass()`.

Thanks!