### PR TITLE
fix: match covariant TValue of collections with Laravel

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -8,7 +8,7 @@ use Illuminate\Support\Traits\EnumeratesValues;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>

--- a/stubs/common/Enumerable.stub
+++ b/stubs/common/Enumerable.stub
@@ -4,7 +4,7 @@ namespace Illuminate\Support;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @extends \IteratorAggregate<TKey, TValue>
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
In the Laravel code of the Collection the TValue is used as template-covariant, see https://github.com/illuminate/collections/blob/master/Collection.php. For me, using it as covariant solves the following issue:

```php
<?php

use Illuminate\Support\Collection;

enum MyEnum: string
{
    case Foo = 'foo';
    case Bar = 'bar';
}

class MyClass
{
    /**
     * @return Collection<int, MyEnum>
     */
    public function getSomeEnumValues(): Collection
    {
        return new Collection([MyEnum::Foo]);
    }
}
```

Currently, phpstan will give the following error:

```
Method MyClass::getSomeEnumValues() should return Illuminate\Support\Collection<int, MyEnum> but returns  
Illuminate\Support\Collection<int, MyEnum::Foo>.                                                                         
🪪 return.type  
```

However, when the `@template-covariant` is used instead of `@template` this issue (like in the Laravel source) doesn't exist.

In this function above I could've just changed the return type, but in my actual code the `getSomeEnumValues` is actually part of an interface that the class implements, meaning I cannot really change the return type to match every enum value.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
I don't think anything breaks
