### PR TITLE
[3.x] fix: remove use of deprecated isSubclassOf() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/http": "^11.41.3 || ^12.0",
         "illuminate/pipeline": "^11.41.3 || ^12.0",
         "illuminate/support": "^11.41.3 || ^12.0",
-        "phpstan/phpstan": "^2.1.3"
+        "phpstan/phpstan": "^2.1.8"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",

--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -83,10 +83,10 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
             $classNames         = [$classReflection->getName()];
             $macroTraitProperty = 'macros';
 
-            if ($classReflection->isSubclassOf(Builder::class)) {
+            if ($classReflection->is(Builder::class)) {
                 $classNames[] = Builder::class;
             }
-        } elseif ($classReflection->isSubclassOf(Facade::class)) {
+        } elseif ($classReflection->is(Facade::class)) {
             $facadeClass = $classReflection->getName();
 
             if ($facadeClass === Auth::class) {

--- a/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
+++ b/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
@@ -32,7 +32,7 @@ class ModelFactoryMethodsClassReflectionExtension implements MethodsClassReflect
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if (! $classReflection->isSubclassOf(Factory::class)) {
+        if (! $classReflection->is(Factory::class)) {
             return false;
         }
 

--- a/src/Methods/Pipes/Facades.php
+++ b/src/Methods/Pipes/Facades.php
@@ -27,7 +27,7 @@ final class Facades implements PipeContract
 
         $found = false;
 
-        if ($classReflection->isSubclassOf(Facade::class)) {
+        if ($classReflection->is(Facade::class)) {
             $facadeClass = $classReflection->getName();
 
             if (ReflectionHelper::hasMethodTag($classReflection, $passable->getMethodName())) {

--- a/src/Methods/Pipes/Managers.php
+++ b/src/Methods/Pipes/Managers.php
@@ -22,7 +22,7 @@ final class Managers implements PipeContract
 
         $found = false;
 
-        if ($classReflection->isSubclassOf(Manager::class) && ! $classReflection->isAbstract()) {
+        if ($classReflection->is(Manager::class) && ! $classReflection->isAbstract()) {
             $driver = null;
 
             $concrete = $this->resolve(

--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -97,7 +97,7 @@ class ModelCastHelper
             return new ObjectType($cast);
         }
 
-        if ($classReflection->isSubclassOf(Castable::class)) {
+        if ($classReflection->is(Castable::class)) {
             $methodReflection = $classReflection->getNativeMethod('castUsing');
             $castUsingReturn  = $methodReflection->getVariants()[0]->getReturnType();
 
@@ -106,13 +106,13 @@ class ModelCastHelper
             }
         }
 
-        if ($classReflection->isSubclassOf(CastsAttributes::class)) {
+        if ($classReflection->is(CastsAttributes::class)) {
             $methodReflection = $classReflection->getNativeMethod('get');
 
             return $methodReflection->getVariants()[0]->getReturnType();
         }
 
-        if ($classReflection->isSubclassOf(CastsInboundAttributes::class)) {
+        if ($classReflection->is(CastsInboundAttributes::class)) {
             return $originalType;
         }
 
@@ -154,7 +154,7 @@ class ModelCastHelper
             return new ObjectType($cast);
         }
 
-        if ($classReflection->isSubclassOf(Castable::class)) {
+        if ($classReflection->is(Castable::class)) {
             $methodReflection = $classReflection->getNativeMethod('castUsing');
             $castUsingReturn  = $methodReflection->getVariants()[0]->getReturnType();
 
@@ -164,8 +164,8 @@ class ModelCastHelper
         }
 
         if (
-            $classReflection->isSubclassOf(CastsAttributes::class)
-            || $classReflection->isSubclassOf(CastsInboundAttributes::class)
+            $classReflection->is(CastsAttributes::class)
+            || $classReflection->is(CastsInboundAttributes::class)
         ) {
             $methodReflection = $classReflection->getNativeMethod('set');
             $parameters       = $methodReflection->getVariants()[0]->getParameters();

--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -56,7 +56,7 @@ class ModelPropertyHelper
             return array_key_exists($propertyName, $this->tables[$classReflectionOrTable]->columns);
         }
 
-        if (! $classReflectionOrTable->isSubclassOf(Model::class)) {
+        if (! $classReflectionOrTable->is(Model::class)) {
             return false;
         }
 
@@ -161,7 +161,7 @@ class ModelPropertyHelper
      */
     public function hasAccessor(ClassReflection $classReflection, string $propertyName, bool $strictGenerics = true): bool
     {
-        if (! $classReflection->isSubclassOf(Model::class)) {
+        if (! $classReflection->is(Model::class)) {
             return false;
         }
 

--- a/src/Properties/ModelRelationsExtension.php
+++ b/src/Properties/ModelRelationsExtension.php
@@ -35,7 +35,7 @@ final class ModelRelationsExtension implements PropertiesClassReflectionExtensio
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
-        if (! $classReflection->isSubclassOf(Model::class)) {
+        if (! $classReflection->is(Model::class)) {
             return false;
         }
 

--- a/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php
@@ -128,7 +128,7 @@ final class ModelFactoryDynamicStaticMethodReturnTypeExtension implements Dynami
 
         foreach ($factoryReflections as $factoryReflection) {
             if (
-                $factoryReflection->isSubclassOf(Factory::class)
+                $factoryReflection->is(Factory::class)
                 && ! $factoryReflection->isAbstract()
             ) {
                 return $factoryReflection;

--- a/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
@@ -56,7 +56,7 @@ class NewModelQueryDynamicMethodReturnTypeExtension implements DynamicMethodRetu
         $types = [];
 
         foreach ($classReflections as $classReflection) {
-            if (! $classReflection->isSubclassOf(Model::class)) {
+            if (! $classReflection->is(Model::class)) {
                 continue;
             }
 

--- a/src/Rules/DeferrableServiceProviderMissingProvidesRule.php
+++ b/src/Rules/DeferrableServiceProviderMissingProvidesRule.php
@@ -34,7 +34,7 @@ class DeferrableServiceProviderMissingProvidesRule implements Rule
         $classReflection = $node->getClassReflection();
 
         // This rule is only applicable to deferrable serviceProviders
-        if (! $classReflection->isSubclassOf(ServiceProvider::class) || ! $classReflection->implementsInterface(DeferrableProvider::class)) {
+        if (! $classReflection->is(ServiceProvider::class) || ! $classReflection->implementsInterface(DeferrableProvider::class)) {
             return [];
         }
 

--- a/src/Rules/ModelAppendsRule.php
+++ b/src/Rules/ModelAppendsRule.php
@@ -49,7 +49,7 @@ class ModelAppendsRule implements Rule
 
         $classReflection = $scope->getClassReflection();
 
-        if (! $classReflection?->isSubclassOf(Model::class)) {
+        if (! $classReflection?->is(Model::class)) {
             return [];
         }
 


### PR DESCRIPTION
Hello!

This removes the deprecated `ClassReflection::isSubclassOf()` calls: https://github.com/phpstan/phpstan/releases/tag/2.1.8

![image](https://github.com/user-attachments/assets/7fa8e41d-042f-47bc-9638-934d24443679)



Thanks!