### PR TITLE
fix return type for literal helper when unpacked array given

### DIFF
--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -183,4 +183,16 @@ function test(?int $value = 0): void
     assertType("object{0: 'bar', 1: 'foo'}&stdClass", literal('bar', 'foo'));
     assertType("object{0: 4, bar: 'foo'}&stdClass", literal(4, bar:'foo'));
     assertType("App\User", literal(new User()));
+    assertType("array{foo: 22, bar: 'bar'}", literal(['foo' => 22, 'bar' => "bar"]));
+    assertType("object{0: 5, 1: 7}&stdClass", literal(...[5,7]));
+    assertType("object{foo: 22, bar: 'bar'}&stdClass", literal(...['foo' => 22, 'bar' => "bar"]));
 }
+
+/**
+ * @param array{loo:'loo'}|array{foo:'foo',bar:'baa'} $parameter
+ */
+function testUnion($parameter): int {
+    assertType("(object{foo: 'foo', bar: 'baa'}&stdClass)|(object{loo: 'loo'}&stdClass)", literal(...$parameter));
+
+    return 0;
+};


### PR DESCRIPTION
- [x] Added or updated tests
Related to: https://github.com/larastan/larastan/pull/2127

**Changes**

In my previous pr https://github.com/larastan/larastan/pull/2127 that added return type to the literal helper, I found that it did not work with array unpacking. It is fixed here

