### PR TITLE
Add possibility to specify config directory

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -396,6 +396,15 @@ parameters:
     noEnvCallsOutsideOfConfig: false
 ```
 
+By default, this rule checks for env calls outside the application config directory. If your configuration files are stored elsewhere, you can use the configDirectories option to specify them.
+
+```neon
+parameters:
+    configDirectories:
+        - src/config
+        - tests
+```
+
 ## ModelAppendsRule
 
 Checks model's `$appends` property for computed properties. The properties added to `$appends` array should both exist in the model and be computed properties.

--- a/extension.neon
+++ b/extension.neon
@@ -19,6 +19,7 @@ parameters:
     databaseMigrationsPath: []
     disableMigrationScan: false
     disableSchemaScan: false
+    configDirectories: []
     viewDirectories: []
     checkModelProperties: false
     checkUnusedViews: false
@@ -33,6 +34,7 @@ parametersSchema:
     noUnnecessaryCollectionCallExcept: listOf(string())
     databaseMigrationsPath: listOf(string())
     disableMigrationScan: bool()
+    configDirectories: listOf(string())
     viewDirectories: listOf(string())
     squashedMigrationsPath: listOf(string())
     disableSchemaScan: bool()
@@ -369,6 +371,8 @@ services:
 
     -
         class: Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule
+        arguments:
+            configDirectories: %configDirectories%
 
     -
         class: Larastan\Larastan\Rules\NoModelMakeRule

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -19,7 +19,7 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return new NoEnvCallsOutsideOfConfigRule();
+        return new NoEnvCallsOutsideOfConfigRule([__DIR__ . '/data/config'], $this->getFileHelper());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #2173
Replaces #2183 (solution based on https://github.com/larastan/larastan/pull/2183#issuecomment-2671705754)

**Changes**
This adds a config parameter for specifying the paths where `env()` is allowed:

```neon
parameters:
    configDirectories:
        - src/config
        - tests
```

This is useful for packages with vendor configs, or applications that uses `env()` to drive some of there tests.