### PR TITLE
[3.x] fix: property type for uuid and ulid primary keys

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -448,6 +448,9 @@ services:
             - phpstan.phpDoc.typeNodeResolverExtension
 
     -
+        class: Larastan\Larastan\Support\ModelHelper
+
+    -
         class: Larastan\Larastan\Properties\MigrationHelper
         arguments:
             databaseMigrationPath: %databaseMigrationsPath%

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Properties;
 
+use Larastan\Larastan\Support\ModelHelper;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
@@ -29,6 +30,7 @@ class MigrationHelper
         private FileHelper $fileHelper,
         private bool $disableMigrationScan,
         private ReflectionProvider $reflectionProvider,
+        private ModelHelper $modelHelper,
     ) {
     }
 
@@ -47,7 +49,7 @@ class MigrationHelper
             $this->databaseMigrationPath = [database_path('migrations')];
         }
 
-        $schemaAggregator = new SchemaAggregator($this->reflectionProvider, $tables);
+        $schemaAggregator = new SchemaAggregator($this->modelHelper, $this->reflectionProvider, $tables);
         $filesArray       = $this->getMigrationFiles();
 
         if (empty($filesArray)) {

--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -15,12 +15,12 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon as IlluminateCarbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Stringable as IlluminateStringable;
+use Larastan\Larastan\Support\ModelHelper;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
@@ -41,7 +41,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use ReflectionException;
 use stdClass;
 use Stringable;
 
@@ -60,6 +59,7 @@ class ModelCastHelper
 
     public function __construct(
         protected ReflectionProvider $reflectionProvider,
+        protected ModelHelper $modelHelper,
     ) {
     }
 
@@ -239,14 +239,8 @@ class ModelCastHelper
             return $this->modelCasts[$className];
         }
 
-        try {
-            /** @var Model $modelInstance */
-            $modelInstance = $modelClassReflection->getNativeReflection()->newInstanceWithoutConstructor();
-        } catch (ReflectionException) {
-            throw new ShouldNotHappenException();
-        }
-
-        $modelCasts = $modelInstance->getCasts();
+        $modelInstance = $this->modelHelper->getModelInstance($modelClassReflection);
+        $modelCasts    = $modelInstance?->getCasts() ?? [];
 
         $castsMethodReturnType = $modelClassReflection->getMethod(
             'casts',

--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -8,19 +8,19 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Larastan\Larastan\Reflection\ReflectionHelper;
+use Larastan\Larastan\Support\ModelHelper;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
-use ReflectionException;
 
 use function array_key_exists;
 use function array_map;
+use function assert;
 use function count;
 use function in_array;
 use function is_string;
@@ -36,6 +36,7 @@ class ModelPropertyHelper
         private MigrationHelper $migrationHelper,
         private SquashedMigrationHelper $squashedMigrationHelper,
         private ModelCastHelper $modelCastHelper,
+        private ModelHelper $modelHelper,
     ) {
     }
 
@@ -68,10 +69,9 @@ class ModelPropertyHelper
             return false;
         }
 
-        try {
-            /** @var Model $modelInstance */
-            $modelInstance = $classReflectionOrTable->getNativeReflection()->newInstanceWithoutConstructor();
-        } catch (ReflectionException) {
+        $modelInstance = $this->modelHelper->getModelInstance($classReflectionOrTable);
+
+        if ($modelInstance === null) {
             return false;
         }
 
@@ -90,12 +90,8 @@ class ModelPropertyHelper
 
     public function getDatabaseProperty(ClassReflection $classReflection, string $propertyName): ModelProperty
     {
-        try {
-            /** @var Model $modelInstance */
-            $modelInstance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
-        } catch (ReflectionException) {
-            throw new ShouldNotHappenException();
-        }
+        $modelInstance = $this->modelHelper->getModelInstance($classReflection);
+        assert($modelInstance !== null);
 
         $tableName = $modelInstance->getTable();
 

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -7,11 +7,11 @@ namespace Larastan\Larastan\Properties;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Larastan\Larastan\Support\ModelHelper;
 use PhpParser;
 use PhpParser\NodeFinder;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
-use ReflectionException;
 
 use function array_key_exists;
 use function array_merge;
@@ -25,8 +25,11 @@ use function strtolower;
 final class SchemaAggregator
 {
     /** @param array<string, SchemaTable> $tables */
-    public function __construct(private ReflectionProvider $reflectionProvider, public array $tables = [])
-    {
+    public function __construct(
+        private ModelHelper $modelHelper,
+        private ReflectionProvider $reflectionProvider,
+        public array $tables = [],
+    ) {
     }
 
     /** @param  array<int, PhpParser\Node\Stmt> $stmts */
@@ -251,6 +254,7 @@ final class SchemaAggregator
                     $columnName = $secondArg->value;
                 }
 
+                /** @phpstan-ignore argument.type (not a class string) */
                 $type = $this->getModelReferenceType($modelClass);
                 if ($unsigned && ($type === null || $type === 'int')) {
                     $type = 'non-negative-int';
@@ -419,13 +423,12 @@ final class SchemaAggregator
         $this->tables[$newTableName] = $table;
     }
 
+    /** @param class-string<Model> $modelClass */
     private function getModelReferenceType(string $modelClass): string|null
     {
-        $classReflection = $this->reflectionProvider->getClass($modelClass);
-        try {
-            /** @var Model $modelInstance */
-            $modelInstance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
-        } catch (ReflectionException) {
+        $modelInstance = $this->modelHelper->getModelInstance($modelClass);
+
+        if ($modelInstance === null) {
             return null;
         }
 

--- a/src/Support/ModelHelper.php
+++ b/src/Support/ModelHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use Throwable;
+
+use function is_string;
+
+/** @internal */
+final class ModelHelper
+{
+    public function __construct(private ReflectionProvider $reflectionProvider)
+    {
+    }
+
+    /** @param ClassReflection|class-string<Model> $model */
+    public function getModelInstance(ClassReflection|string $model): Model|null
+    {
+        if (is_string($model)) {
+            if (! $this->reflectionProvider->hasClass($model)) {
+                return null;
+            }
+
+            $model = $this->reflectionProvider->getClass($model);
+        }
+
+        if ($model->isAbstract()) {
+            return null;
+        }
+
+        try {
+            /** @var Model $modelInstance */
+            $modelInstance = $model->getNativeReflection()->newInstance();
+        } catch (Throwable) {
+            /** @var Model $modelInstance */
+            $modelInstance = $model->getNativeReflection()->newInstanceWithoutConstructor();
+        }
+
+        return $modelInstance;
+    }
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -28,6 +28,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1985.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2073.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2111.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2188.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/conditionable.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/container-array-access.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/container-make.php');

--- a/tests/Type/data/bug-2188.php
+++ b/tests/Type/data/bug-2188.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\UlidModel;
+use App\UuidModel;
+
+use function PHPStan\Testing\assertType;
+
+function test(UlidModel $ulid, UuidModel $uuid): void
+{
+    assertType('string', $ulid->id);
+    assertType('string', $uuid->id);
+}

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -6,8 +6,10 @@ namespace Tests\Unit;
 
 use Larastan\Larastan\Properties\MigrationHelper;
 use Larastan\Larastan\Properties\SchemaTable;
+use Larastan\Larastan\Support\ModelHelper;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -19,27 +21,30 @@ class MigrationHelperTest extends PHPStanTestCase
 
     private FileHelper $fileHelper;
 
+    private ModelHelper $modelHelper;
+
+    private ReflectionProvider $reflectionProvider;
+
     public function setUp(): void
     {
         $this->parser             = self::getContainer()->getService('currentPhpVersionSimpleDirectParser');
         $this->fileHelper         = self::getContainer()->getByType(FileHelper::class);
-        $this->reflectionProvider = $this->createReflectionProvider();
+        $this->reflectionProvider = self::createReflectionProvider();
+        $this->modelHelper        = new ModelHelper($this->reflectionProvider);
     }
 
     #[Test]
     public function it_will_return_empty_array_if_migrations_path_is_not_a_directory(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, ['foobar'], $this->fileHelper, false, $this->reflectionProvider);
+        $tables = $this->getMigrationHelper(['foobar'])->initializeTables();
 
-        self::assertSame([], $migrationHelper->initializeTables());
+        self::assertSame([], $tables);
     }
 
     #[Test]
     public function it_can_read_basic_migrations_and_create_table_structure(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/basic_migration'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/basic_migration'])->initializeTables();
 
         $this->assertUsersTableSchema($tables);
     }
@@ -47,9 +52,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_read_schema_definitions_from_any_method_in_class(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_with_different_methods'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_with_different_methods'])->initializeTables();
 
         $this->assertUsersTableSchema($tables);
     }
@@ -57,9 +60,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_read_schema_definitions_with_multiple_create_and_drop_methods_for_one_table(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/complex_migrations'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/complex_migrations'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -80,12 +81,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_read_additional_directories(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [
-            __DIR__ . '/data/basic_migration',
-            __DIR__ . '/data/additional_migrations',
-        ], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/basic_migration', __DIR__ . '/data/additional_migrations'])->initializeTables();
 
         self::assertCount(2, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -95,11 +91,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_use_of_after_method_in_migration(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [
-            __DIR__ . '/data/migrations_using_after_method',
-        ], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_using_after_method'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -115,11 +107,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_alter_table_and_column_rename(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [
-            __DIR__ . '/data/rename_migrations',
-        ], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/rename_migrations'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayNotHasKey('users', $tables);
@@ -133,9 +121,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_soft_deletes(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_using_soft_deletes'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -146,9 +132,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_soft_deletes_tz(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_soft_deletes_tz'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_using_soft_deletes_tz'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -159,9 +143,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_default_arguments(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_default_arguments'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migration_with_default_arguments'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -182,9 +164,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_connection_before_schema_create(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_schema_connection'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migration_with_schema_connection'])->initializeTables();
 
         $this->assertUsersTableSchema($tables);
     }
@@ -192,12 +172,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_disable_migration_scanning(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [
-            __DIR__ . '/data/basic_migration',
-            __DIR__ . '/data/additional_migrations',
-        ], $this->fileHelper, true, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/basic_migration', __DIR__ . '/data/additional_migrations'], true)->initializeTables();
 
         self::assertSame([], $tables);
     }
@@ -205,9 +180,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_nullable_in_migrations(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_nullable'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_using_nullable'])->initializeTables();
 
         self::assertSame(false, $tables['users']->columns['name']->nullable);
         self::assertSame(true, $tables['users']->columns['email']->nullable);
@@ -231,11 +204,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_array_passed_to_drop_column(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [
-            __DIR__ . '/data/migrations_using_drop_column',
-        ], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migrations_using_drop_column'])->initializeTables();
 
         self::assertCount(1, $tables);
         self::assertArrayHasKey('users', $tables);
@@ -246,9 +215,7 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_if_statements(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/conditional_migrations'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/conditional_migrations'])->initializeTables();
 
         self::assertArrayHasKey('id', $tables['users']->columns);
         self::assertArrayHasKey('name', $tables['users']->columns);
@@ -260,12 +227,16 @@ class MigrationHelperTest extends PHPStanTestCase
     #[Test]
     public function it_can_handle_migrations_with_const_as_table(): void
     {
-        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_const'], $this->fileHelper, false, $this->reflectionProvider);
-
-        $tables = $migrationHelper->initializeTables();
+        $tables = $this->getMigrationHelper([__DIR__ . '/data/migration_with_const'])->initializeTables();
 
         self::assertArrayHasKey('id', $tables['users']->columns);
         self::assertArrayHasKey('name', $tables['users']->columns);
         self::assertArrayHasKey('email', $tables['users']->columns);
+    }
+
+    /** @param string[] $paths */
+    private function getMigrationHelper(array $paths, bool $scan = false): MigrationHelper
+    {
+        return new MigrationHelper($this->parser, $paths, $this->fileHelper, $scan, $this->reflectionProvider, $this->modelHelper);
     }
 }

--- a/tests/application/app/UlidModel.php
+++ b/tests/application/app/UlidModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+final class UlidModel extends Model
+{
+    use HasUlids;
+}

--- a/tests/application/app/UuidModel.php
+++ b/tests/application/app/UuidModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+final class UuidModel extends Model
+{
+    use HasUuids;
+}

--- a/tests/application/database/migrations/2025-01-30_create_ulid_and_uuid_model_tables.php
+++ b/tests/application/database/migrations/2025-01-30_create_ulid_and_uuid_model_tables.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use App\Role;
+use App\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UlidAndUuidTableMigration extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ulid_models', static function (Blueprint $table) {
+            $table->ulid('id')->primary();
+        });
+        Schema::create('uuid_models', static function (Blueprint $table) {
+            $table->ulid('id')->primary();
+        });
+    }
+}


### PR DESCRIPTION
Closes #2188, supersedes #2187

 
**Changes**

This PR allows Larastan to properly detect the correct model key type when using unique string ids.

We also had a lot of places in the code where we were obtaining a model instance, moving this logic to a helper class removed the duplication and cleans up the code.

This has been released on my [fork](https://github.com/calebdw/larastan) if anyone would like to take advantage of this immediately.

Thanks!