### PR TITLE
[3.x] Add connection to Redis facade

### DIFF
--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 abstract class Facade {}
 
 /**
+ * @mixin \Illuminate\Redis\Connections\Connection
  * @mixin \Redis
  * @mixin \Illuminate\Redis\RedisManager
  * @mixin \Illuminate\Contracts\Redis\Factory

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -43,6 +43,7 @@ function test(): void
     assertType('bool', Storage::cloud()->deleteDirectory('foo'));
     assertType('string|false', Storage::putFile('foo', 'foo/bar'));
     assertType('mixed', Redis::get('foo'));
+    assertType('mixed', Redis::client());
 
     assertType('string', DummyFacade::foo());
     assertType('int', DummyFacade::bar());


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Exposes redis connection methods that are available to the facade. They are exposed in Laravel via `__call` to the Connection class.
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Redis/RedisManager.php#L276

Currently, using the `Redis::client()` method expects a parameter to be passed, when that is not actually the case, because the `\Redis` extension expects a parameter. Mixing in the connection class first fixes this.