### PR TITLE
fix: remove assertions for non-existing methods in Date

### DIFF
--- a/tests/Type/data/date-extension.php
+++ b/tests/Type/data/date-extension.php
@@ -19,8 +19,6 @@ function test(mixed $date): void
     assertType('Illuminate\Support\Carbon', Date::fromSerialized($date));
     assertType('Illuminate\Support\Carbon|null', Date::getTestNow());
     assertType('Illuminate\Support\Carbon', Date::instance($date));
-    assertType('Illuminate\Support\Carbon', Date::maxValue());
-    assertType('Illuminate\Support\Carbon', Date::minValue());
     assertType('Illuminate\Support\Carbon', Date::now());
     assertType('Illuminate\Support\Carbon', Date::parse());
     assertType('Illuminate\Support\Carbon', Date::today());


### PR DESCRIPTION
The methods `maxValue` and `minValue` are not available in the `Date` class. This removes the assertions for these methods.

See: https://github.com/laravel/framework/pull/55151

@szepeviktor, this is needed for the CI to pass on newer laravel versions.

Thanks!
