### PR TITLE
fix: prevent crash when newEloquentBuilder method does not exist

### DIFF
--- a/e2e/canvural-larastan-strict-rules.baseline.neon
+++ b/e2e/canvural-larastan-strict-rules.baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$className of method PHPStan\\\\Reflection\\\\ReflectionProvider\\:\\:getClass\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: ../../e2e/src/Rules/NoDynamicWhereRule.php

--- a/e2e/filamentphp-filament.baseline.neon
+++ b/e2e/filamentphp-filament.baseline.neon
@@ -111,6 +111,16 @@ parameters:
 			path: ../../e2e/packages/panels/src/Commands/MakeResourceCommand.php
 
 		-
+			message: "#^Unable to resolve the template type TGroupKey in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),Filament\\\\Navigation\\\\NavigationItem\\>\\:\\:groupBy\\(\\)$#"
+			count: 1
+			path: ../../e2e/packages/panels/src/Navigation/NavigationManager.php
+
+		-
+			message: "#^Unable to resolve the template type TGroupKey in call to method Illuminate\\\\Support\\\\Collection\\<int,Filament\\\\Navigation\\\\NavigationItem\\>\\:\\:groupBy\\(\\)$#"
+			count: 1
+			path: ../../e2e/packages/panels/src/Navigation/NavigationManager.php
+
+		-
 			message: "#^Unable to resolve the template type TMapValue in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),string\\>\\:\\:map\\(\\)$#"
 			count: 1
 			path: ../../e2e/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Larastan\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
@@ -72,11 +71,11 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
      */
     private function findMethod(ClassReflection $classReflection, string $methodName): MethodReflection|null
     {
-        if ($classReflection->getName() !== Model::class && ! $classReflection->isSubclassOf(Model::class)) {
+        $builderName = $this->builderHelper->determineBuilderName($classReflection);
+
+        if ($builderName === null) {
             return null;
         }
-
-        $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
 
         if (in_array($methodName, ['increment', 'decrement'], true)) {
             $methodReflection = $classReflection->getNativeMethod($methodName);

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -76,7 +76,11 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             $modelReflection = $this->reflectionProvider->getClass(Model::class);
         }
 
-        $builderName = $this->builderHelper->determineBuilderName($modelReflection->getName());
+        $builderName = $this->builderHelper->determineBuilderName($modelReflection);
+
+        if ($builderName === null) {
+            return null;
+        }
 
         $builderReflection = $this->reflectionProvider->getClass($builderName)->withTypes([$relatedModel]);
 

--- a/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
@@ -56,11 +56,11 @@ class NewModelQueryDynamicMethodReturnTypeExtension implements DynamicMethodRetu
         $types = [];
 
         foreach ($classReflections as $classReflection) {
-            if (! $classReflection->isSubclassOf(Model::class)) {
+            $builderName = $this->builderHelper->determineBuilderName($classReflection);
+
+            if ($builderName === null) {
                 continue;
             }
-
-            $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
 
             $types[] = new GenericObjectType($builderName, [new ObjectType($classReflection->getName())]);
         }

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -23,6 +23,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1565.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1760.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1830.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1997.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/carbon.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/conditionable.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/container-array-access.php');

--- a/tests/Type/data/bug-1997.php
+++ b/tests/Type/data/bug-1997.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug1997;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+use function PHPStan\Testing\assertType;
+
+interface User
+{
+    /** @return BelongsToMany<Team> */
+    public function teams(): BelongsToMany;
+
+    public function getKey();
+}
+
+interface Team {}
+
+
+function test(User $user): void
+{
+    // should not crash when analyzing this
+    assertType('*ERROR*', $user->teams()->whereKey($user->getKey()));
+}


### PR DESCRIPTION
Hello!

This closes #1997 by checking if the class and method exist before getting the `newEloquentBuilder` method.

Thanks!
