### PR TITLE
fix: parameter type for HasOneOrMany::createMany

### DIFF
--- a/stubs/common/HasOneOrMany.stub
+++ b/stubs/common/HasOneOrMany.stub
@@ -71,7 +71,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a Collection of new instances of the related model.
      *
-     * @param  iterable<model-property<TRelatedModel>, mixed>  $records
+     * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function createMany(iterable $records);

--- a/tests/Integration/data/model-property-relation.php
+++ b/tests/Integration/data/model-property-relation.php
@@ -10,3 +10,8 @@ $user->accounts()->updateOrCreate(['foo' => 'bar']);
 $user->posts()->where('foo', 'bar');
 
 $user->accounts()->createOrFirst(['foo' => 'bar']);
+
+$user->accountsCamel()->createMany([
+    ['name' => 'foo'],
+    ['name' => 'bar'],
+]);

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -247,6 +247,14 @@ function test(
         'Illuminate\Database\Eloquent\Relations\HasManyThrough<App\Part, App\Mechanic, App\User>',
         $user->through($user->mechanic())->has(fn ($mechanic) => $mechanic->parts()),
     );
+
+    assertType(
+        'App\AccountCollection<int, App\Account>',
+        $user->accountsCamel()->createMany([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]),
+    );
 }
 
 /**


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The `$records` parameter type for the `HasOneOrMany::createMany()` method was wrong.
It should be an iterable of arrays with model properties as keys and mixed values.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
