### PR TITLE
[3.x] feat: add new rule to detect unnecessary Enumerable::toArray() calls

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -84,6 +84,41 @@ parameters:
     noUnnecessaryCollectionCallExcept: ['contains']
 ```
 
+## NoUnnecessaryEnumerableToArrayCalls
+
+This rule checks for unnecessary calls `Enumerable::toArray()` that
+could have used `all()` instead. The `toArray()` method recursively
+converts all Arrayable items in the Enumerable to an array and if
+none of the items are Arrayable, it is unnecessary map call.
+
+### Examples
+
+```php
+collect([1, 2, 3])->toArray();
+```
+
+Will result in the following error:
+
+```
+Called [toArray()] on an Enumerable which does not contain any Arrayables.
+```
+
+To fix the error, the code in the previous example could be changed to:
+
+```php
+collect([1, 2, 3])->all();
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    noUnnecessaryEnumerableToArrayCalls: true
+```
+
 ## ModelPropertyRule
 
 ---

--- a/extension.neon
+++ b/extension.neon
@@ -15,6 +15,7 @@ parameters:
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
+    noUnnecessaryEnumerableToArrayCalls: false
     squashedMigrationsPath: []
     databaseMigrationsPath: []
     disableMigrationScan: false
@@ -34,6 +35,7 @@ parametersSchema:
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
+    noUnnecessaryEnumerableToArrayCalls: bool()
     databaseMigrationsPath: listOf(string())
     disableMigrationScan: bool()
     configDirectories: listOf(string())
@@ -53,6 +55,8 @@ conditionalTags:
         phpstan.rules.rule: %noModelMake%
     Larastan\Larastan\Rules\NoUnnecessaryCollectionCallRule:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
+    Larastan\Larastan\Rules\NoUnnecessaryEnumerableToArrayCallsRule:
+        phpstan.rules.rule: %noUnnecessaryEnumerableToArrayCalls%
     Larastan\Larastan\Rules\OctaneCompatibilityRule:
         phpstan.rules.rule: %checkOctaneCompatibility%
     Larastan\Larastan\Rules\UnusedViewsRule:
@@ -387,6 +391,9 @@ services:
         arguments:
             onlyMethods: %noUnnecessaryCollectionCallOnly%
             excludeMethods: %noUnnecessaryCollectionCallExcept%
+
+    -
+        class: Larastan\Larastan\Rules\NoUnnecessaryEnumerableToArrayCallsRule
 
     -
         class: Larastan\Larastan\Rules\ModelAppendsRule

--- a/src/Rules/NoUnnecessaryEnumerableToArrayCallsRule.php
+++ b/src/Rules/NoUnnecessaryEnumerableToArrayCallsRule.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Enumerable;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * This rule checks for unnecessary calls `Enumerable::toArray()` that
+ * could have used `all()` instead. The `toArray()` method recursively
+ * converts all Arrayable items in the Enumerable to an array and if
+ * none of the items are Arrayable, it is unnecessary map call.
+ *
+ * For example:
+ *     collect([1, 2, 3])->toArray()
+ * could be simplified to:
+ *      collect([1, 2, 3])->all()
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoUnnecessaryEnumerableToArrayCallsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /** @return RuleError[] */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $node->name;
+
+        if (! $name instanceof Identifier || $name->toString() !== 'toArray') {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+
+        if (! (new ObjectType(Enumerable::class))->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        $valueType = $calledOnType->getTemplateType(Enumerable::class, 'TValue');
+
+        if (! (new ObjectType(Arrayable::class))->isSuperTypeOf($valueType)->no()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Called [toArray()] on an Enumerable which does not contain any Arrayables.',
+            )
+                ->tip('Use [all()] to get the items as an array.')
+                ->identifier('larastan.unnecessaryEnumerableToArrayCall')
+                ->line($name->getStartLine())
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/NoUnnecessaryEnumerableToArrayCallsRuleTest.php
+++ b/tests/Rules/NoUnnecessaryEnumerableToArrayCallsRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Larastan\Larastan\Rules\NoUnnecessaryEnumerableToArrayCallsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<NoUnnecessaryEnumerableToArrayCallsRule> */
+class NoUnnecessaryEnumerableToArrayCallsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoUnnecessaryEnumerableToArrayCallsRule();
+    }
+
+    public function test_rule(): void
+    {
+        $message = "Called [toArray()] on an Enumerable which does not contain any Arrayables.\n    💡 Use [all()] to get the items as an array.";
+
+        $this->analyse([__DIR__ . '/data/unnecessary-enumerable-toArray-calls.php'], [
+            [$message, 27],
+        ]);
+    }
+}

--- a/tests/Rules/data/unnecessary-enumerable-toArray-calls.php
+++ b/tests/Rules/data/unnecessary-enumerable-toArray-calls.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * @param  Collection<int, int>  $ints
+ * @param  EloquentCollection<int, Model>  $models
+ * @param  LazyCollection<int, Model|string>  $innerUnion
+ * @param  EloquentCollection<int, Model>|Collection<string, string>  $outerUnion
+ */
+function test(
+    mixed $unknown,
+    Collection $ints,
+    EloquentCollection $models,
+    LazyCollection $innerUnion,
+    Enumerable $outerUnion,
+): void {
+    // should be reported
+    $ints->toArray();
+
+    // should not be reported
+    $unknown->toArray();
+    $models->toArray();
+    $innerUnion->toArray();
+    $outerUnion->toArray();
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

**Changes**

Hello!

This creates a new rule that's disabled by default.

If none of the items in an Enumerable are Arrayables, then there's no need to call [`toArray`](https://github.com/laravel/framework/blob/fac2d778f5f3c899cbcf8890011f7cd0727568bf/src/Illuminate/Collections/Traits/EnumeratesValues.php#L946-L954)---`all()` can be used instead.

Thanks!
