### PR TITLE
Better default for viewDirectories

### DIFF
--- a/src/Support/ViewFileHelper.php
+++ b/src/Support/ViewFileHelper.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Support;
 
 use Generator;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Larastan\Larastan\Concerns\HasContainer;
 use PHPStan\File\FileHelper;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
 
+use function array_merge;
+use function array_values;
 use function count;
 use function explode;
 use function is_dir;
 use function iterator_to_array;
-use function resource_path;
 use function str_contains;
 use function str_replace;
 
@@ -22,6 +25,8 @@ use const DIRECTORY_SEPARATOR;
 
 final class ViewFileHelper
 {
+    use HasContainer;
+
     /** @param  list<non-empty-string> $viewDirectories */
     public function __construct(private array $viewDirectories, private FileHelper $fileHelper)
     {
@@ -29,7 +34,14 @@ final class ViewFileHelper
             return;
         }
 
-        $this->viewDirectories = [resource_path('views')]; // @phpstan-ignore-line
+        $finder = $this->resolve(ViewFactory::class)->getFinder();
+
+        $viewDirectories = array_merge(
+            $finder->getPaths(),
+            ...array_values($finder->getHints()),
+        );
+
+        $this->viewDirectories = $viewDirectories; // @phpstan-ignore-line
     }
 
     public function getAllViewFilePaths(): Generator


### PR DESCRIPTION
**Changes**

This gets all configured view paths from the application rather then just the main view folder. This way the user won't have to configure any view folders, which can be hard if they are not aware of what vendor folder templates are being automatically loaded from (see #2173).

I use the same code for this task in the latest version of Bladestan.

I would argue that this makes the viewDirectories config option redundant, but I did not remove it in case you still want to provide it. If you agree and think I should also remove the config option then let me know and I can do so as well.