### PR TITLE
Update param types in QueryBuilder

### DIFF
--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -143,8 +143,7 @@ class Builder
     /**
      * Add a union statement to the query.
      *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Closure  $query
      * @param  bool  $all
      * @return $this
      */
@@ -153,8 +152,7 @@ class Builder
     /**
      * Add a union all statement to the query.
      *
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<TModel>|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Closure  $query
      * @return $this
      */
     public function unionAll($query);

--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -141,23 +141,6 @@ class Builder
     public function havingBetween($column, array $values, $boolean = 'and', $not = false);
 
     /**
-     * Add a union statement to the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Closure  $query
-     * @param  bool  $all
-     * @return $this
-     */
-    public function union($query, $all = false);
-
-    /**
-     * Add a union all statement to the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Closure  $query
-     * @return $this
-     */
-    public function unionAll($query);
-
-    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Updates the param type definition of QueryBuilder::union() and QueryBuilder::unionAll() in line with [https://github.com/laravel/framework/pull/51851](https://github.com/laravel/framework/pull/51851)
and from [Builder.php#L2885](https://github.com/laravel/framework/blob/8b93d39c4721a0c170b92bfbf7bfb5090b5407cc/src/Illuminate/Database/Query/Builder.php#L2885), [Builder.php#L2905](https://github.com/laravel/framework/blob/8b93d39c4721a0c170b92bfbf7bfb5090b5407cc/src/Illuminate/Database/Query/Builder.php#L2905)

**Breaking changes**

None
