### PR TITLE
[3.x] Use generics in Arrayable::toArray

### DIFF
--- a/stubs/common/Contracts/Support.stub
+++ b/stubs/common/Contracts/Support.stub
@@ -14,7 +14,7 @@ interface Arrayable
     /**
      * Get the instance as an array.
      *
-     * @return array<mixed>
+     * @return array<TKey, TValue>
      */
     public function toArray();
 }


### PR DESCRIPTION
Hey, heads up - first contribution to Larastan.

- [N/A] Added or updated tests
- [N/A] Documented user facing changes

Resolves #2239

**Changes**

Uses Arrayable's generics, for the return type of it's toArray method.

**Breaking changes**

I don't think this is a breaking change despite potentially raising new issues, as it just improves analysis. This seems to be inline with [PHPStan's BC Promise](https://phpstan.org/user-guide/backward-compatibility-promise#type-inference-capabilities)?
