### PR TITLE
[3.x] Fix: Address the return type for Date::createFromFormat and Date::createSafe

### DIFF
--- a/src/ReturnTypes/DateExtension.php
+++ b/src/ReturnTypes/DateExtension.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Date;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -59,11 +58,7 @@ class DateExtension implements DynamicStaticMethodReturnTypeExtension
     ): Type {
         $dateType = new ObjectType(get_class(now()));
 
-        if (in_array($methodReflection->getName(), ['createFromFormat', 'createSafe'], true)) {
-            return TypeCombinator::union($dateType, new ConstantBooleanType(false));
-        }
-
-        if (in_array($methodReflection->getName(), ['getTestNow', 'make'], true)) {
+        if (in_array($methodReflection->getName(), ['createFromFormat', 'createSafe', 'getTestNow', 'make'], true)) {
             return TypeCombinator::addNull($dateType);
         }
 

--- a/tests/Type/data/date-extension.php
+++ b/tests/Type/data/date-extension.php
@@ -24,7 +24,7 @@ function test(mixed $date): void
     assertType('Illuminate\Support\Carbon', Date::today());
     assertType('Illuminate\Support\Carbon', Date::tomorrow());
     assertType('Illuminate\Support\Carbon', Date::yesterday());
-    assertType('Illuminate\Support\Carbon|false', Date::createFromFormat('Y-m-d', '2022-01-01'));
-    assertType('Illuminate\Support\Carbon|false', Date::createSafe());
+    assertType('Illuminate\Support\Carbon|null', Date::createFromFormat('Y-m-d', '2022-01-01'));
+    assertType('Illuminate\Support\Carbon|null', Date::createSafe());
     assertType('Illuminate\Support\Carbon|null', Date::make('today'));
 }


### PR DESCRIPTION
Address the return type of Date::createFromFormat and Date::createSafe.

Date::createFromFormat and Date::createSafe returns `Illuminate\Support\Carbon|null`, not `Illuminate\Support\Carbon|false`.

See https://api.laravel.com/docs/12.x/Illuminate/Support/DateFactory.html#method_createFromFormat

