### PR TITLE
Improve types for IntegrationTest

### DIFF
--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -16,7 +16,7 @@ use function sprintf;
 
 class IntegrationTest extends PHPStanTestCase
 {
-    /** @return iterable<mixed> */
+    /** @return iterable<array{0: string, 1?: array<int, array<int, string>>}> */
     public static function dataIntegrationTests(): iterable
     {
         self::getContainer();
@@ -101,7 +101,7 @@ class IntegrationTest extends PHPStanTestCase
     }
 
     /**
-     * @param array<int, array<int, string>> $expectedErrors
+     * @param array<int, array<int, string>>|null $expectedErrors
      *
      * @dataProvider dataIntegrationTests
      */


### PR DESCRIPTION
I am copying the approach you took in this file in https://github.com/mll-lab/laravel-utils/blob/38f3b0fcaea10e1997e8d54a5d772ad98932e48e/tests/PHPStan/PHPStanExtensionTest.php and found myself wondering why the type for the data provider is so imprecise.