### PR TITLE
[3.x] feat(config): allow glob paths for several config values

### DIFF
--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -18,6 +18,7 @@ parameters:
     databaseMigrationsPath:
         - app/Domain/DomainA/migrations
         - app/Domain/DomainB/migrations
+        - modules/*/migrations
 ```
 
 **Note:** If your migrations are using `if` statements to conditionally alter database structure (ex: create table only if it's not there, add column only if table exists and column does not etc...) Larastan will assume those if statements evaluate to true and will consider everything from the `if` body.
@@ -43,6 +44,7 @@ parameters:
     squashedMigrationsPath:
         - app/Domain/DomainA/schema
         - app/Domain/DomainB/schema
+        - modules/*/schema
 ```
 
 ### PostgreSQL
@@ -100,7 +102,7 @@ By default, Larastan assumes your config files are under `/config` directory. It
 parameters:
     configDirectories:
         - src/config
-        - foo/config
+        - modules/*/config
 ```
 
 ### Example

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -106,19 +106,21 @@ final class SquashedMigrationHelper
         /** @var SplFileInfo[] $schemaFiles */
         $schemaFiles = [];
 
-        foreach ($this->schemaPaths as $additionalPath) {
-            $absolutePath = $this->fileHelper->absolutizePath($additionalPath);
+        foreach ($this->schemaPaths as $additionalPathGlob) {
+            foreach ((glob($additionalPathGlob) ?: []) as $additionalPath) {
+                $absolutePath = $this->fileHelper->absolutizePath($additionalPath);
 
-            if (! is_dir($absolutePath)) {
-                continue;
+                if (! is_dir($absolutePath)) {
+                    continue;
+                }
+
+                $schemaFiles += iterator_to_array(
+                    new RegexIterator(
+                        new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
+                        '/\.dump|\.sql/i',
+                    ),
+                );
             }
-
-            $schemaFiles += iterator_to_array(
-                new RegexIterator(
-                    new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                    '/\.dump|\.sql/i',
-                ),
-            );
         }
 
         return $schemaFiles;

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -16,6 +16,7 @@ use SplFileInfo;
 use function array_key_exists;
 use function database_path;
 use function file_get_contents;
+use function glob;
 use function is_array;
 use function is_bool;
 use function is_dir;

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -16,6 +16,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 
 use function config_path;
 use function count;
+use function glob;
 use function is_dir;
 use function str_starts_with;
 
@@ -71,15 +72,17 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
-        foreach ($this->configDirectories as $configDirectory) {
-            $absolutePath = $this->fileHelper->absolutizePath($configDirectory);
+        foreach ($this->configDirectories as $configDirectoryGlob) {
+            foreach ((glob($configDirectoryGlob) ?: []) as $configDirectory) {
+                $absolutePath = $this->fileHelper->absolutizePath($configDirectory);
 
-            if (! is_dir($absolutePath)) {
-                continue;
-            }
+                if (! is_dir($absolutePath)) {
+                    continue;
+                }
 
-            if (str_starts_with($scope->getFile(), $absolutePath)) {
-                return false;
+                if (str_starts_with($scope->getFile(), $absolutePath)) {
+                    return false;
+                }
             }
         }
 

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -34,7 +34,7 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
     /** @test */
     public function itDoesNotFailForEnvCallsInsideGlobConfigDirectory(): void
     {
-        $this->analyse([__DIR__ . '/data/module/foo/config/env-calls.php'], []);
+        $this->analyse([__DIR__ . '/data/module/foo/config/env-calls.php', __DIR__ . '/data/module/bar/config/env-calls.php'], []);
     }
 
     /** @test */

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -19,13 +19,22 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return new NoEnvCallsOutsideOfConfigRule([__DIR__ . '/data/config'], $this->getFileHelper());
+        return new NoEnvCallsOutsideOfConfigRule([
+            __DIR__ . '/data/config',
+            __DIR__ . '/data/module/*/config',
+        ], $this->getFileHelper());
     }
 
     /** @test */
     public function itDoesNotFailForEnvCallsInsideConfigDirectory(): void
     {
         $this->analyse([__DIR__ . '/data/config/env-calls.php'], []);
+    }
+
+    /** @test */
+    public function itDoesNotFailForEnvCallsInsideGlobConfigDirectory(): void
+    {
+        $this->analyse([__DIR__ . '/data/module/foo/config/env-calls.php'], []);
     }
 
     /** @test */

--- a/tests/Rules/data/module/bar/config/env-calls.php
+++ b/tests/Rules/data/module/bar/config/env-calls.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Rules\Module\Bar;
+
+use function Foo\Bar\env as scopedEnv;
+
+env('foo');
+\env('bar');
+
+// no report for namespaced calls
+\Foo\Bar\env('bar');
+scopedEnv('foo');

--- a/tests/Rules/data/module/foo/config/env-calls.php
+++ b/tests/Rules/data/module/foo/config/env-calls.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Rules\Module\Foo;
+
+use function Foo\Bar\env as scopedEnv;
+
+env('foo');
+\env('bar');
+
+// no report for namespaced calls
+\Foo\Bar\env('bar');
+scopedEnv('foo');


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This introduces the ability to add glob paths to the documented directories of migrations, schemas and config files.

This creates some flexibility for modular Laravel applications.

**Breaking changes**

No, existing paths should still work.
