### PR TITLE
[3.x] Fix trait error source

### DIFF
--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -51,7 +51,7 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
             RuleErrorBuilder::message("Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.")
                 ->identifier('larastan.noEnvCallsOutsideOfConfig')
                 ->line($node->getStartLine())
-                ->file($scope->getFile())
+                ->file($scope->getFile(), $scope->getFileDescription())
                 ->build(),
         ];
     }

--- a/src/Rules/NoModelMakeRule.php
+++ b/src/Rules/NoModelMakeRule.php
@@ -60,7 +60,7 @@ class NoModelMakeRule implements Rule
             RuleErrorBuilder::message("Called 'Model::make()' which performs unnecessary work, use 'new Model()'.")
                 ->identifier('larastan.noModelMake')
                 ->line($node->getStartLine())
-                ->file($scope->getFile())
+                ->file($scope->getFile(), $scope->getFileDescription())
                 ->build(),
         ];
     }

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -37,6 +37,45 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
         ]);
     }
 
+    /** @test */
+    public function itDoesNotReportTraitFunctionsThatHaveBeenOverridden(): void
+    {
+        $this->analyse([
+            __DIR__ . '/data/EnvUsageClassOverride.php',
+            __DIR__ . '/data/EnvUsageTrait.php',
+        ], []);
+    }
+
+    /** @test */
+    public function itReportsEnvCallsInTraitRatherThanClass(): void
+    {
+        $actualErrors = $this->gatherAnalyserErrors([
+            __DIR__ . '/data/EnvUsageClass.php',
+            __DIR__ . '/data/EnvUsageTrait.php',
+        ]);
+
+        $this->assertCount(2, $actualErrors);
+        $this->assertSame(
+            "Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.",
+            $actualErrors[0]->getMessage(),
+        );
+        $this->assertSame(
+            __DIR__ . '/data/EnvUsageTrait.php (in context of class Tests\Rules\Data\EnvUsageClass)',
+            $actualErrors[0]->getFile(),
+        );
+        $this->assertSame(17, $actualErrors[0]->getLine());
+
+        $this->assertSame(
+            "Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.",
+            $actualErrors[1]->getMessage(),
+        );
+        $this->assertSame(
+            __DIR__ . '/data/EnvUsageTrait.php (in context of class Tests\Rules\Data\EnvUsageClass)',
+            $actualErrors[1]->getFile(),
+        );
+        $this->assertSame(18, $actualErrors[1]->getLine());
+    }
+
     protected function overrideConfigPath(string $path): void
     {
         $app = Application::getInstance();

--- a/tests/Rules/NoModelMakeRuleTest.php
+++ b/tests/Rules/NoModelMakeRuleTest.php
@@ -18,14 +18,36 @@ class NoModelMakeRuleTest extends RuleTestCase
 
     public function testNoFalsePositives(): void
     {
-        $this->analyse([__DIR__ . '/data/CorrectModelInstantiation.php'], []);
+        $this->analyse([
+            __DIR__ . '/data/CorrectModelInstantiation.php',
+            __DIR__ . '/data/ModelMakeTrait.php',
+        ], []);
     }
 
     public function testModelMake(): void
     {
         $this->analyse([__DIR__ . '/data/ModelMake.php'], [
-            ["Called 'Model::make()' which performs unnecessary work, use 'new Model()'.", 13],
-            ["Called 'Model::make()' which performs unnecessary work, use 'new Model()'.", 20],
+            ["Called 'Model::make()' which performs unnecessary work, use 'new Model()'.", 15],
+            ["Called 'Model::make()' which performs unnecessary work, use 'new Model()'.", 22],
         ]);
+    }
+
+    public function testReportsModelMakeCallsInTraitRatherThanClass(): void
+    {
+        $actualErrors = $this->gatherAnalyserErrors([
+            __DIR__ . '/data/ModelMake.php',
+            __DIR__ . '/data/ModelMakeTrait.php',
+        ]);
+
+        $this->assertCount(3, $actualErrors);
+        $this->assertSame(
+            "Called 'Model::make()' which performs unnecessary work, use 'new Model()'.",
+            $actualErrors[0]->getMessage(),
+        );
+        $this->assertSame(
+            __DIR__ . '/data/ModelMakeTrait.php (in context of class Tests\Rules\Data\ModelMake)',
+            $actualErrors[0]->getFile(),
+        );
+        $this->assertSame(13, $actualErrors[0]->getLine());
     }
 }

--- a/tests/Rules/data/CorrectModelInstantiation.php
+++ b/tests/Rules/data/CorrectModelInstantiation.php
@@ -9,6 +9,8 @@ use App\User;
 
 class CorrectModelInstantiation
 {
+    use ModelMakeTrait;
+
     public function construct(): User
     {
         return new User();
@@ -22,5 +24,15 @@ class CorrectModelInstantiation
     public function relationMake(): Group
     {
         return (new User)->group()->make();
+    }
+
+    public function makeFromTrait(): User
+    {
+        return $this->makeInTrait();
+    }
+
+    protected function makeInTrait(): User
+    {
+        return new User;
     }
 }

--- a/tests/Rules/data/EnvUsageClass.php
+++ b/tests/Rules/data/EnvUsageClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+class EnvUsageClass
+{
+    use EnvUsageTrait;
+
+    public function test(): void
+    {
+        $this->callEnv();
+    }
+}

--- a/tests/Rules/data/EnvUsageClassOverride.php
+++ b/tests/Rules/data/EnvUsageClassOverride.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+class EnvUsageClassOverride
+{
+    use EnvUsageTrait;
+
+    public function test(): void
+    {
+        $this->callEnv();
+    }
+
+    protected function callEnv(): void
+    {
+        //
+    }
+}

--- a/tests/Rules/data/EnvUsageTrait.php
+++ b/tests/Rules/data/EnvUsageTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use function Foo\Bar\env as scopedEnv;
+
+trait EnvUsageTrait
+{
+    protected function callEnv(): void
+    {
+        // no report for namespaced calls
+        \Foo\Bar\env('bar');
+        scopedEnv('foo');
+
+        env('foo');
+        \env('bar');
+    }
+}

--- a/tests/Rules/data/ModelMake.php
+++ b/tests/Rules/data/ModelMake.php
@@ -8,6 +8,8 @@ use App\User;
 
 class ModelMake
 {
+    use ModelMakeTrait;
+
     public function make(): User
     {
         return User::make();
@@ -18,5 +20,10 @@ class ModelMake
         $class = User::class;
 
         return $class::make();
+    }
+
+    public function makeFromTrait(): User
+    {
+        return $this->makeInTrait();
     }
 }

--- a/tests/Rules/data/ModelMakeTrait.php
+++ b/tests/Rules/data/ModelMakeTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use App\User;
+
+trait ModelMakeTrait
+{
+    protected function makeInTrait(): User
+    {
+        return User::make();
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

When an analysis error triggers inside a trait, the error ends up reported as the class using the trait rather than the trait itself. This causes it to be impossible to ignore with the ignore comments.

I ran into this with an env call within a trait that I wanted to ignore. I thought it made sense to update `noModelMake` as well, but I wasn't sure if it made sense for the model appends rule so I left that alone.


**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

This passes the file description into the error builder, which is the file as usual when not a trait or the trait file when within a trait (with a reference to the class using it).

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

None
