### PR TITLE
Add Fallback for Types That Can't Be Resolved Dynamically

### DIFF
--- a/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
@@ -28,7 +28,7 @@ final class AppMakeDynamicReturnTypeExtension implements DynamicStaticMethodRetu
         return $methodReflection->getName() === 'make' || $methodReflection->getName() === 'makeWith';
     }
 
-    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type|null
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -58,6 +57,6 @@ final class AppMakeHelper
             return TypeCombinator::union(...$types);
         }
 
-        return new MixedType();
+        return null;
     }
 }

--- a/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
@@ -30,7 +30,7 @@ final class ApplicationMakeDynamicReturnTypeExtension implements DynamicMethodRe
         return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type|null
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
@@ -30,7 +30,7 @@ final class ContainerMakeDynamicReturnTypeExtension implements DynamicMethodRetu
         return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type|null
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -31,7 +31,7 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
         FunctionReflection $functionReflection,
         FuncCall $functionCall,
         Scope $scope,
-    ): Type {
+    ): Type|null {
         if (count($functionCall->getArgs()) === 0) {
             return new ObjectType(Application::class);
         }

--- a/tests/Type/data/FailsAtRuntime.php
+++ b/tests/Type/data/FailsAtRuntime.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class FailsAtRuntime
+{
+    public function __construct()
+    {
+        throw new \Exception("Cannot resolve class dynamically.");
+    }
+}

--- a/tests/Type/data/application-make.php
+++ b/tests/Type/data/application-make.php
@@ -2,6 +2,7 @@
 
 namespace ApplicationMake;
 
+use FailsAtRuntime;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
@@ -15,10 +16,12 @@ function test(Application $app, ApplicationContract $app2, string $model): void
     assertType('Illuminate\Config\Repository', $app->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app->resolve(FailsAtRuntime::class));
 
     assertType('Illuminate\Config\Repository', $app2->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app2->resolve(FailsAtRuntime::class));
 
     assertType('mixed', $app->make($model));
     assertType('mixed', $app->makeWith($model));


### PR DESCRIPTION
**Changes**
When resolving types for calls like `resolve(MyClass::class)`, Larastan may fail to resolve an object dynamically in certain environments. In such cases, the resolved type is marked as `*ERROR*`, leading to a fallback to `mixed` without explicit warnings, even if the type could be derived from the input string.

This patch introduces a fallback mechanism that uses the provided string (e.g., `MyClass::class`) as the return type if dynamic resolution fails. This ensures that type information is preserved whenever possible, while maintaining compatibility with existing behavior.

**Breaking changes**
Cases where the `*ERROR*` type was previously returned (causing subsequent code to operate on an implicit `mixed`) will now see the object type. This may result in the detection of errors that were previously missed.

Anyone using PHPStan at level 10 would already have addressed such cases in one way or another, so they should not see any new issues. However, they may now be able to remove some workarounds.