### PR TITLE
[3.x] Fix incorrect return type for DateExtension in Laravel versions above 12

### DIFF
--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -34,7 +34,13 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/custom-eloquent-builder.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/custom-eloquent-collection.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/database-transaction.php');
-        yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension.php');
+
+        if (laravel_version_compare('12.0.0', '>=')) {
+            yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension-l12.php');
+        } else {
+            yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension-l11.php');
+        }
+
         yield from self::gatherAssertTypes(__DIR__ . '/data/environment-helper.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/facades.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');

--- a/tests/Type/data/date-extension-l11.php
+++ b/tests/Type/data/date-extension-l11.php
@@ -20,7 +20,7 @@ function test(mixed $date): void
     assertType('Illuminate\Support\Carbon|null', Date::getTestNow());
     assertType('Illuminate\Support\Carbon', Date::instance($date));
     assertType('Illuminate\Support\Carbon', Date::now());
-    assertType('Illuminate\Support\Carbon', Date::parse());
+    assertType('Illuminate\Support\Carbon', Date::parse('12:00'));
     assertType('Illuminate\Support\Carbon', Date::today());
     assertType('Illuminate\Support\Carbon', Date::tomorrow());
     assertType('Illuminate\Support\Carbon', Date::yesterday());

--- a/tests/Type/data/date-extension-l12.php
+++ b/tests/Type/data/date-extension-l12.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DateExtension;
+
+use Illuminate\Support\Facades\Date;
+
+use function PHPStan\Testing\assertType;
+
+function test(mixed $date): void
+{
+    assertType('Illuminate\Support\Carbon', Date::create());
+    assertType('Illuminate\Support\Carbon', Date::createFromDate());
+    assertType('Illuminate\Support\Carbon', Date::createFromTime());
+    assertType('Illuminate\Support\Carbon', Date::createFromTimeString('12:00'));
+    assertType('Illuminate\Support\Carbon', Date::createFromTimestamp(0));
+    assertType('Illuminate\Support\Carbon', Date::createFromTimestampMs(0));
+    assertType('Illuminate\Support\Carbon', Date::createFromTimestampUTC(0));
+    assertType('Illuminate\Support\Carbon', Date::createMidnightDate());
+    assertType('Illuminate\Support\Carbon', Date::fromSerialized($date));
+    assertType('Illuminate\Support\Carbon|null', Date::getTestNow());
+    assertType('Illuminate\Support\Carbon', Date::instance($date));
+    assertType('Illuminate\Support\Carbon', Date::now());
+    assertType('Illuminate\Support\Carbon', Date::parse('12:00'));
+    assertType('Illuminate\Support\Carbon', Date::today());
+    assertType('Illuminate\Support\Carbon', Date::tomorrow());
+    assertType('Illuminate\Support\Carbon', Date::yesterday());
+    assertType('Illuminate\Support\Carbon|null', Date::createFromFormat('Y-m-d', '2022-01-01'));
+    assertType('Illuminate\Support\Carbon|null', Date::createSafe());
+    assertType('Illuminate\Support\Carbon|null', Date::make('today'));
+}


### PR DESCRIPTION
### Summary
Fixes the return type for Laravel Date facade methods `createFromFormat` and `createSafe` to correctly handle different Laravel versions, where the return type behavior changed between versions.

### Problem
The previous implementation incorrectly returned `Carbon|false` for `createFromFormat` and `createSafe` methods regardless of Laravel version, but Laravel 12+ changed these methods to return `Carbon|null` instead of `Carbon|false`.

### Solution
  - **Version-aware Type Resolution**: Added Laravel version detection using `laravel_version_compare()` to return appropriate types:
  - **Laravel 12.0.0+**: Returns `Carbon|null` for `createFromFormat` and `createSafe`
  - **Laravel < 12.0.0**: Returns `Carbon|false` for `createFromFormat` and `createSafe`
  - **Dynamic Test Loading**: Modified test suite to load appropriate test cases based on the detected Laravel version

### Reference
https://github.com/briannesbitt/Carbon/blob/2.x/src/Carbon/Factory.php#L33
https://github.com/briannesbitt/Carbon/blob/3.x/src/Carbon/Factory.php#L41