### PR TITLE
remove unnecessary use of `ParametersAcceptorSelector::selectSingle`

### DIFF
--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -9,7 +9,6 @@ use Larastan\Larastan\Concerns;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -38,7 +37,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         MethodReflection $methodReflection,
         StaticCall $methodCall,
         Scope $scope,
-    ): Type {
+    ): Type|null {
         $config     = $this->getContainer()->get('config');
         $authModels = [];
 
@@ -47,7 +46,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         }
 
         if (count($authModels) === 0) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+            return null;
         }
 
         return TypeCombinator::addNull(

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -9,7 +9,6 @@ use Larastan\Larastan\Concerns;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -37,7 +36,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope,
-    ): Type {
+    ): Type|null {
         $config     = $this->getContainer()->get('config');
         $authModels = [];
 
@@ -46,7 +45,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         }
 
         if (count($authModels) === 0) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+            return null;
         }
 
         return TypeCombinator::addNull(

--- a/src/Types/RelationDynamicMethodReturnTypeExtension.php
+++ b/src/Types/RelationDynamicMethodReturnTypeExtension.php
@@ -55,7 +55,7 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope,
-    ): Type {
+    ): Type|null {
         /** @var FunctionVariant $functionVariant */
         $functionVariant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
         $returnType      = $functionVariant->getReturnType();
@@ -63,7 +63,7 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
         $classNames = $returnType->getObjectClassNames();
 
         if (count($classNames) !== 1) {
-            return $returnType;
+            return null;
         }
 
         $calledOnType = $scope->getType($methodCall->var);
@@ -78,14 +78,14 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
                 return new GenericObjectType($classNames[0], [new ObjectType(Model::class), $calledOnType]);
             }
 
-            return $returnType;
+            return null;
         }
 
         $argType    = $scope->getType($methodCall->getArgs()[0]->value);
         $argStrings = $argType->getConstantStrings();
 
         if (count($argStrings) !== 1) {
-            return $returnType;
+            return null;
         }
 
         $argClassName = $argStrings[0]->getValue();


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
Simplify the migration path to PHPStan 2.x in which `ParametersAcceptorSelector::selectSingle` is deprecated.

see https://phpstan.org/developing-extensions/dynamic-return-type-extensions

<img width="707" alt="grafik" src="https://github.com/user-attachments/assets/5106753c-e56c-4dea-ae16-743f8b862093">



**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
none
