### PR TITLE
[3.x] fix: model relation properties

### DIFF
--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -5,13 +5,6 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Properties;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Larastan\Larastan\Concerns;
@@ -19,20 +12,13 @@ use Larastan\Larastan\Reflection\ReflectionHelper;
 use Larastan\Larastan\Support\CollectionHelper;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
-use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 
@@ -66,17 +52,11 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         }
 
         foreach ($methodNames as $methodName) {
-            $hasNativeMethod = $classReflection->hasNativeMethod($methodName);
-
-            if (! $hasNativeMethod) {
+            if (! $classReflection->hasNativeMethod($methodName)) {
                 continue;
             }
 
             $returnType = $classReflection->getNativeMethod($methodName)->getVariants()[0]->getReturnType();
-
-            if ($returnType->getTemplateType(Relation::class, 'TRelatedModel') instanceof ErrorType) {
-                continue;
-            }
 
             if ((new ObjectType(Relation::class))->isSuperTypeOf($returnType)->yes()) {
                 return true;
@@ -86,91 +66,29 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
         return false;
     }
 
-    /**
-     * @throws ShouldNotHappenException
-     * @throws MissingMethodFromReflectionException
-     */
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
         if (str_ends_with($propertyName, '_count')) {
             return new ModelProperty($classReflection, IntegerRangeType::createAllGreaterThanOrEqualTo(0), new NeverType(), false);
         }
 
-        $method = $classReflection->getMethod($propertyName, new OutOfClassScope());
+        $returnType = $classReflection->getMethod($propertyName, new OutOfClassScope())
+            ->getVariants()[0]
+            ->getReturnType();
 
-        $returnType = $method->getVariants()[0]->getReturnType();
-
-        $relatedModel = $returnType->getTemplateType(Relation::class, 'TRelatedModel');
-
-        if ($relatedModel->getObjectClassNames() === []) {
-            $relatedModelClassNames = [Model::class];
-        } else {
-            $relatedModelClassNames = $relatedModel->getObjectClassNames();
-        }
-
-        $relationType = TypeTraverser::map($returnType, function (Type $type, callable $traverse) use ($relatedModelClassNames, $relatedModel) {
+        $relationType = TypeTraverser::map($returnType, static function (Type $type, callable $traverse): Type {
             if ($type instanceof UnionType || $type instanceof IntersectionType) {
                 return $traverse($type);
             }
 
-            if ($type->getObjectClassNames() === []) {
-                return $traverse($type);
+            if (! (new ObjectType(Relation::class))->isSuperTypeOf($type)->yes()) {
+                return $type;
             }
 
-            if ($type instanceof GenericObjectType) {
-                $relatedModel           = $type->getTypes()[0];
-                $relatedModelClassNames = $relatedModel->getObjectClassNames();
-            }
-
-            if (
-                (new ObjectType(BelongsToMany::class))->isSuperTypeOf($type)->yes()
-                || (new ObjectType(HasMany::class))->isSuperTypeOf($type)->yes()
-                || (
-                    (new ObjectType(HasManyThrough::class))->isSuperTypeOf($type)->yes()
-                    // HasOneThrough extends HasManyThrough
-                    && ! (new ObjectType(HasOneThrough::class))->isSuperTypeOf($type)->yes()
-                )
-                || (new ObjectType(MorphMany::class))->isSuperTypeOf($type)->yes()
-                || (new ObjectType(MorphToMany::class))->isSuperTypeOf($type)->yes()
-                || Str::contains($type->getObjectClassNames()[0], 'Many') // fallback
-            ) {
-                $types = [];
-
-                foreach ($relatedModelClassNames as $relatedModelClassName) {
-                    $types[] = $this->collectionHelper->determineCollectionClass($relatedModelClassName);
-                }
-
-                if ($types !== []) {
-                    return TypeCombinator::union(...$types);
-                }
-            }
-
-            if (
-                (new ObjectType(MorphTo::class))->isSuperTypeOf($type)->yes()
-                || Str::endsWith($type->getObjectClassNames()[0], 'MorphTo') // fallback
-            ) {
-                // There was no generic type, or it was just Model
-                // so we will return mixed to avoid errors.
-                if ($relatedModel->getObjectClassNames()[0] === Model::class) {
-                    return new MixedType();
-                }
-
-                $types = [];
-
-                foreach ($relatedModelClassNames as $relatedModelClassName) {
-                    $types[] = new ObjectType($relatedModelClassName);
-                }
-
-                if ($types !== []) {
-                    return TypeCombinator::union(...$types);
-                }
-            }
-
-            return new UnionType([
-                $relatedModel,
-                new NullType(),
-            ]);
+            return $type->getTemplateType(Relation::class, 'TResult');
         });
+
+        $relationType = $this->collectionHelper->replaceCollectionsInType($relationType);
 
         return new ModelProperty($classReflection, $relationType, new NeverType(), false);
     }

--- a/tests/Type/data/model-properties-relations.php
+++ b/tests/Type/data/model-properties-relations.php
@@ -4,7 +4,6 @@ namespace ModelPropertiesRelations;
 
 use App\Account;
 use App\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -98,8 +97,8 @@ function test(Foo $foo, Bar $bar, Account $account): void
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>', $foo->hasManyThroughRelation);
     assertType('ModelPropertiesRelations\Baz|null', $foo->hasOneThroughRelation);
     assertType('ModelPropertiesRelations\Foo', $bar->belongsToRelation);
-    assertType('mixed', $bar->morphToRelation);
-    assertType('App\Account|App\User', $bar->morphToUnionRelation);
+    assertType('Illuminate\Database\Eloquent\Model|null', $bar->morphToRelation);
+    assertType('App\Account|App\User|null', $bar->morphToUnionRelation);
     assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation->first());
     assertType('ModelPropertiesRelations\Bar|null', $foo->hasManyRelation()->find(1));
     assertType('App\User|null', $account->ownerRelation);
@@ -107,4 +106,3 @@ function test(Foo $foo, Bar $bar, Account $account): void
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Bar>|ModelPropertiesRelations\Baz|null', $foo->relationReturningUnion2);
     assertType('Illuminate\Database\Eloquent\Collection<int, ModelPropertiesRelations\Foo>', $foo->ancestors);
 }
-

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -229,7 +229,7 @@ function test(
 
     assertType('Illuminate\Database\Eloquent\Relations\MorphTo<Illuminate\Database\Eloquent\Model, App\Comment>', $comment->commentable());
     assertType('Illuminate\Database\Eloquent\Model|null', $comment->commentable()->getResults());
-    assertType('mixed', $comment->commentable);
+    assertType('Illuminate\Database\Eloquent\Model|null', $comment->commentable);
     assertType('Illuminate\Database\Eloquent\Collection<int, App\Comment>', $comment->commentable()->getEager());
     assertType('Illuminate\Database\Eloquent\Model', $comment->commentable()->createModelByType('foo'));
     assertType('App\Comment', $comment->commentable()->associate(new Post()));


### PR DESCRIPTION
**Changes**

Hello!

This closes #1866, closes #2152 , and closes #2169 and greatly cleans up the model relation extension now that we can take full advantage of the `TResult` template.

Thanks!

**Breaking changes**

None