### PR TITLE
Fix/ulid or UUID primary key

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -92,16 +92,22 @@ class ModelPropertyHelper
     {
         try {
             /** @var Model $modelInstance */
-            $modelInstance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
+            $modelInstance = $classReflection->getNativeReflection()->newInstance();
         } catch (ReflectionException) {
             throw new ShouldNotHappenException();
         }
 
         $tableName = $modelInstance->getTable();
 
+        $isScalar = $this->stringResolver->resolve($modelInstance->getKeyType())->isScalar()->yes();
+
         if (
             $propertyName === $modelInstance->getKeyName()
-            && (! array_key_exists($tableName, $this->tables) || ! array_key_exists($propertyName, $this->tables[$tableName]->columns))
+            && (
+                ! array_key_exists($tableName, $this->tables)
+                || ! array_key_exists($propertyName, $this->tables[$tableName]->columns)
+                || $isScalar
+            )
         ) {
             return new ModelProperty(
                 $classReflection,

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -98,10 +98,7 @@ class IntegrationTest extends PHPStanTestCase
             ],
         ];
 
-        yield 'ulid and uuid as primary keys' =>[
-            __DIR__ . '/data/ulid_and_uuid_as_primary_keys.php',
-            [],
-        ];
+        yield [ __DIR__ . '/data/ulid_and_uuid_as_primary_keys.php'];
     }
 
     /**

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -97,6 +97,11 @@ class IntegrationTest extends PHPStanTestCase
                 25 => ['Parameter #2 $lineTwo of class ModelPropertyMutatorAndCasting\Address constructor expects string, mixed given.'],
             ],
         ];
+
+        yield 'ulid and uuid as primary keys' =>[
+            __DIR__ . '/data/ulid_and_uuid_as_primary_keys.php',
+            [],
+        ];
     }
 
     /**

--- a/tests/Integration/data/ulid_and_uuid_as_primary_keys.php
+++ b/tests/Integration/data/ulid_and_uuid_as_primary_keys.php
@@ -1,0 +1,12 @@
+<?php
+
+function string_param(string $param): void
+{
+    // Do something with param
+}
+
+$ulidModel = \App\UlidModel::firstOrFail();
+$uuidModel = \App\UuidModel::firstOrFail();
+
+string_param($ulidModel->id);
+string_param($uuidModel->id);

--- a/tests/application/app/UlidModel.php
+++ b/tests/application/app/UlidModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+final class UlidModel extends Model
+{
+    use HasUlids;
+}

--- a/tests/application/app/UuidModel.php
+++ b/tests/application/app/UuidModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+final class UuidModel extends Model
+{
+    use HasUuids;
+}

--- a/tests/application/database/migrations/2025-01-30_create_ulid_and_uuid_model_tables.php
+++ b/tests/application/database/migrations/2025-01-30_create_ulid_and_uuid_model_tables.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use App\Role;
+use App\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UlidAndUuidTableMigration extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ulid_models', static function (Blueprint $table) {
+            $table->ulid('id')->primary();
+        });
+        Schema::create('uuid_models', static function (Blueprint $table) {
+            $table->ulid('id')->primary();
+        });
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes (There are none)

Fixes #2188.

**Changes**

Currently, there is an error in larastan which treats primary uuids or ulids without further documentation as an int. Laravel however returns them as string. This PR fixes this by aligning larastan's behaviour to Laravel's. 

**Breaking changes**

None