### PR TITLE
fix: improve PHPDoc for find method of QueryBuilder to support FETCH_ASSOC

### DIFF
--- a/stubs/10.0.0/QueryBuilder.stub
+++ b/stubs/10.0.0/QueryBuilder.stub
@@ -180,7 +180,7 @@ class Builder
      *
      * @param  int|string  $id
      * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
-     * @return object|null
+     * @return array<array-key, mixed>|object|null
      */
     public function find($id, $columns = ['*']);
 

--- a/stubs/11.0.0/QueryBuilder.stub
+++ b/stubs/11.0.0/QueryBuilder.stub
@@ -144,7 +144,7 @@ class Builder
      *
      * @param  int|string  $id
      * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
-     * @return object|null
+     * @return array<array-key, mixed>|object|null
      */
     public function find($id, $columns = ['*']);
 

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -180,7 +180,7 @@ class Builder
      *
      * @param  int|string  $id
      * @param  array<string>  $columns
-     * @return object|null
+     * @return array<array-key, mixed>|object|null
      */
     public function find($id, $columns = ['*']);
 

--- a/tests/Type/data/query-builder-l10-24.php
+++ b/tests/Type/data/query-builder-l10-24.php
@@ -44,7 +44,7 @@ function test(): void
 
     assertType('Illuminate\Database\Query\Builder', $builder);
 
-    assertType('object|null', DB::table('users')->find(1, [DB::raw('email_verified_at')]));
+    assertType('array|object|null', DB::table('users')->find(1, [DB::raw('email_verified_at')]));
     assertType('mixed', DB::table('users')->aggregate('sum', [DB::raw('id')]));
     assertType('float|int', DB::table('users')->numericAggregate('sum', [DB::raw('id')]));
     assertType('float|int|numeric-string', DB::table('users')->sum(DB::raw('id')));


### PR DESCRIPTION
The current PHPDoc for the find() method declares the return type as object|null. 

This likely stems from Laravel’s default fetchMode for the Database\Connection property being set to `PDO::FETCH_OBJ.` However, when users customize the `Connection` to use `PDO::FETCH_ASSOC`, this can result in numerous errors, as the return type differs. 

My attempt to override Larastan’s stub with a custom file was unsuccessful because PHPStan does not support overriding stub files. 

This limitation highlights the need for a more flexible solution to accommodate different fetch modes without causing type-related errors.