### PR TITLE
[3.x] fix: collection template types being overwritten

### DIFF
--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -14,11 +14,11 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
+use function collect;
+use function count;
 use function in_array;
 
 final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
@@ -79,29 +79,15 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 
         $classNames = $modelType->getObjectClassNames();
 
-        if ($classNames !== [] && $modelType->isObject()->yes() && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $collectionClassName = $this->collectionHelper->determineCollectionClassName($classNames[0]);
-
-            $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
-
-            if (! $collectionReflection->isGeneric()) {
-                // Not generic. So return the type as is
-                return new ObjectType($collectionClassName);
-            }
-
-            $typeMap = $collectionReflection->getActiveTemplateTypeMap();
-
-            // Specifies key and value
-            if ($typeMap->count() === 2) {
-                return new GenericObjectType($collectionClassName, [new IntegerType(), $modelType]);
-            }
-
-            // Specifies only value
-            if (($typeMap->count() === 1) && $typeMap->hasType('TModel')) {
-                return new GenericObjectType($collectionClassName, [$modelType]);
-            }
+        if (count($classNames) === 0 || ! in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            return null;
         }
 
-        return null;
+        return TypeCombinator::union(
+            ...collect($classNames)
+                ->map(fn ($className) => $this->collectionHelper->determineCollectionClass($className, $modelType))
+                ->filter()
+                ->all(),
+        );
     }
 }

--- a/src/Support/CollectionHelper.php
+++ b/src/Support/CollectionHelper.php
@@ -99,8 +99,10 @@ final class CollectionHelper
         }
     }
 
-    public function determineCollectionClass(string $modelClassName): Type
+    public function determineCollectionClass(string $modelClassName, Type|null $modelType = null): Type
     {
+        $modelType ??= new ObjectType($modelClassName);
+
         $collectionClassName  = $this->determineCollectionClassName($modelClassName);
         $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
 
@@ -109,12 +111,12 @@ final class CollectionHelper
 
             // Specifies key and value
             if ($typeMap->count() === 2) {
-                return new GenericObjectType($collectionClassName, [new IntegerType(), new ObjectType($modelClassName)]);
+                return new GenericObjectType($collectionClassName, [new IntegerType(), $modelType]);
             }
 
             // Specifies only value
             if (($typeMap->count() === 1) && $typeMap->hasType('TModel')) {
-                return new GenericObjectType($collectionClassName, [new ObjectType($modelClassName)]);
+                return new GenericObjectType($collectionClassName, [$modelType]);
             }
         }
 
@@ -137,13 +139,14 @@ final class CollectionHelper
                 return $traverse($type);
             }
 
-            $models = $type->getTemplateType(EloquentCollection::class, 'TModel')->getObjectClassNames();
+            $templateType = $type->getTemplateType(EloquentCollection::class, 'TModel');
+            $models       = $templateType->getObjectClassNames();
 
-            if (count($models) === 0) {
-                return $type;
-            }
-
-            return TypeCombinator::union(...array_map([$this, 'determineCollectionClass'], $models));
+            return match (count($models)) {
+                0 => $type,
+                1 => $this->determineCollectionClass($models[0], $templateType),
+                default => TypeCombinator::union(...array_map(fn ($m) => $this->determineCollectionClass($m), $models)),
+            };
         });
     }
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -25,6 +25,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1760.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1830.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1985.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2044.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2073.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2111.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/conditionable.php');

--- a/tests/Type/data/bug-2044.php
+++ b/tests/Type/data/bug-2044.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug2044;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+use function PHPStan\Testing\assertType;
+
+/** @template TModel of \Illuminate\Database\Eloquent\Model */
+class Repository
+{
+    /** @var Builder<TModel> */
+    private Builder $query;
+
+    /** @return Collection<int, TModel> */
+    public function all(): Collection
+    {
+        $models = $this->query->get();
+        assertType('Illuminate\Database\Eloquent\Collection<int, TModel of Illuminate\Database\Eloquent\Model (class Bug2044\Repository, argument)>', $models);
+
+        return $models;
+    }
+}


### PR DESCRIPTION
Hello!

This fix was included with #1990, but it looks like it didn't make it into the release. This closes #2044 by preventing the collection template types from being overwritten.

Thanks!