### PR TITLE
[3.x] feat: support dynamic relation closures

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -534,6 +534,19 @@ services:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
 
     -
+        class: Larastan\Larastan\Parameters\EloquentBuilderRelationParameterExtension
+        tags:
+            - phpstan.methodParameterClosureTypeExtension
+
+    -
+        class: Larastan\Larastan\Parameters\ModelRelationParameterExtension
+        tags:
+            - phpstan.staticMethodParameterClosureTypeExtension
+
+    -
+        class: Larastan\Larastan\Parameters\RelationClosureHelper
+
+    -
         class: Larastan\Larastan\ReturnTypes\AppMakeHelper
 
     -

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -16,10 +16,8 @@ use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\Php\DummyParameter;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
@@ -35,7 +33,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
     /** @var array<string, MethodReflection> */
     private array $cache = [];
 
-    public function __construct(private BuilderHelper $builderHelper, private ReflectionProvider $reflectionProvider, private EloquentBuilderForwardsCallsExtension $eloquentBuilderForwardsCallsExtension)
+    public function __construct(private BuilderHelper $builderHelper, private EloquentBuilderForwardsCallsExtension $eloquentBuilderForwardsCallsExtension)
     {
     }
 
@@ -80,8 +78,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
         if (in_array($methodName, ['increment', 'decrement'], true)) {
             $methodReflection = $classReflection->getNativeMethod($methodName);
 
-            return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection
-            {
+            return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection {
                 private ClassReflection $classReflection;
 
                 private string $methodName;
@@ -168,17 +165,21 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             };
         }
 
-        $builderReflection          = $this->reflectionProvider->getClass($builderName)->withTypes([new ObjectType($classReflection->getName())]);
-        $genericBuilderAndModelType = new GenericObjectType($builderName, [new ObjectType($classReflection->getName())]);
+        $builderType       = $this->builderHelper->getBuilderTypeForModels($classReflection->getName());
+        $builderReflection = $builderType->getClassReflection();
+
+        if ($builderReflection === null) {
+            return null;
+        }
 
         if ($builderReflection->hasNativeMethod($methodName)) {
             $reflection = $builderReflection->getNativeMethod($methodName);
 
-            $parametersAcceptor = $this->transformStaticParameters($reflection, $genericBuilderAndModelType);
+            $parametersAcceptor = $this->transformStaticParameters($reflection, $builderType);
 
-            $returnType = TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($genericBuilderAndModelType) {
+            $returnType = TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($builderType) {
                 if ($type instanceof TypeWithClassName && $type->getClassName() === Builder::class) {
-                    return $genericBuilderAndModelType;
+                    return $builderType;
                 }
 
                 return $traverse($type);
@@ -200,7 +201,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
         return null;
     }
 
-    private function transformStaticParameters(MethodReflection $method, GenericObjectType $builder): ParametersAcceptor
+    private function transformStaticParameters(MethodReflection $method, ObjectType $builder): ParametersAcceptor
     {
         $acceptor = $method->getVariants()[0];
 
@@ -218,7 +219,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
         }, $acceptor->getParameters()), $acceptor->isVariadic(), $this->transformStaticType($acceptor->getReturnType(), $builder));
     }
 
-    private function transformStaticType(Type $type, GenericObjectType $builder): Type
+    private function transformStaticType(Type $type, ObjectType $builder): Type
     {
         return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($builder): Type {
             if ($type instanceof StaticType) {

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 
@@ -80,8 +79,7 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             return null;
         }
 
-        $builderName = $this->builderHelper->determineBuilderName($modelReflection->getName());
-        $builderType = new GenericObjectType($builderName, [new ObjectType($modelReflection->getName())]);
+        $builderType = $this->builderHelper->getBuilderTypeForModels($modelReflection->getName());
 
         if (! $builderType->hasMethod($methodName)->yes()) {
             return null;

--- a/src/Parameters/ClosureQueryParameter.php
+++ b/src/Parameters/ClosureQueryParameter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Parameters;
+
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\Type;
+
+final class ClosureQueryParameter implements ParameterReflection
+{
+    public function __construct(
+        private string $name,
+        private Type $type,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    public function passedByReference(): PassedByReference
+    {
+        return PassedByReference::createNo();
+    }
+
+    public function isVariadic(): bool
+    {
+        return false;
+    }
+
+    public function getDefaultValue(): Type|null
+    {
+        return null;
+    }
+}

--- a/src/Parameters/EloquentBuilderRelationParameterExtension.php
+++ b/src/Parameters/EloquentBuilderRelationParameterExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Parameters;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\MethodParameterClosureTypeExtension;
+use PHPStan\Type\Type;
+
+final class EloquentBuilderRelationParameterExtension implements MethodParameterClosureTypeExtension
+{
+    public function __construct(private RelationClosureHelper $relationClosureHelper)
+    {
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+    {
+        return $this->relationClosureHelper->isMethodSupported($methodReflection, $parameter);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        ParameterReflection $parameter,
+        Scope $scope,
+    ): Type|null {
+        return $this->relationClosureHelper->getTypeFromMethodCall($methodReflection, $methodCall, $parameter, $scope);
+    }
+}

--- a/src/Parameters/ModelRelationParameterExtension.php
+++ b/src/Parameters/ModelRelationParameterExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Parameters;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\StaticMethodParameterClosureTypeExtension;
+use PHPStan\Type\Type;
+
+final class ModelRelationParameterExtension implements StaticMethodParameterClosureTypeExtension
+{
+    public function __construct(private RelationClosureHelper $relationClosureHelper)
+    {
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+    {
+        return $this->relationClosureHelper->isMethodSupported($methodReflection, $parameter);
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        ParameterReflection $parameter,
+        Scope $scope,
+    ): Type|null {
+        return $this->relationClosureHelper->getTypeFromMethodCall($methodReflection, $methodCall, $parameter, $scope);
+    }
+}

--- a/src/Parameters/RelationClosureHelper.php
+++ b/src/Parameters/RelationClosureHelper.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Parameters;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Larastan\Larastan\Methods\BuilderHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\VariadicPlaceholder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+use function array_push;
+use function array_shift;
+use function collect;
+use function count;
+use function explode;
+use function in_array;
+
+final class RelationClosureHelper
+{
+    /** @var list<string> */
+    private array $methods = [
+        'has',
+        'doesntHave',
+        'whereHas',
+        'withWhereHas',
+        'orWhereHas',
+        'whereDoesntHave',
+        'orWhereDoesntHave',
+        'whereRelation',
+        'orWhereRelation',
+    ];
+
+    /** @var list<string> */
+    private array $morphMethods = [
+        'hasMorph',
+        'doesntHaveMorph',
+        'whereHasMorph',
+        'orWhereHasMorph',
+        'whereDoesntHaveMorph',
+        'orWhereDoesntHaveMorph',
+        'whereMorphRelation',
+        'orWhereMorphRelation',
+    ];
+
+    public function __construct(
+        private BuilderHelper $builderHelper,
+    ) {
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+    {
+        if (! $methodReflection->getDeclaringClass()->is(EloquentBuilder::class)) {
+            return false;
+        }
+
+        return in_array($methodReflection->getName(), [...$this->methods, ...$this->morphMethods], strict: true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall|StaticCall $methodCall,
+        ParameterReflection $parameter,
+        Scope $scope,
+    ): Type|null {
+        $method        = $methodReflection->getName();
+        $isMorphMethod = in_array($method, $this->morphMethods, strict: true);
+        $models        = [];
+        $relations     = [];
+
+        if ($isMorphMethod) {
+            $models = $this->getMorphModels($methodCall, $scope);
+        } else {
+            $relations = $this->getRelationsFromMethodCall($methodCall, $scope);
+            $models    = $this->getModelsFromRelations($relations);
+        }
+
+        if (count($models) === 0) {
+            return null;
+        }
+
+        $type = $this->builderHelper->getBuilderTypeForModels($models);
+
+        if ($method === 'withWhereHas') {
+            $type = TypeCombinator::union($type, ...$relations);
+        }
+
+        return new ClosureType([
+            new ClosureQueryParameter('query', $type),
+            new ClosureQueryParameter('type', $isMorphMethod ? new NeverType() : new StringType()),
+        ], new MixedType());
+    }
+
+    /** @return array<int, string> */
+    private function getMorphModels(MethodCall|StaticCall $methodCall, Scope $scope): array
+    {
+        $models = null;
+
+        foreach ($methodCall->args as $i => $arg) {
+            if ($arg instanceof VariadicPlaceholder) {
+                continue;
+            }
+
+            if (($i === 1 && $arg->name === null) || $arg->name?->toString() === 'types') {
+                $models = $scope->getType($arg->value);
+                break;
+            }
+        }
+
+        if ($models === null) {
+            return [];
+        }
+
+        return collect($models->getConstantArrays())
+            ->flatMap(static fn (ConstantArrayType $t) => $t->getValueTypes())
+            ->flatMap(static fn (Type $t) => $t->getConstantStrings())
+            ->merge($models->getConstantStrings())
+            ->map(static fn (ConstantStringType $t) => $t->getValue())
+            ->map(static fn (string $v) => $v === '*' ? Model::class : $v)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param array<int, Type> $relations
+     *
+     * @return array<int, string>
+     */
+    private function getModelsFromRelations(array $relations): array
+    {
+        return collect($relations)
+            ->flatMap(
+                static fn (Type $relation) => $relation
+                    ->getTemplateType(Relation::class, 'TRelatedModel')
+                    ->getObjectClassNames(),
+            )
+            ->values()
+            ->all();
+    }
+
+    /** @return array<int, Type> */
+    public function getRelationsFromMethodCall(MethodCall|StaticCall $methodCall, Scope $scope): array
+    {
+        $relationType = null;
+
+        foreach ($methodCall->args as $arg) {
+            if ($arg instanceof VariadicPlaceholder) {
+                continue;
+            }
+
+            if ($arg->name === null || $arg->name->toString() === 'relation') {
+                $relationType = $scope->getType($arg->value);
+                break;
+            }
+        }
+
+        if ($relationType === null) {
+            return [];
+        }
+
+        if ($methodCall instanceof MethodCall) {
+            $calledOnModels = $scope->getType($methodCall->var)
+                ->getTemplateType(EloquentBuilder::class, 'TModel')
+                ->getObjectClassNames();
+        } else {
+            $calledOnModels = $methodCall->class instanceof Name
+                ? [$scope->resolveName($methodCall->class)]
+                : $scope->getType($methodCall->class)->getReferencedClasses();
+        }
+
+        return collect($relationType->getConstantStrings())
+            ->map(static fn ($type) => $type->getValue())
+            ->flatMap(fn ($relation) => $this->getRelationTypeFromString($calledOnModels, explode('.', $relation), $scope))
+            ->merge([$relationType])
+            ->filter(static fn ($r) => (new ObjectType(Relation::class))->isSuperTypeOf($r)->yes())
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param list<string> $calledOnModels
+     * @param list<string> $relationParts
+     *
+     * @return list<Type>
+     */
+    public function getRelationTypeFromString(
+        array $calledOnModels,
+        array $relationParts,
+        Scope $scope,
+    ): array {
+        $relations = [];
+
+        while ($relationName = array_shift($relationParts)) {
+            $relations     = [];
+            $relatedModels = [];
+
+            foreach ($calledOnModels as $model) {
+                $modelType = new ObjectType($model);
+
+                if (! $modelType->hasMethod($relationName)->yes()) {
+                    continue;
+                }
+
+                $relationType = $modelType->getMethod($relationName, $scope)->getVariants()[0]->getReturnType();
+
+                if (! (new ObjectType(Relation::class))->isSuperTypeOf($relationType)->yes()) {
+                    continue;
+                }
+
+                $relations[] = $relationType;
+
+                array_push($relatedModels, ...$relationType->getTemplateType(Relation::class, 'TRelatedModel')->getObjectClassNames());
+            }
+
+            $calledOnModels = $relatedModels;
+        }
+
+        return $relations;
+    }
+}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -44,6 +44,7 @@ class IntegrationTest extends PHPStanTestCase
                 35 => ['Parameter #1 $columns of method Illuminate\Database\Eloquent\Builder<App\User>::first() expects array<int, model property of App\User>|model property of App\User, array<int, string> given.'],
                 36 => ['Parameter #1 $columns of method Illuminate\Database\Eloquent\Builder<App\User>::first() expects array<int, model property of App\User>|model property of App\User, string given.'],
                 39 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'roles.foo\' given.'],
+                43 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\Account>::where() expects array<int|model property of App\Account, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\Account>): Illuminate\Database\Eloquent\Builder<App\Account>)|(Closure(Illuminate\Database\Eloquent\Builder<App\Account>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\Account, \'foo\' given.'],
             ],
         ];
 

--- a/tests/Integration/data/model-property-builder.php
+++ b/tests/Integration/data/model-property-builder.php
@@ -39,12 +39,9 @@ function test(Builder $builder, User $user, string $union): void
     User::query()->join('roles', 'users.role_id', '=', 'roles.id')->where('roles.foo', 'admin');
 }
 
-//// Currently, there is no way to change the type of `$query` inside the callback.
-//// So until we have a way to do that, we will ignore errors for `Builder<Model>`
-//// @see https://github.com/phpstan/phpstan/discussions/6850
-//\App\User::query()->whereHas('accounts', function (\Illuminate\Database\Eloquent\Builder $query) {
-//    $query->where('foo', 'bar');
-//});
+User::query()->whereHas('accounts', function (Builder $query) {
+   $query->where('foo', 'bar');
+});
 
 function getKey(): string
 {

--- a/tests/Type/data/custom-eloquent-builder.php
+++ b/tests/Type/data/custom-eloquent-builder.php
@@ -63,7 +63,7 @@ function test(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
 class ModelWithCustomBuilder extends Model
 {
     // Dummy relation
-    /** @return HasMany<User> */
+    /** @return HasMany<User, $this> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class);

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -8,9 +8,10 @@ use App\Post;
 use App\PostBuilder;
 use App\Team;
 use App\User;
+use App\Address;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 use function PHPStan\Testing\assertType;
 
@@ -21,7 +22,7 @@ interface OnlyUsers
  * @template TModel of \Illuminate\Database\Eloquent\Model
  *
  * @param Builder<User> $userBuilder
- * @param Builder<User|Team> $userOrTeamBuilder
+ * @param Builder<User>|\App\ChildTeamBuilder $userOrTeamBuilder
  * @param Builder<TModel> $templateBuilder
  */
 function test(
@@ -32,124 +33,141 @@ function test(
     Builder $userOrTeamBuilder,
     Builder $templateBuilder,
 ): void {
+    User::query()->has('accounts', callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
     User::query()->has('accounts', '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    User::query()->has('accounts.posts', '=', 1, 'and', function (Builder $query) {
+        assertType('App\PostBuilder<App\Post>', $query);
     });
 
     Post::query()->has('users', '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
     });
 
     User::query()->doesntHave('accounts', 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->doesntHave('users', 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
     User::query()->whereHas('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
-    Post::query()->whereHas('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    User::query()->withWhereHas('accounts.posts', function (Builder|Relation $query) {
+        assertType('App\PostBuilder<App\Post>|Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Post, App\Account>', $query);
+    });
+
+    Post::query()->withWhereHas('users', function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>|Illuminate\Database\Eloquent\Relations\BelongsToMany<App\User, App\Post>', $query);
     });
 
     User::query()->orWhereHas('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->orWhereHas('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->hasMorph('accounts', [], '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->hasMorph('users', [], '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->doesntHaveMorph('accounts', [], 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->doesntHaveMorph('users', [], 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->whereHasMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->whereHasMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->orWhereHasMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->orWhereHasMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->whereDoesntHaveMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->whereDoesntHaveMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::query()->orWhereDoesntHaveMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->orWhereDoesntHaveMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
     User::query()->whereDoesntHave('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::query()->whereDoesntHave('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
     User::query()->orWhereDoesntHave('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
-    Post::query()->orWhereDoesntHave('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    Post::query()->whereRelation('users', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    User::query()->orWhereRelation('accounts', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    $relation = random_int(0, 1) ? 'accounts' : 'address';
+    User::query()->whereHas($relation, function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>', $query);
+    });
+    User::query()->withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>|Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+    $relation = random_int(0, 1) ? 'accounts.posts' : 'address';
+    User::query()->whereHas($relation, function (Builder $query) {
+        assertType('App\PostBuilder<App\Post>|Illuminate\Database\Eloquent\Builder<App\Address>', $query);
+    });
+    User::query()->withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('App\PostBuilder<App\Post>|Illuminate\Database\Eloquent\Builder<App\Address>|Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Post, App\Account>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+    $relation = random_int(0, 1) ? $user->accounts() : $user->address();
+    User::query()->whereHas($relation, function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>', $query);
+    });
+    User::query()->withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>|Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+
+    $user->has($user->accounts(), callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    $user->withWhereHas($user->accounts(), function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>|Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>', $query);
+    });
+
+    $userOrTeamBuilder->has('address', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Address>', $query);
+    });
+
+    $userOrTeamBuilder->has('members', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    $userOrTeamBuilder->has('transactions', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Transaction>', $query);
+    });
+
+    Address::query()->hasMorph('addressable', [User::class, Team::class], callable: function ($query) {
+        assertType('App\ChildTeamBuilder|Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->hasMorph('addressable', User::class, '=', 1, 'and', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->hasMorph('addressable', '*', callback: function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    });
+
+    Address::query()->doesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->whereHasMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->orWhereHasMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->whereDoesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->orWhereDoesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->whereMorphRelation('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::query()->orWhereMorphRelation('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
     });
 
     User::query()->firstWhere(function (Builder $query) {
@@ -173,13 +191,13 @@ function test(
     ])->get());
 
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::where('id', 1)->get());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User)->where('id', 1)->get());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User())->where('id', 1)->get());
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::where('id', 1)
         ->whereNotNull('name')
         ->where('email', 'bar')
         ->whereFoo(['bar'])
         ->get());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User)->whereNotNull('name')
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User())->whereNotNull('name')
         ->where('email', 'bar')
         ->whereFoo(['bar'])
         ->get());
@@ -187,8 +205,8 @@ function test(
         return [$user->name => $user->email];
     }));
 
-    assertType('mixed', (new User)->where('email', 1)->max('email'));
-    assertType('bool', (new User)->where('email', 1)->exists());
+    assertType('mixed', (new User())->where('email', 1)->max('email'));
+    assertType('bool', (new User())->where('email', 1)->exists());
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::with('accounts')->whereNull('name'));
     assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::with('accounts')
         ->where('email', 'bar')
@@ -339,7 +357,7 @@ function test(
     }, 1000));
 
     assertType('App\Team|App\User', $userOrTeamBuilder->findOrFail(4));
-    assertType('Illuminate\Database\Eloquent\Builder<App\Team|App\User>', $userOrTeamBuilder->where('id', 5));
+    assertType('App\ChildTeamBuilder|Illuminate\Database\Eloquent\Builder<App\User>', $userOrTeamBuilder->where('id', 5));
 
     assertType('Illuminate\Database\Eloquent\Builder<TModel of Illuminate\Database\Eloquent\Model (function EloquentBuilder\test(), argument)>', $templateBuilder->select());
 }

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -6,6 +6,8 @@ use App\Account;
 use App\Post;
 use App\PostBuilder;
 use App\Thread;
+use App\Team;
+use App\Address;
 use App\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -67,12 +69,14 @@ trait HasBar
  * @param  class-string<Model>  $modelClass
  * @param  class-string<User>|class-string<Post>  $userOrPostClass
  * @param  class-string<User>|class-string<Account>  $userOrAccountClass
+ * @param  class-string<User>|class-string<Team>  $userOrTeamClass
  */
 function test(
     Model $model,
     string $modelClass,
     string $userOrPostClass,
     string $userOrAccountClass,
+    string $userOrTeamClass,
     FormRequest $request,
     User $user,
 ): void {
@@ -174,28 +178,12 @@ function test(
     assertType('string', Thread::valid()->toRawSql());
     assertType('Illuminate\Database\Eloquent\Builder<App\Thread>', Thread::valid()->dumpRawSql());
 
-    User::has('accounts', '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::has('users', '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::doesntHave('accounts', 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::doesntHave('users', 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
     User::where(function (Builder $query) {
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Team::where(function ($query) {
+        assertType('App\ChildTeamBuilder', $query);
     });
 
     Post::where(function (PostBuilder $query) {
@@ -210,114 +198,133 @@ function test(
         assertType('App\PostBuilder<App\Post>', $query);
     });
 
+    User::has('accounts', callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    User::has('accounts', '=', 1, 'and', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    User::has('accounts.posts', '=', 1, 'and', function (Builder $query) {
+        assertType('App\PostBuilder<App\Post>', $query);
+    });
+
+    Post::has('users', '=', 1, 'and', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    User::doesntHave('accounts', 'and', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
     User::whereHas('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
-    Post::whereHas('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::withWhereHas('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::withWhereHas('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    Post::withWhereHas('users', function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>|Illuminate\Database\Eloquent\Relations\BelongsToMany<App\User, App\Post>', $query);
     });
 
     User::orWhereHas('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::orWhereHas('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::hasMorph('accounts', [], '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::hasMorph('users', [], '=', 1, 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::doesntHaveMorph('accounts', [], 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::doesntHaveMorph('users', [], 'and', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::whereHasMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::whereHasMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::orWhereHasMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::orWhereHasMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::whereDoesntHaveMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::whereDoesntHaveMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
-    });
-
-    User::orWhereDoesntHaveMorph('accounts', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::orWhereDoesntHaveMorph('users', [], function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
     User::whereDoesntHave('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
-    });
-
-    Post::whereDoesntHave('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
     User::orWhereDoesntHave('accounts', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
     });
 
-    Post::orWhereDoesntHave('users', function (Builder $query) {
-        assertType('Illuminate\Database\Eloquent\Builder', $query);
-        //assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    Post::whereRelation('users', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    User::orWhereRelation('accounts', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    $relation = random_int(0, 1) ? 'accounts' : 'address';
+    User::whereHas($relation, function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>', $query);
+    });
+    User::withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>|Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+    $relation = random_int(0, 1) ? 'accounts.posts' : 'address';
+    User::whereHas($relation, function (Builder $query) {
+        assertType('App\PostBuilder<App\Post>|Illuminate\Database\Eloquent\Builder<App\Address>', $query);
+    });
+    User::withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('App\PostBuilder<App\Post>|Illuminate\Database\Eloquent\Builder<App\Address>|Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Post, App\Account>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+    $relation = random_int(0, 1) ? $user->accounts() : $user->address();
+    User::whereHas($relation, function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>', $query);
+    });
+    User::withWhereHas($relation, function (Builder|Relation $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\Account|App\Address>|Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>|Illuminate\Database\Eloquent\Relations\MorphMany<App\Address, App\User>', $query);
+    });
+
+    // currently a bug in PHPStan: https://github.com/phpstan/phpstan/issues/11742
+    $user::has($user->accounts(), callback: function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
+    });
+
+    $userOrTeamClass::has('address', function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Builder<App\Address>', $query);
+    });
+
+    $userOrTeamClass::has('members', function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    $userOrTeamClass::has('transactions', function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Builder<App\Transaction>', $query);
+    });
+
+    Address::hasMorph('addressable', [User::class, Team::class], callable: function ($query) {
+        assertType('App\ChildTeamBuilder|Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::hasMorph('addressable', User::class, '=', 1, 'and', function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::hasMorph('addressable', '*', callback: function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    });
+
+    Address::doesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::whereHasMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::orWhereHasMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::whereDoesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::orWhereDoesntHaveMorph('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::whereMorphRelation('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
+    });
+
+    Address::orWhereMorphRelation('addressable', [User::class], function (Builder $query) {
+        assertType('Illuminate\Database\Eloquent\Builder<App\User>', $query);
     });
 
     User::firstWhere(function (Builder $query) {

--- a/tests/application/app/Address.php
+++ b/tests/application/app/Address.php
@@ -15,7 +15,7 @@ class Address extends Model
 {
     protected $keyType = 'uuid';
 
-    /** @return MorphTo<Model, Address> */
+    /** @return MorphTo<Model, $this> */
     public function addressable(): MorphTo
     {
         return $this->morphTo();

--- a/tests/application/app/Team.php
+++ b/tests/application/app/Team.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property string $name
@@ -15,6 +16,18 @@ class Team extends Model
      * @var string
      */
     protected $keyType = 'string';
+
+    /** @return HasMany<Transaction, $this> */
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
+    /** @return HasMany<User, $this> */
+    public function members(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
 
     /**
      * @return ChildTeamBuilder


### PR DESCRIPTION
**Changes**

Hello!

This PR adds support for dynamic relation closures as shown in @canvural's tweet: https://x.com/can__vural/status/1793999106022711748

Below are some examples from the test suite:

```php
    User::has('accounts', callback: function ($query) {
        assertType('Illuminate\Database\Eloquent\Builder<App\Account>', $query);
    });

    User::has('accounts.posts', callback: function ($query) {
        assertType('App\PostBuilder<App\Post>', $query);
    });

    Address::hasMorph('addressable', [User::class, Team::class], callable: function ($query) {
        assertType('App\ChildTeamBuilder|Illuminate\Database\Eloquent\Builder<App\User>', $query);
    });
```

Thanks!