### PR TITLE
Collection::groupBy() return type

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -63,7 +63,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(TValue, TKey): TGroupKey)|list<string|\Closure>|string  $groupBy
      * @param  bool  $preserveKeys
-     * @return static<($groupBy is string ? array-key : ($groupBy is array ? array-key : TGroupKey)), static<($preserveKeys is true ? TKey : int), TValue>>
+     * @return static<($groupBy is string ? array-key : ($groupBy is array ? array-key : TGroupKey)), static<($preserveKeys is true ? TKey : int), ($groupBy is array ? mixed : TValue)>>
      */
     public function groupBy($groupBy, $preserveKeys = false);
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes


<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Updates the return type definition of `Collection::groupBy()` in line with https://github.com/laravel/framework/pull/53684.

**Breaking changes**

None.
