### PR TITLE
fix(docs): correct markdown list numbering in contribution steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Please review these guidelines before submitting any pull requests.
 ## Process
 
 1. Fork the project
-1. Create a new branch
-1. Code, test, commit and push
-1. Open a pull request detailing your changes. Make sure to follow the [template](.github/PULL_REQUEST_TEMPLATE.md)
+2. Create a new branch
+3. Code, test, commit and push
+4. Open a pull request detailing your changes. Make sure to follow the [template](.github/PULL_REQUEST_TEMPLATE.md)
 
 ## Guidelines
 


### PR DESCRIPTION
**Changes**

- Fixed the markdown list numbering in the contribution guide by replacing repeated 1. entries with proper sequential numbers (1., 2., 3., 4.).
- This improves readability and ensures correct rendering across markdown viewers.