### PR TITLE
fix: do not throw if application could not be bootstrapped

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,16 +18,16 @@ if (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applicat
     $app = require $applicationPath;
 } elseif (trait_exists(CreatesApplication::class)) { // Packages
     $app = ApplicationResolver::resolve();
-} else {
-    throw new Exception('Could not find Laravel bootstrap file nor Testbench is installed. Install orchestra/testbench if analyzing a package.');
 }
 
-if ($app instanceof Application) {
-    $app->make(Kernel::class)->bootstrap();
-} elseif ($app instanceof LumenApplication) {
-    $app->boot();
-}
+if(isset($app)) {
+    if ($app instanceof Application) {
+        $app->make(Kernel::class)->bootstrap();
+    } elseif ($app instanceof LumenApplication) {
+        $app->boot();
+    }
 
-if (! defined('LARAVEL_VERSION')) {
-    define('LARAVEL_VERSION', $app->version());
+    if (! defined('LARAVEL_VERSION')) {
+        define('LARAVEL_VERSION', $app->version());
+    }
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,7 +20,7 @@ if (file_exists($applicationPath = getcwd().'/bootstrap/app.php')) { // Applicat
     $app = ApplicationResolver::resolve();
 }
 
-if(isset($app)) {
+if (isset($app)) {
     if ($app instanceof Application) {
         $app->make(Kernel::class)->bootstrap();
     } elseif ($app instanceof LumenApplication) {


### PR DESCRIPTION
Since https://github.com/larastan/larastan/pull/1983 wasn't merged yet, and someone else [ran in the same issue](https://github.com/larastan/larastan/pull/1983#issuecomment-2423574138) today, I submit this one as an alternative attempt. 

Instead of using env, this PR seeks to not throw and silcently move on to bootstrappers defined in the PhpStan config.

**Summary of the problem:**

- PhpStan loads extension configs first.
- The Larastan bootstrap.php (not PhpStan) file has hard-coded paths. If Larastan cannot bootstrap the Laravel application it throws `Could not find Laravel bootstrap file nor Testbench is installed. Install orchestra/testbench if analyzing a package`.
- Since the PhpStan config would have been loaded after this step, we never reach this stage to handle our own bootstrapping.