### PR TITLE
Test GenericStaticType - 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/pipeline": "^11.15.0",
         "illuminate/support": "^11.15.0",
         "phpmyadmin/sql-parser": "^5.9.0",
-        "phpstan/phpstan": "^2.0.3"
+        "phpstan/phpstan": "^2.1.3"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",


### PR DESCRIPTION
I just added support for `static<...>` to PHPStan: https://github.com/phpstan/phpstan-src/commit/0c1f22ad73fea06e7ef3c5ea0b936700057f6062 (to both 1.12.x and 2.1.x)

@canvural has some concerns about compatibility with Larastan so I'm opening PRs to test both 2.x and 3.x branches.

2.x here: https://github.com/larastan/larastan/pull/2190