### PR TITLE
Add fallback to existing classes/interfaces for improved type resolution

### DIFF
--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -43,7 +43,7 @@ final class AppMakeHelper
                     $resolved = $this->resolve($constantString->getValue());
 
                     if ($resolved === null) {
-                        if ($constantString->isClassString()) {
+                        if ($constantString->isClassString()->yes()) {
                             $types[] = $constantString->getClassStringObjectType();
                             continue;
                         }

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -43,8 +43,8 @@ final class AppMakeHelper
                     $resolved = $this->resolve($constantString->getValue());
 
                     if ($resolved === null) {
-                        if (class_exists($constantString->getValue()) || interface_exists($constantString->getValue())) {
-                            $types[] = new ObjectType($constantString->getValue());
+                        if ($constantString->isClassString()) {
+                            $types[] = $constantString->getClassStringObjectType();
                             continue;
                         }
 

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -16,7 +16,9 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Throwable;
 
+use function class_exists;
 use function count;
+use function interface_exists;
 
 final class AppMakeHelper
 {
@@ -41,6 +43,11 @@ final class AppMakeHelper
                     $resolved = $this->resolve($constantString->getValue());
 
                     if ($resolved === null) {
+                        if (class_exists($constantString->getValue()) || interface_exists($constantString->getValue())) {
+                            $types[] = new ObjectType($constantString->getValue());
+                            continue;
+                        }
+
                         return new ErrorType();
                     }
 

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -16,9 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Throwable;
 
-use function class_exists;
 use function count;
-use function interface_exists;
 
 final class AppMakeHelper
 {

--- a/tests/Type/data/FailsAtRuntime.php
+++ b/tests/Type/data/FailsAtRuntime.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class FailsAtRuntime
+{
+    public function __construct()
+    {
+        throw new \Exception("Cannot resolve class dynamically.");
+    }
+}

--- a/tests/Type/data/application-make.php
+++ b/tests/Type/data/application-make.php
@@ -2,6 +2,7 @@
 
 namespace ApplicationMake;
 
+use FailsAtRuntime;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
@@ -15,10 +16,12 @@ function test(Application $app, ApplicationContract $app2, string $model): void
     assertType('Illuminate\Config\Repository', $app->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app->resolve(FailsAtRuntime::class));
 
     assertType('Illuminate\Config\Repository', $app2->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app2->resolve(FailsAtRuntime::class));
 
     assertType('mixed', $app->make($model));
     assertType('mixed', $app->makeWith($model));


### PR DESCRIPTION
### Overview:
This change improves type resolution in Larastan by falling back to the class string if it cannot be instantiated in the current environment, but only if the given class or interface exists.

### Problem:
When Larastan cannot instantiate a class or interface due to missing configuration or other environment-specific issues, it falls back to `mixed` without a clear indication. This leads to missing or ambiguous type information, requiring manual type hints, an error-prone ultimately and unnecessary workaround.

### Solution:
- Check if the class or interface exists before giving up.
- If it exists, use the class/interface as the type.
- If it does not exist, the error handling remains unchanged.

### Benefits:
- **Improved Type Resolution**:  Safely preserves type information when instantiation fails.
- **Compatibility**: No breaking changes; maintains existing behavior.
- **Fewer Workarounds**: Reduces the need for manual type hints when Larastan previously failed to resolve types.

This change makes Larastan's type resolution more reliable and predictable, helping developers avoid manual workarounds and improving overall analysis in dynamic environments.

It should also resolve the issue that @rudiedirkx encountered in #2128, which stemmed from environment differences between local development and GitHub CI. Based on testing, this fix eliminates around 140 issues in my application, which contains 3,700 classes, and makes an unknown number of workarounds redundant.