### PR TITLE
docs: update Larastan install instructions for Laravel 12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Larastan was created by [Can Vural](https://github.com/canvural) and [Nuno Madur
 | < 9                | 1.x              |
 | \> 9.0 && >= 11.16 | 2.x              |
 | 11.16+             | 3.0+             |
+| 12.0+              | 3.4+             |
 
 ## Sponsors
 <a href="https://blackfire.io/docs/introduction?utm_source=larastan&utm_medium=github_readme&utm_campaign=logo"><img src="assets/blackfire-logo.png" alt="Blackfire.io" width="254" height="64"></a>
@@ -42,7 +43,7 @@ Larastan was created by [Can Vural](https://github.com/canvural) and [Nuno Madur
 **1**: First, you may use [Composer](https://getcomposer.org) to install Larastan as a development dependency into your Laravel project:
 
 ```bash
-composer require --dev "larastan/larastan:^3.0"
+composer require --dev larastan/larastan
 ```
 
 > Using Larastan for analysing Laravel packages? You may need to install `orchestra/testbench`.


### PR DESCRIPTION
 Updated the Larastan installation instructions in the documentation to recommend installing the latest version (using ^3.4 or no version constraint).
- Clarified that Laravel 12 requires Larastan 3.4 or higher.
- This prevents dependency conflicts and ensures compatibility with Laravel 12 and PHP 8.2+.

- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
