### PR TITLE
[3.x] Fix: Public scopes using attribute

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -153,7 +153,7 @@ class BuilderHelper
                     }
                 }
 
-                if (! $methodReflection->isPublic() && $hasScopeAttribute) {
+                if ($hasScopeAttribute) {
                     $parametersAcceptor = $methodReflection->getVariants()[0];
 
                     $parameters = $parametersAcceptor->getParameters();

--- a/tests/Type/data/model-scope-attribute-l12.php
+++ b/tests/Type/data/model-scope-attribute-l12.php
@@ -17,7 +17,6 @@ function test(Builder $query): void
     assertType('Illuminate\Database\Eloquent\Builder<ModelScopeAttribute\Activity>', Activity::withVoidReturn());
     assertType('Illuminate\Database\Eloquent\Builder<ModelScopeAttribute\Activity>', $query->withVoidReturn());
     assertType('ModelScopeAttribute\Activity', $query->withVoidReturn()->firstOrFail());
-    assertType('*ERROR*', $query->notAScope());
 }
 
 class Activity extends Model
@@ -35,13 +34,6 @@ class Activity extends Model
     /** @param  Builder<static>  $query */
     #[Scope]
     protected function withVoidReturn(Builder $query): void
-    {
-        $query->where('whyuse', 'void');
-    }
-
-    /** @param  Builder<static>  $query */
-    #[Scope]
-    public function notAScope(Builder $query): void
     {
         $query->where('whyuse', 'void');
     }


### PR DESCRIPTION
- [ 🟢 ] Added or updated tests
- [ N/A ] Documented user facing changes

Resolves #2286 

**Changes**

Currently, Larastan does not detect public methods that are declared with the `Scope` attribute as valid scopes. This seems to have [been done intentionally](https://github.com/larastan/larastan/pull/2244) however I cannot immediately see why, as public scopes are valid (see original issue). This brings detection logic for scopes via the `Scope` attribute inline with other methods.

**Breaking changes**

Public scopes declared using the `Scope` attribute will now be recognised as valid scopes by Larastan. I do not think this warrants any documentation.
