### PR TITLE
Fix typo in address #2125

### DIFF
--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -126,14 +126,14 @@ function test(
     assertType('Illuminate\Database\Eloquent\Collection<int, App\Address>', $user->address()->get());
     assertType('App\Address', $user->address()->make());
     assertType('App\Address', $user->address()->create());
-    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\ChildUser>', $child->oneAdress());
-    assertType('App\Address', $child->oneAdress()->make());
-    assertType('App\Address', $child->oneAdress()->create([]));
-    assertType('App\Address', $child->oneAdress()->getRelated());
-    assertType('App\ChildUser', $child->oneAdress()->getParent());
-    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAdress());
-    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAdress()->where('zip'));
-    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAdress()->orderBy('zip'));
+    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\ChildUser>', $child->oneAddress());
+    assertType('App\Address', $child->oneAddress()->make());
+    assertType('App\Address', $child->oneAddress()->create([]));
+    assertType('App\Address', $child->oneAddress()->getRelated());
+    assertType('App\ChildUser', $child->oneAddress()->getParent());
+    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAddress());
+    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAddress()->where('zip'));
+    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Address, App\User>', $user->oneAddress()->orderBy('zip'));
 
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>', $user->accountsCamel());
     assertType('App\AccountCollection<int, App\Account>', $user->accountsCamel()->getResults());

--- a/tests/application/app/User.php
+++ b/tests/application/app/User.php
@@ -183,7 +183,7 @@ class User extends Authenticatable
     }
 
     /** @return HasOne<Address, $this> */
-    public function oneAdress(): HasOne
+    public function oneAddress(): HasOne
     {
         return $this->hasOne(Address::class);
     }


### PR DESCRIPTION
- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Fixes typo in relationship `oneAdress` to `oneAddress` in testbench

<!-- Detail the changes in behaviour this PR introduces. -->

**No breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
