### PR TITLE
Add documentation for packages regarding view-strings

### DIFF
--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -31,6 +31,13 @@ If the string is not an existing blade view, the following error will be display
 Parameter #1 $view of method TestClass::renderView() expects view-string, string given.  
 ```
 
+When working with packages, all vendor prefixed paths like `acme::example` may fail. As packages don't contain a Laravel app, the default skeleton from `orchestra/testbench` is used. This instance doesn't know about the package so views are not registered. Create a `testbench.yaml` file to [register](https://packages.tools/testbench#package-service-providers) your service provider to solve this issue.
+
+```yaml
+providers:
+    - Acme\AcmeServiceProvider
+```
+
 ## model-property
 `model-property` extends the built-in `string` type and acts like a string in the type level. But during the analysis if Larastan finds that an argument of the method or a function has a `model-property<ModelName>`, it'll try to check that the given argument value is actually a property of the model.
 

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -31,7 +31,7 @@ If the string is not an existing blade view, the following error will be display
 Parameter #1 $view of method TestClass::renderView() expects view-string, string given.  
 ```
 
-When working with packages, all vendor prefixed paths like `acme::example` may fail. As packages don't contain a Laravel app, the default skeleton from `orchestra/testbench` is used. This instance doesn't know about the package so views are not registered. Create a `testbench.yaml` file to [register](https://packages.tools/testbench#package-service-providers) your service provider to solve this issue.
+When working with packages, all vendor-prefixed paths like `acme::example` may fail. As packages don't contain a Laravel app, the default skeleton from `orchestra/testbench` is used. This instance doesn't know about the package so views are not registered. Create a `testbench.yaml` file to [register](https://packages.tools/testbench#package-service-providers) your service provider to solve this issue.
 
 ```yaml
 providers:


### PR DESCRIPTION
I've added documentation about the `view-string` type when developing packages. This has also been discussed in #2213.