### PR TITLE
[3.x] fix: check for `dynamicWhere` method existence

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -112,7 +112,13 @@ class BuilderHelper
 
         $classReflection = $this->reflectionProvider->getClass(QueryBuilder::class);
 
-        $methodReflection = $classReflection->getNativeMethod('dynamicWhere');
+        if (! $classReflection->hasNativeMethod('dynamicWhere')) {
+            throw new ShouldNotHappenException(<<<'TXT'
+                Method 'dynamicWhere' not found in QueryBuilder reflection.
+                This is known to happen when Larastan scans the stubs from the
+                IDE-Helper package.
+                TXT);
+        }
 
         return new EloquentBuilderMethodReflection(
             $methodName,


### PR DESCRIPTION
**Changes**

This closes #1309, #2015, and closes #2174 by checking for the existence of the `dynamicWhere` method before trying to resolve it. Normally this would exist in a Laravel project, but when users mistakenly configure Larastan to scan the ide-helper files, the ide-helper stub for the QueryBuilder *replaces* the actual definition of the class and the method does not exit.

In general, any calls to PHPStan `->get*()` methods should generally be guarded by `->has*()` calls to gracefully handle these situations instead of just throwing a confusing exception.

Thanks!

**Breaking changes**

N/A