### PR TITLE
[3.x] fix: chunkWhile generics 

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -76,6 +76,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @return static<($keyBy is string ? array-key : ($keyBy is array ? array-key : TNewKey)), TValue>
      */
     public function keyBy($keyBy);
+
+    /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable(TValue, TKey, static<TKey, TValue>): bool  $callback
+     * @return static<int, static<TKey, TValue>>
+     */
+    public function chunkWhile(callable $callback);
 }
 
 /**
@@ -100,4 +108,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @return static<array-key, TCombineValue>
      */
     public function combine($values);
+
+    /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable(TValue, TKey, static<TKey, TValue>): bool  $callback
+     * @return static<int, static<TKey, TValue>>
+     */
+    public function chunkWhile(callable $callback);
 }

--- a/stubs/common/Enumerable.stub
+++ b/stubs/common/Enumerable.stub
@@ -39,4 +39,12 @@ interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable, 
     * @return static<array-key, TCombineValue>
     */
    public function combine($values);
+
+    /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable(TValue, TKey, static<TKey, TValue>): bool  $callback
+     * @return static<int, static<TKey, TValue>>
+     */
+    public function chunkWhile(callable $callback);
 }

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -145,7 +145,7 @@ function test(
     assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunkWhile(fn (User $u) => $u->id > 5));
     assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunkWhile(fn (Transaction $t) => $t->id > 5));
     assertType('App\UserCollection', $secondCustomEloquentCollection->chunkWhile(fn (User $t) => $t->id > 5));
-    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $items->chunkWhile(fn ($v) => $v > 5));
+    assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->chunkWhile(fn ($v) => $v > 5));
 
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->values());
     assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->values());


### PR DESCRIPTION
Hello!

This fixes the `chunkWhile` method for all versions, see https://github.com/laravel/framework/pull/55324

Thanks!