### PR TITLE
fix: relation class forwarding

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -66,7 +66,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
      */
     private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
     {
-        if ($classReflection->getName() !== EloquentBuilder::class && ! $classReflection->isSubclassOf(EloquentBuilder::class)) {
+        if (! $classReflection->is(EloquentBuilder::class)) {
             return null;
         }
 

--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -70,9 +70,8 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
             }
         } elseif (
             $this->hasIndirectTraitUse($classReflection, Macroable::class) ||
-            $classReflection->getName() === Builder::class ||
-            $classReflection->isSubclassOf(Builder::class) ||
-            $classReflection->getName() === QueryBuilder::class
+            $classReflection->is(Builder::class) ||
+            $classReflection->is(QueryBuilder::class)
         ) {
             $classNames         = [$classReflection->getName()];
             $macroTraitProperty = 'macros';

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -72,7 +72,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
      */
     private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
     {
-        if ($classReflection->getName() !== Model::class && ! $classReflection->isSubclassOf(Model::class)) {
+        if (! $classReflection->is(Model::class)) {
             return null;
         }
 

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -60,7 +60,7 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
      */
     private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
     {
-        if (! $classReflection->isSubclassOf(Relation::class)) {
+        if (! $classReflection->is(Relation::class)) {
             return null;
         }
 

--- a/src/Support/CollectionHelper.php
+++ b/src/Support/CollectionHelper.php
@@ -109,7 +109,7 @@ final class CollectionHelper
 
         $innerValueType = $classReflection->getActiveTemplateTypeMap()->getType('TModel');
 
-        if ($classReflection->getName() === EloquentCollection::class || $classReflection->isSubclassOf(EloquentCollection::class)) {
+        if ($classReflection->is(EloquentCollection::class)) {
             $keyType = new IntegerType();
         }
 

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -9,6 +9,7 @@ use App\Thread;
 use App\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Http\FormRequest;
 
 use function PHPStan\Testing\assertType;
@@ -120,6 +121,9 @@ function test(
     assertType('App\User|null', User::firstWhere(['email' => 'foo@bar.com']));
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->with('accounts'));
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->with('accounts')->with('group'));
+    assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->with(['accounts' => function (Relation $relation) {
+        assertType('Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model>', $relation->orderBy('id'));
+    }]));
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::lockForUpdate());
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::sharedLock());
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::query());


### PR DESCRIPTION
**Changes**

Hello!

This fixes builder method forwarding on the base `Relation` class and closes #2040.

I discovered that the `ClassReflection` class has a handy `is` method which cleans up some code.


Thanks!
