### PR TITLE
fix: self::query() for final models

### DIFF
--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -21,6 +21,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
@@ -79,9 +80,11 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
 
         if (count(array_intersect([EloquentBuilder::class], $returnType->getReferencedClasses())) > 0) {
             if ($methodCall->class instanceof Name) {
+                $type = $scope->resolveTypeByName($methodCall->class);
+
                 return new GenericObjectType(
                     $this->builderHelper->determineBuilderName($scope->resolveName($methodCall->class)),
-                    [$scope->resolveTypeByName($methodCall->class)],
+                    [$type instanceof ThisType ? $type->getStaticObjectType() : $type],
                 );
             }
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -23,6 +23,7 @@ class IntegrationTest extends PHPStanTestCase
         self::getContainer();
 
         yield [__DIR__ . '/data/bug-2074.php'];
+        yield [__DIR__ . '/data/bug-final_model_query.php'];
         yield [__DIR__ . '/data/test-case-extension.php', [34 => ['Call to function method_exists() with $this(TestTestCase) and \'partialMock\' will always evaluate to true.']]];
         yield [__DIR__ . '/data/model-builder.php'];
         yield [__DIR__ . '/data/model-properties.php'];

--- a/tests/Integration/data/bug-final_model_query.php
+++ b/tests/Integration/data/bug-final_model_query.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BugFinalModelQuery;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+final class User extends Model
+{
+    /** @return Builder<self> */
+    public function test(): Builder
+    {
+        return self::query();
+    }
+}

--- a/tests/Integration/data/model-builder.php
+++ b/tests/Integration/data/model-builder.php
@@ -21,7 +21,7 @@ class User extends Model
         return static::query()->create();
     }
 
-    public static function testCreateSelf(): static
+    public static function testCreateSelf(): self
     {
         return self::query()->create();
     }

--- a/tests/Type/data/model-l11-42.php
+++ b/tests/Type/data/model-l11-42.php
@@ -39,10 +39,10 @@ class Bar extends Model
 
     public function test(): void
     {
-        assertType('Illuminate\Database\Eloquent\Builder<$this(Model\Bar)>', self::query());
+        assertType('Illuminate\Database\Eloquent\Builder<Model\Bar>', self::query());
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query());
 
-        assertType('$this(Model\Bar)|null', self::query()->first());
+        assertType('Model\Bar|null', self::query()->first());
         assertType('static(Model\Bar)|null', static::query()->first());
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query()->orWhere('foo', 'bar'));
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query()->select('foo'));

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -39,10 +39,10 @@ class Bar extends Model
 
     public function test(): void
     {
-        assertType('Illuminate\Database\Eloquent\Builder<$this(Model\Bar)>', self::query());
+        assertType('Illuminate\Database\Eloquent\Builder<Model\Bar>', self::query());
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query());
 
-        assertType('$this(Model\Bar)|null', self::query()->first());
+        assertType('Model\Bar|null', self::query()->first());
         assertType('static(Model\Bar)|null', static::query()->first());
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query()->orWhere('foo', 'bar'));
         assertType('Illuminate\Database\Eloquent\Builder<static(Model\Bar)>', static::query()->select('foo'));


### PR DESCRIPTION
Hello!

For some reason, when using `$scope->resolveTypeByName`, PHPStan resolves `self::` as a `ThisType`. However, this was causing final models that returned builders from `self::query()` to fail with:

```
Method App\Mail\Models\Message::prunable() should return Illuminate\Database\Eloquent\Builder<App\Mail\Models\Message> but returns Illuminate\Database\Eloquent\Builder<$this(App\Mail\Models\Message)>.
```

This PR fixes that by downgrading to a static object type.


Thanks!