### PR TITLE
[3.x] Only check existing views

### DIFF
--- a/src/Rules/UnusedViewsRule.php
+++ b/src/Rules/UnusedViewsRule.php
@@ -21,6 +21,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 
 use function array_diff;
 use function array_filter;
+use function array_unique;
 use function collect;
 use function iterator_to_array;
 use function view;
@@ -56,26 +57,20 @@ final class UnusedViewsRule implements Rule
             $this->viewsUsedInOtherViews,
         ])->flatten()->unique()->toArray();
 
+        /** @var Factory $factory */
+        $factory = view();
+        $finder  = $factory->getFinder();
+
         $allViews = iterator_to_array($this->viewFileHelper->getAllViewNames());
 
-        $existingViews = [];
+        $usedViews = static::filterExistingViews($factory, $usedViews);
+        $allViews  = static::filterExistingViews($factory, $allViews);
 
-        /** @var Factory $view */
-        $view = view();
-
-        foreach ($usedViews as $viewName) {
-            if (! $view->exists($viewName)) {
-                continue;
-            }
-
-            $existingViews[] = $viewName;
-        }
-
-        $unusedViews = array_diff($allViews, array_filter($existingViews));
+        $unusedViews = array_unique(array_diff($allViews, $usedViews));
 
         $errors = [];
         foreach ($unusedViews as $file) {
-            $path = $view->getFinder()->find($file);
+            $path = $finder->find($file);
 
             $errors[] = RuleErrorBuilder::message('This view is not used in the project.')
                 ->file($path)
@@ -85,5 +80,17 @@ final class UnusedViewsRule implements Rule
         }
 
         return $errors;
+    }
+
+    /**
+     * @param string[] $views
+     *
+     * @return string[]
+     */
+    protected static function filterExistingViews(Factory $factory, array $views): array
+    {
+        return array_filter($views, static function (string $view) use ($factory): bool {
+            return $factory->exists($view);
+        });
     }
 }

--- a/tests/Rules/UnusedViewsRuleTest.php
+++ b/tests/Rules/UnusedViewsRuleTest.php
@@ -22,7 +22,10 @@ class UnusedViewsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        $viewFileHelper = new ViewFileHelper([__DIR__ . '/../application/resources/views'], $this->getFileHelper());
+        $viewFileHelper = new ViewFileHelper([
+            __DIR__ . '/../application/resources/views',
+            __DIR__ . '/../../vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/views',
+        ], $this->getFileHelper());
 
         return new UnusedViewsRule(new UsedViewInAnotherViewCollector(
             $this->getContainer()->getService('currentPhpVersionSimpleDirectParser'),


### PR DESCRIPTION
- [x] Added or updated tests

This pull request resolves issue #2255.

**Introduction**

Pull request #2218 has added additional view paths. The `UnusedViewsRule` receives all the views from the `getAllViewNames` method, which now contain views from the vendor folder that may not be accessible directly. Because these views can't be found in the application itself, an `InvalidArgumentException` is thrown.

In a fresh Laravel project, the path `vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/views` and others are added to the directory list. The first file in this folder is `401.blade.php`. As this file does not exist in the application, the exception mentioned above will be thrown which causes issue #2255. Note that the error mentions view `401` and not `errors.401`.

Another side effect of adding multiple paths is that duplicate view names can appear. If the project itself would also contain an unused `401.blade.php` in the root, you'll get the unused file error twice for that file.

**Changes**

I've changed the code to check the existence of every view. This will prevent the rule from checking views that are only available in the vendor directory. Also, an `array_unique` has been wrapped around the unused views to prevent duplicate errors.

The test has also been modified to add a vendor view path.

**Reproduce**

The issue can be reproduced by following these steps:

1. Run `composer create-project laravel/laravel larastan-view-rule`
2. Run `cd larastan-view-rule`
3. Run `composer require --dev "larastan/larastan:^3.0"`
4. Add a `phpstan.neon` file with the following content:

```neon
includes:
    - vendor/larastan/larastan/extension.neon

parameters:
    paths:
        - app/
        - routes/
    checkUnusedViews: true
    level: 9
```

5. Run `./vendor/bin/phpstan` and an internal error will appear.

**Breaking changes**

No breaking changes have been introduced.
