### PR TITLE
Illuminate\Database\Query\Builder::get() stub

### DIFF
--- a/stubs/11.0.0/QueryBuilder.stub
+++ b/stubs/11.0.0/QueryBuilder.stub
@@ -7,6 +7,14 @@ class Expression {}
 class Builder
 {
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  list<string>|string  $columns
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    public function get($columns = ['*']);
+
+    /**
      * Add a basic where clause to the query.
      *
      * @param  \Closure|string|array<string|int, mixed>|\Illuminate\Contracts\Database\Query\Expression  $column


### PR DESCRIPTION
- [ ] Added or updated tests
- <s>Documented user facing changes</s> none

**Changes**

Adds stub function for `Illuminate\Database\Query\Builder::get()` to make the return type better: 'Collection of objects' instead of just 'Collection (of mixed)'.

**Breaking changes**

No breaking changes.

----

Tests?