### PR TITLE
Post and query can also be array with a key given (fixes #2268)

### DIFF
--- a/stubs/common/Http/InteractsWithInput.stub
+++ b/stubs/common/Http/InteractsWithInput.stub
@@ -10,7 +10,7 @@ trait InteractsWithInput
      * @template TDefault
      * @param  string|null  $key
      * @param  TDefault  $default
-     * @return ($key is null ? array : string|TDefault)
+     * @return ($key is null ? array : string|array|TDefault)
      */
     public function query($key = null, $default = null);
 
@@ -20,7 +20,7 @@ trait InteractsWithInput
      * @template TDefault
      * @param  string|null  $key
      * @param  TDefault  $default
-     * @return ($key is null ? array : string|TDefault)
+     * @return ($key is null ? array : string|array|TDefault)
      */
     public function post($key = null, $default = null);
 

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -13,10 +13,18 @@ function test(Request $request): void
     assertType('array<int, Illuminate\Http\UploadedFile>', $request->file());
     assertType('Illuminate\Http\UploadedFile|null', $request->file('foo'));
     assertType('array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|stdClass', $request->file('foo', new \stdClass()));
+
     assertType('Illuminate\Routing\Route|null', $request->route());
     assertType('(object|string|null)', $request->route('foo'));
     assertType('(object|string)', $request->route('foo', 'bar'));
+
     assertType('array<string, string>', $request->server());
     assertType('string|null', $request->server('foo'));
     assertType('5|string', $request->server('foo', 5));
+
+    assertType('array|string|null', $request->post('foo'));
+    assertType('array|string', $request->post('foo', 'bar'));
+
+    assertType('array|string|null', $request->query('foo'));
+    assertType('array|string', $request->query('foo', 'bar'));
 }

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -22,9 +22,11 @@ function test(Request $request): void
     assertType('string|null', $request->server('foo'));
     assertType('5|string', $request->server('foo', 5));
 
+    assertType('array', $request->post());
     assertType('array|string|null', $request->post('foo'));
     assertType('array|string', $request->post('foo', 'bar'));
 
+    assertType('array', $request->query());
     assertType('array|string|null', $request->query('foo'));
     assertType('array|string', $request->query('foo', 'bar'));
 }


### PR DESCRIPTION
Resolves #2268

**Changes**

Added the array type as query and post can return an array with the key set.

**Breaking changes**

No
