### PR TITLE
Improve parameter of QueryBuilder::get

### DIFF
--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -178,7 +178,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>|string  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -178,7 +178,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  string[]|string  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);


### PR DESCRIPTION
Allow `Expression` in querybuilder `->get()` method.

- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**