### PR TITLE
[3.x] fix: package config(`Package/config/config.php`) can use `env`

### DIFF
--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -67,6 +67,6 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
     protected function isCalledOutsideOfPackageConfig(FuncCall $call, Scope $scope): bool
     {
-        return basename(dirname($scope->getFile())) !== 'config';
+        return str_starts_with($scope->getFile(), getcwd() . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR) === false;
     }
 }

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -9,13 +9,13 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 use const DIRECTORY_SEPARATOR;
 use function config_path;
-use function getcwd;
 use function str_starts_with;
 
 /**
@@ -26,6 +26,10 @@ use function str_starts_with;
 class NoEnvCallsOutsideOfConfigRule implements Rule
 {
     use HasContainer;
+
+    public function __construct(private FileHelper $fileHelper)
+    {
+    }
 
     public function getNodeType(): string
     {
@@ -69,6 +73,6 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
     protected function isCalledOutsideOfPackageConfig(Scope $scope): bool
     {
-        return str_starts_with($scope->getFile(), getcwd() . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR) === false;
+        return str_starts_with($scope->getFile(), $this->fileHelper->absolutizePath('config') . DIRECTORY_SEPARATOR) === false;
     }
 }

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -13,7 +13,9 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
+use const DIRECTORY_SEPARATOR;
 use function config_path;
+use function getcwd;
 use function str_starts_with;
 
 /**
@@ -47,7 +49,7 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
             return [];
         }
 
-        if (! $this->isCalledOutsideOfPackageConfig($node, $scope)) {
+        if (! $this->isCalledOutsideOfPackageConfig($scope)) {
             return [];
         }
 
@@ -65,7 +67,7 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
         return str_starts_with($scope->getFile(), config_path()) === false;
     }
 
-    protected function isCalledOutsideOfPackageConfig(FuncCall $call, Scope $scope): bool
+    protected function isCalledOutsideOfPackageConfig(Scope $scope): bool
     {
         return str_starts_with($scope->getFile(), getcwd() . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR) === false;
     }

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -47,6 +47,10 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
             return [];
         }
 
+        if (! $this->isCalledOutsideOfPackageConfig($node, $scope)) {
+            return [];
+        }
+
         return [
             RuleErrorBuilder::message("Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.")
                 ->identifier('larastan.noEnvCallsOutsideOfConfig')
@@ -59,5 +63,10 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
         return str_starts_with($scope->getFile(), config_path()) === false;
+    }
+
+    protected function isCalledOutsideOfPackageConfig(FuncCall $call, Scope $scope): bool
+    {
+        return basename(dirname($scope->getFile())) !== 'config';
     }
 }

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -6,6 +6,7 @@ namespace Tests\Rules;
 
 use Illuminate\Foundation\Application;
 use Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -14,16 +15,22 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
 {
     protected function setUp(): void
     {
-        $this->overrideConfigPath(__DIR__ . '/data/config');
+        $this->overrideConfigPath(__DIR__ . '/data/config_path');
     }
 
     protected function getRule(): Rule
     {
-        return new NoEnvCallsOutsideOfConfigRule();
+        return new NoEnvCallsOutsideOfConfigRule(new FileHelper(__DIR__ . '/data/'));
     }
 
     /** @test */
     public function itDoesNotFailForEnvCallsInsideConfigDirectory(): void
+    {
+        $this->analyse([__DIR__ . '/data/config_path/env-calls.php'], []);
+    }
+
+    /** @test */
+    public function itDoesNotFailForEnvCallsInsidePackageConfigDirectory(): void
     {
         $this->analyse([__DIR__ . '/data/config/env-calls.php'], []);
     }

--- a/tests/Rules/data/config_path/env-calls.php
+++ b/tests/Rules/data/config_path/env-calls.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Tests\Rules\Data;
+
+env('foo');
+\env('bar');


### PR DESCRIPTION
- Resolves #2173

**Changes**

-  Support packages config file 
> ```
>Line   packages/PackageName/config/config.php
> ------ ----------------------------------------------------------------------
>  6      Called 'env' outside of the config directory which returns null when
>         the config is cached, use 'config'.
>         🪪  larastan.noEnvCallsOutsideOfConfig
>```

