### PR TITLE
Fixed the type of the make method of the Attribute class

### DIFF
--- a/stubs/common/Attribute.stub
+++ b/stubs/common/Attribute.stub
@@ -11,14 +11,14 @@ class Attribute
     /**
      * The attribute accessor.
      *
-     * @var callable(): TGet
+     * @var callable(mixed, array<string, mixed>): TGet
      */
     public $get;
 
     /**
      * The attribute mutator.
      *
-     * @var callable(TSet): mixed
+     * @var callable(TSet, array<string, mixed>): mixed
      */
     public $set;
 
@@ -27,8 +27,8 @@ class Attribute
      *
      * @template TMakeGet
      * @template TMakeSet
-     * @param  (callable(mixed, mixed): TMakeGet)|null  $get
-     * @param  (callable(TMakeSet, mixed=): mixed)|null  $set
+     * @param  (callable(mixed, array<string, mixed>): TMakeGet)|null  $get
+     * @param  (callable(TMakeSet, array<string, mixed>): mixed)|null  $set
      * @return Attribute<TMakeGet, TMakeSet>
      */
     public static function make(callable $get = null, callable $set = null);
@@ -37,7 +37,7 @@ class Attribute
      * Create a new attribute accessor.
      *
      * @template T
-     * @param  callable(mixed, mixed=): T  $get
+     * @param  callable(mixed, array<string, mixed>): T  $get
      * @return Attribute<T, never>
      */
     public static function get(callable $get);
@@ -46,7 +46,7 @@ class Attribute
      * Create a new attribute mutator.
      *
      * @template T
-     * @param  callable(T, mixed=): mixed $set
+     * @param  callable(T, array<string, mixed>): mixed $set
      * @return Attribute<never, T>
      */
     public static function set(callable $set);

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -89,6 +89,14 @@ class IntegrationTest extends PHPStanTestCase
                 34 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<ModelPropertyStaticCall\ModelPropertyStaticCallsInClass>::create() expects array<model property of ModelPropertyStaticCall\ModelPropertyStaticCallsInClass, mixed>, array<string, string> given.'],
             ],
         ];
+
+        yield [
+            __DIR__ . '/data/model-property-mutator-and-casting.php',
+            [
+                24 => ['Parameter #1 $lineOne of class ModelPropertyMutatorAndCasting\Address constructor expects string, mixed given.'],
+                25 => ['Parameter #2 $lineTwo of class ModelPropertyMutatorAndCasting\Address constructor expects string, mixed given.'],
+            ],
+        ];
     }
 
     /**

--- a/tests/Integration/data/model-property-mutator-and-casting.php
+++ b/tests/Integration/data/model-property-mutator-and-casting.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ModelPropertyMutatorAndCasting;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class Address
+{
+    public function __construct(
+        public string $lineOne,
+        public string $lineTwo,
+    ) {}
+}
+
+class ModelPropertyMutatorAndCastingInClass extends \Illuminate\Database\Eloquent\Model
+{
+    /**
+     * @return Attribute<Address,Address>
+     */
+    protected function address(): Attribute
+    {
+        return Attribute::make(
+            get: fn(mixed $value, array $attributes) => new Address(
+                $attributes['address_line_one'],
+                $attributes['address_line_two'],
+            ),
+            set: fn(Address $value) => [
+                'address_line_one' => $value->lineOne,
+                'address_line_two' => $value->lineTwo,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

**Changes**

The argument type of the make method of the Attribute class has been modified to match the Laravel documentation.

https://laravel.com/docs/11.x/eloquent-mutators#building-value-objects-from-multiple-attributes

I wrote the following code according to the Laravel documentation, but when I ran it on Larastan (Level 9), I noticed the following error, which led me to create a PR:
If there doesn't seem to be any problems, I'd like to ask you to merge it.

```php
    /**
     * @return Attribute<Period, Period>
     */
    protected function publishPeriod(): Attribute
    {
        return Attribute::make(
            get: fn(mixed $value, array $attributes) => new Period(
                $attributes['publish_from'],
                $attributes['publish_to'],
            ),
            set: fn(Period $value) => [
                'publish_from' => $value->from,
                'publish_to' => $value->to,
            ],
        );
    }
```

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Models/Recruitment.php                                                                                                                                                            
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  24     Parameter $get of static method Illuminate\Database\Eloquent\Casts\Attribute<mixed,mixed>::make() expects (callable(mixed, mixed): App\ValueObjects\Period)|null, Closure(mixed,  
         array): App\ValueObjects\Period given.                                                                                                                                            
         🪪  argument.type                                                                                                                                                                 
         💡 Type #1 from the union: Type array of parameter #2 $attributes of passed callable needs to be same or wider than parameter type mixed of accepting callable.                   
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

**Breaking changes**

