### PR TITLE
[2.x] Improve parameter of QueryBuilder::get

### DIFF
--- a/stubs/10.0.0/QueryBuilder.stub
+++ b/stubs/10.0.0/QueryBuilder.stub
@@ -346,7 +346,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  string[]|string  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>|string  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);

--- a/stubs/11.0.0/QueryBuilder.stub
+++ b/stubs/11.0.0/QueryBuilder.stub
@@ -288,7 +288,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  string[]|string  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>|string  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -194,7 +194,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>|string  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -194,7 +194,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  string[]|string  $columns
+     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -194,7 +194,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array<string|\Illuminate\Contracts\Database\Query\Expression>|string  $columns
+     * @param  string[]|string  $columns
      * @return \Illuminate\Support\Collection<int, \stdClass>
      */
     public function get($columns = ['*']);


### PR DESCRIPTION
Allow `Expression` in querybuilder `->get()` method.


Asked to put a PR in for V2 as well in https://github.com/larastan/larastan/pull/2131