### PR TITLE
Add failedValidation() to FormRequest.stub

### DIFF
--- a/stubs/common/Foundation/Http/FormRequest.stub
+++ b/stubs/common/Foundation/Http/FormRequest.stub
@@ -21,4 +21,14 @@ class FormRequest
      * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function validated($key = null, $default = null);
+
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    protected function failedValidation(Validator $validator);
 }


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

* Added [`failedValidation()`](/laravel/framework/blob/11.x/src/Illuminate/Foundation/Http/FormRequest.php#L218-L221) to FormRequest.stub
* Changed type of `$validator` argument changed to [`\Illuminate\Validation\Validator`](/laravel/framework/blob/11.x/src/Illuminate/Validation/Validator.php)
* Therefore, calling [`$validator->getException()`](/laravel/framework/blob/11.x/src/Illuminate/Validation/Validator.php#L1518-L1521 inside the method doesn't result in an error anymore, that `getException()`) is not defined in [`\Illuminate\Contracts\Validation\Validator`](/laravel/framework/blob/11.x/src/Illuminate/Contracts/Validation/Validator.php)

**Breaking changes**

_n/a_
