### PR TITLE
[3.x] fix: allow private methods to be used as accessors

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -173,7 +173,7 @@ class ModelPropertyHelper
 
         $methodReflection = $classReflection->getNativeMethod($camelCase);
 
-        if ($methodReflection->isPublic() || $methodReflection->isPrivate()) {
+        if ($methodReflection->isPublic()) {
             return false;
         }
 


### PR DESCRIPTION
Hello!

Rector automatically converts protected methods to private in final classes (as it should). However, this breaks attribute detection.


Thanks!