### PR TITLE
Uses `orchestra/testbench-core` instead of `orchestra/testbench`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
+        "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
         "nikic/php-parser": "^4.19.1",
         "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
-        "orchestra/testbench": "^7.33.0 || ^8.13.0 || ^9.0.3",
+        "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
         "phpstan/phpstan-deprecation-rules": "^1.2",
         "phpunit/phpunit": "^9.6.13 || ^10.5.16"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "laravel/framework": "^9.52.16 || ^10.28.0 || ^11.16",
+        "mockery/mockery": "^1.5.1",
         "nikic/php-parser": "^4.19.1",
         "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
         "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",


### PR DESCRIPTION
- ~Added or updated tests~
- ~Documented user facing changes~

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

For "Development" packages it is best to require `orchestra/testbench-core` due to the minimum amount of dependencies introduced.
<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

No breaking changes since it only changes `require-dev`
