### PR TITLE
Update EnumeratesValues.stub

### DIFF
--- a/stubs/common/EnumeratesValues.stub
+++ b/stubs/common/EnumeratesValues.stub
@@ -48,4 +48,14 @@ trait EnumeratesValues
      * @return static<TFlatMapKey, TFlatMapValue>
      */
     public function flatMap(callable $callback);
+
+	/**
+     * Run a map over each nested chunk of items.
+     *
+     * @template TMapSpreadValue
+     *
+     * @param  callable(...TValue, ?TKey): TMapSpreadValue  $callback
+     * @return static<TKey, TMapSpreadValue>
+     */
+    public function mapSpread(callable $callback);
 }


### PR DESCRIPTION
Teach EnumeratesValues::mapSpread() to expand an array of TValue and TKey into the expected callback signature.

- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

I attempted to see this fixed via PHPStan directly: https://phpstan.org/r/8ca0712e-3193-4ada-8069-078cda880038

However, PHPStan on its own complains about a syntax error. I believe something Larastan does handles the portion that PHPStan views as a docblock syntax error. I don't know where that is, I'm not familiar with the internals of Larastan.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

In `\Illuminate\Support\Traits\EnumeratesValues::mapSpread()`, the `$callback` parameter is document as `@param  callable(mixed...): TMapSpreadValue  $callback`. This prevents proper identification of callbacks that match the spread of the collection. For example:

```php
/** @var Collection<int, array{int, int}> $c */
$c = new Collection();
$c->mapSpread(function (int $i, int $j): int {
    return $i + $j;
});
```

This should work, but in my app it fails, complaining that:

```
Parameter #1 $callback of method Illuminate\Support\Collection<int,array<int, int>>::mapSpread() expects callable(mixed ...): int, Closure(int, int): int given.
```

Something in Larastan allows for the `...TValue` syntax I propose here, allowing `mapSpread()` to correctly identify the types of the argument spread.

**Breaking changes**

I don't know of any breaking changes. My best guess would be that any baselines that have these errors notated could report `Ignored error pattern ... was not matched in reported errors.`, depending on the value of `reportUnmatchedIgnoredErrors`.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
