### PR TITLE
Replace slash with DIRECTORY_SEPARATOR on rule `NoEnvCallsOutsideOfConfigRule`

### DIFF
--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -33,12 +33,13 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     public function __construct(private array $configDirectories, private FileHelper $fileHelper)
     {
         if (count($configDirectories) !== 0) {
+            /** @var list<non-empty-string> $normalizedDirectories */
             $normalizedDirectories = [];
-    
+
             foreach ($configDirectories as $directory) {
                 $normalizedDirectories[] = $this->fileHelper->normalizePath($directory);
             }
-    
+
             $this->configDirectories = $normalizedDirectories;
 
             return;

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -33,9 +33,13 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     public function __construct(private array $configDirectories, private FileHelper $fileHelper)
     {
         if (count($configDirectories) !== 0) {
-            foreach ($this->configDirectories as &$directory) {
-                $directory = $this->fileHelper->normalizePath($directory);
+            $normalizedDirectories = [];
+    
+            foreach ($configDirectories as $directory) {
+                $normalizedDirectories[] = $this->fileHelper->normalizePath($directory);
             }
+    
+            $this->configDirectories = $normalizedDirectories;
 
             return;
         }

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -33,6 +33,10 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     public function __construct(private array $configDirectories, private FileHelper $fileHelper)
     {
         if (count($configDirectories) !== 0) {
+            foreach ($this->configDirectories as &$directory) {
+                $directory = $this->fileHelper->normalizePath($directory);
+            }
+
             return;
         }
 
@@ -73,7 +77,6 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
         foreach ($this->configDirectories as $configDirectoryGlob) {
-            $configDirectoryGlob = str_replace('/', DIRECTORY_SEPARATOR, $configDirectoryGlob);
             foreach ((glob($configDirectoryGlob) ?: []) as $configDirectory) {
                 $absolutePath = $this->fileHelper->absolutizePath($configDirectory);
 

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -73,6 +73,7 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
         foreach ($this->configDirectories as $configDirectoryGlob) {
+            $configDirectoryGlob = str_replace('/', DIRECTORY_SEPARATOR, $configDirectoryGlob);
             foreach ((glob($configDirectoryGlob) ?: []) as $configDirectory) {
                 $absolutePath = $this->fileHelper->absolutizePath($configDirectory);
 

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -29,18 +29,16 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 {
     use HasContainer;
 
+    /** @var list<string> */
+    private array $configDirectories = [];
+
     /** @param  list<non-empty-string> $configDirectories */
-    public function __construct(private array $configDirectories, private FileHelper $fileHelper)
+    public function __construct(array $configDirectories, private FileHelper $fileHelper)
     {
         if (count($configDirectories) !== 0) {
-            /** @var list<non-empty-string> $normalizedDirectories */
-            $normalizedDirectories = [];
-
             foreach ($configDirectories as $directory) {
-                $normalizedDirectories[] = $this->fileHelper->normalizePath($directory);
+                $this->configDirectories[] = $this->fileHelper->normalizePath($directory);
             }
-
-            $this->configDirectories = $normalizedDirectories;
 
             return;
         }


### PR DESCRIPTION
**Changes**

This PR allows Windows users to define in the `phpstan.neon` file custom `configDirectories`.

```
parameters:
    configDirectories:
        - config
        - modules/*/Config
```

Before this change only Unix-like system could use this functionality as the absolute path was wrong for Windows users.

Before PR: `C:\Users\User\Herd\laravel\modules/ModuleA/Config/config.php`
After PR: `C:\Users\User\Herd\laravel\modules\ModuleA\Config\config.php`

The `glob` method returns the path following the directory separator in the provided pattern.

Before the PR this condition was always false for Windows users as the path did not match:

https://github.com/larastan/larastan/blob/36706736a0c51d3337478fab9c919d78d2e03404/src/Rules/NoEnvCallsOutsideOfConfigRule.php#L83