### PR TITLE
Make Query Builder whereColumn doc type match laravel 11

### DIFF
--- a/stubs/common/QueryBuilder.stub
+++ b/stubs/common/QueryBuilder.stub
@@ -40,7 +40,7 @@ class Builder
     /**
      * Add a "where" clause comparing two columns to the query.
      *
-     * @param  string|array<array-key, mixed>  $first
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|array<array-key, mixed>  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string|null  $boolean


### PR DESCRIPTION
**Changes**
Change the Builder stub to also allow Expression in **whereColumn**-method like in Laravels php docs

Laravel 11/12 builder reference:
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Query/Builder.php
https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Query/Builder.php


