### PR TITLE
[3.x] Add NoMissingTranslationsRule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -399,7 +399,9 @@ parameters:
 
 ## NoMissingTranslationsRule
 
-This rule will find any untranslated strings in your application. This rule is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule is unnecessary.
+This rule will find any untranslated strings in your application. This rule is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule may be unnecessary.
+
+> **NOTE**: If you store your translations in a database, this rule will not be able to detect them. You should leave this rule disabled in such case.
 
 ### Examples
 
@@ -421,6 +423,16 @@ To enable, add the following to your `phpstan.neon` file:
 ```neon
 parameters:
     checkMissingTranslations: true
+```
+
+By default, the path `resources/lang` is scanned. If you have translations elsewhere, make sure to register all the paths.
+
+```neon
+parameters:
+    checkMissingTranslations: true
+    translationDirectories:
+        - resources/lang
+        - resources/translations
 ```
 
 ## NoEnvCallsOutsideOfConfig

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -397,6 +397,32 @@ parameters:
 - `@includeWhen` Blade directive.
 - `@includeFirst` Blade directive.
 
+## NoMissingTranslationsRule
+
+This rule will find any untranslated strings in your application. This rule is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule is unnecessary.
+
+### Examples
+
+For the following code:
+```php
+__('messages.greet')
+```
+
+Larastan may report the following error:
+```
+Translation "messages.greet" has not been found.
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkMissingTranslations: true
+```
+
 ## NoEnvCallsOutsideOfConfig
 
 Checks for `env` calls outside the `config` directory, which return `null` when the config is cached.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -399,9 +399,9 @@ parameters:
 
 ## NoMissingTranslationsRule
 
-This rule will find any untranslated strings in your application. This rule is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule may be unnecessary.
+This rule will find any untranslated strings in your application. It is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule may be unnecessary. Enabling this rule may decrease performance as it will scan the available views and translations.
 
-> **NOTE**: If you store your translations in a database, this rule will not be able to detect them. You should leave this rule disabled in such case.
+> **NOTE**: If you store your translations in a database, this rule will not be able to detect them. You should leave this rule disabled in such cases.
 
 ### Examples
 

--- a/extension.neon
+++ b/extension.neon
@@ -24,6 +24,7 @@ parameters:
     viewDirectories: []
     checkModelProperties: false
     checkUnusedViews: false
+    checkMissingTranslations: false
     checkModelAppends: true
     generalizeEnvReturnType: false
     checkConfigTypes: false
@@ -45,6 +46,7 @@ parametersSchema:
     disableSchemaScan: bool()
     checkModelProperties: bool()
     checkUnusedViews: bool()
+    checkMissingTranslations: bool()
     checkModelAppends: bool()
     generalizeEnvReturnType: bool()
     checkConfigTypes: bool()
@@ -63,6 +65,8 @@ conditionalTags:
         phpstan.rules.rule: %checkOctaneCompatibility%
     Larastan\Larastan\Rules\UnusedViewsRule:
         phpstan.rules.rule: %checkUnusedViews%
+    Larastan\Larastan\Rules\NoMissingTranslationsRule:
+        phpstan.rules.rule: %checkMissingTranslations%
     Larastan\Larastan\Rules\ModelAppendsRule:
         phpstan.rules.rule: %checkModelAppends%
     Larastan\Larastan\Rules\NoAuthFacadeInRequestScopeRule:
@@ -528,6 +532,29 @@ services:
         class: Larastan\Larastan\Support\ViewFileHelper
         arguments:
             viewDirectories: %viewDirectories%
+
+    -
+        class: Larastan\Larastan\Rules\NoMissingTranslationsRule
+
+    -
+        class: Larastan\Larastan\Collectors\UsedTranslationFunctionCollector
+        tags:
+            - phpstan.collector
+
+    -
+        class: Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector
+        tags:
+            - phpstan.collector
+
+    -
+        class: Larastan\Larastan\Collectors\UsedTranslationFacadeCollector
+        tags:
+            - phpstan.collector
+
+    -
+        class: Larastan\Larastan\Collectors\UsedTranslationViewCollector
+        arguments:
+            parser: @currentPhpVersionSimpleDirectParser
 
     -
         class: Larastan\Larastan\ReturnTypes\ApplicationMakeDynamicReturnTypeExtension

--- a/extension.neon
+++ b/extension.neon
@@ -22,6 +22,7 @@ parameters:
     disableSchemaScan: false
     configDirectories: []
     viewDirectories: []
+    translationDirectories: []
     checkModelProperties: false
     checkUnusedViews: false
     checkMissingTranslations: false
@@ -42,6 +43,7 @@ parametersSchema:
     disableMigrationScan: bool()
     configDirectories: listOf(string())
     viewDirectories: listOf(string())
+    translationDirectories: listOf(string())
     squashedMigrationsPath: listOf(string())
     disableSchemaScan: bool()
     checkModelProperties: bool()
@@ -535,6 +537,8 @@ services:
 
     -
         class: Larastan\Larastan\Rules\NoMissingTranslationsRule
+        arguments:
+            translationDirectories: %translationDirectories%
 
     -
         class: Larastan\Larastan\Collectors\UsedTranslationFunctionCollector
@@ -652,6 +656,9 @@ services:
 
     -
         class: Larastan\Larastan\Rules\ConfigCollectionRule
+
+    -
+        class: Illuminate\Filesystem\Filesystem
 
 rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule

--- a/extension.neon
+++ b/extension.neon
@@ -528,12 +528,16 @@ services:
             - phpstan.collector
     -
         class: Larastan\Larastan\Collectors\UsedViewInAnotherViewCollector
-        arguments:
-            parser: @currentPhpVersionSimpleDirectParser
+
     -
         class: Larastan\Larastan\Support\ViewFileHelper
         arguments:
             viewDirectories: %viewDirectories%
+
+    -
+        class: Larastan\Larastan\Support\ViewParser
+        arguments:
+            parser: @currentPhpVersionSimpleDirectParser
 
     -
         class: Larastan\Larastan\Rules\NoMissingTranslationsRule
@@ -557,8 +561,6 @@ services:
 
     -
         class: Larastan\Larastan\Collectors\UsedTranslationViewCollector
-        arguments:
-            parser: @currentPhpVersionSimpleDirectParser
 
     -
         class: Larastan\Larastan\ReturnTypes\ApplicationMakeDynamicReturnTypeExtension

--- a/src/Collectors/UsedTranslationFacadeCollector.php
+++ b/src/Collectors/UsedTranslationFacadeCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Collectors;
+
+use Illuminate\Support\Facades\Lang;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Type\ObjectType;
+
+use function count;
+use function in_array;
+
+/** @implements Collector<Node\Expr\StaticCall, string> */
+final class UsedTranslationFacadeCollector implements Collector
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\StaticCall::class;
+    }
+
+    /** @param Node\Expr\StaticCall $node */
+    public function processNode(Node $node, Scope $scope): array|null
+    {
+        $name = $node->name;
+
+        if (! $name instanceof Node\Identifier) {
+            return null;
+        }
+
+        if (! in_array($name->name, ['get', 'choice'], true)) {
+            return null;
+        }
+
+        if (count($node->getArgs()) === 0) {
+            return null;
+        }
+
+        $class = $node->class;
+
+        if (! $class instanceof Node\Name) {
+            return null;
+        }
+
+        $class = $scope->resolveName($class);
+
+        if (! (new ObjectType(Lang::class))->isSuperTypeOf(new ObjectType($class))->yes()) {
+            return null;
+        }
+
+        $template = $node->getArgs()[0]->value;
+
+        if (! $template instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        return [$template->value, $node->getStartLine()];
+    }
+}

--- a/src/Collectors/UsedTranslationFacadeCollector.php
+++ b/src/Collectors/UsedTranslationFacadeCollector.php
@@ -21,7 +21,11 @@ final class UsedTranslationFacadeCollector implements Collector
         return Node\Expr\StaticCall::class;
     }
 
-    /** @param Node\Expr\StaticCall $node */
+    /**
+     * @param Node\Expr\StaticCall $node
+     *
+     * @return array{0: string, 1: int}
+     */
     public function processNode(Node $node, Scope $scope): array|null
     {
         $name = $node->name;

--- a/src/Collectors/UsedTranslationFunctionCollector.php
+++ b/src/Collectors/UsedTranslationFunctionCollector.php
@@ -19,7 +19,11 @@ final class UsedTranslationFunctionCollector implements Collector
         return Node\Expr\FuncCall::class;
     }
 
-    /** @param Node\Expr\FuncCall $node */
+    /**
+     * @param Node\Expr\FuncCall $node
+     *
+     * @return array{0: string, 1: int}
+     */
     public function processNode(Node $node, Scope $scope): array|null
     {
         if (! $node->name instanceof Node\Name) {

--- a/src/Collectors/UsedTranslationFunctionCollector.php
+++ b/src/Collectors/UsedTranslationFunctionCollector.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Collectors;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+use function count;
+use function in_array;
+
+/** @implements Collector<Node\Expr\FuncCall, string> */
+final class UsedTranslationFunctionCollector implements Collector
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\FuncCall::class;
+    }
+
+    /** @param Node\Expr\FuncCall $node */
+    public function processNode(Node $node, Scope $scope): array|null
+    {
+        if (! $node->name instanceof Node\Name) {
+            return null;
+        }
+
+        if (! in_array($scope->resolveName($node->name), ['__', 'trans', 'trans_choice'], true)) {
+            return null;
+        }
+
+        if (count($node->getArgs()) === 0) {
+            return null;
+        }
+
+        $template = $node->getArgs()[0]->value;
+
+        if (! $template instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        return [$template->value, $node->getStartLine()];
+    }
+}

--- a/src/Collectors/UsedTranslationTranslatorCollector.php
+++ b/src/Collectors/UsedTranslationTranslatorCollector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Collectors;
+
+use Illuminate\Translation\Translator;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Type\ObjectType;
+
+use function count;
+use function in_array;
+
+/** @implements Collector<Node\Expr\MethodCall, string> */
+final class UsedTranslationTranslatorCollector implements Collector
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /** @param Node\Expr\MethodCall $node */
+    public function processNode(Node $node, Scope $scope): array|null
+    {
+        $name = $node->name;
+
+        if (! $name instanceof Node\Identifier) {
+            return null;
+        }
+
+        if (! in_array($name->name, ['get', 'choice'], true)) {
+            return null;
+        }
+
+        if (count($node->getArgs()) === 0) {
+            return null;
+        }
+
+        $class = $node->var;
+
+        if (! (new ObjectType(Translator::class))->isSuperTypeOf($scope->getType($class))->yes()) {
+            return null;
+        }
+
+        $template = $node->getArgs()[0]->value;
+
+        if (! $template instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        return [$template->value, $node->getStartLine()];
+    }
+}

--- a/src/Collectors/UsedTranslationTranslatorCollector.php
+++ b/src/Collectors/UsedTranslationTranslatorCollector.php
@@ -21,7 +21,11 @@ final class UsedTranslationTranslatorCollector implements Collector
         return Node\Expr\MethodCall::class;
     }
 
-    /** @param Node\Expr\MethodCall $node */
+    /**
+     * @param Node\Expr\MethodCall $node
+     *
+     * @return array{0: string, 1: int}
+     */
     public function processNode(Node $node, Scope $scope): array|null
     {
         $name = $node->name;

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Collectors;
 
 use Larastan\Larastan\Support\ViewFileHelper;
+use Larastan\Larastan\Support\ViewParser;
 use PhpParser\Node;
-use PHPStan\Parser\Parser;
-use PHPStan\Parser\ParserErrorsException;
 
 use function array_filter;
 use function array_map;
@@ -22,7 +21,7 @@ final class UsedTranslationViewCollector
     /** @see https://regex101.com/r/ksUgGz/1 */
     private const TRANSLATION_REGEX = '/[^\w](trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*)\k{quote}[\),]/m';
 
-    public function __construct(private Parser $parser, private ViewFileHelper $viewFileHelper)
+    public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {
     }
 
@@ -32,13 +31,9 @@ final class UsedTranslationViewCollector
         $translations = [];
 
         foreach ($this->viewFileHelper->getRootViewFilePaths() as $viewFile) {
-            try {
-                $parserNodes = $this->parser->parseFile($viewFile);
+            $parserNodes = $this->viewParser->getNodes($viewFile);
 
-                $translations[$viewFile] = $this->processNodes($parserNodes);
-            } catch (ParserErrorsException) {
-                continue;
-            }
+            $translations[$viewFile] = $this->processNodes($parserNodes);
         }
 
         return $translations;

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Collectors;
+
+use Larastan\Larastan\Support\ViewFileHelper;
+use PhpParser\Node;
+use PHPStan\Parser\Parser;
+use PHPStan\Parser\ParserErrorsException;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function count;
+use function preg_match_all;
+
+use const PREG_SET_ORDER;
+
+final class UsedTranslationViewCollector
+{
+    /** @see https://regex101.com/r/ksUgGz/1 */
+    private const TRANSLATION_REGEX = '/[^\w](trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*)\k{quote}[\),]/m';
+
+    public function __construct(private Parser $parser, private ViewFileHelper $viewFileHelper)
+    {
+    }
+
+    /** @return string[] */
+    public function getUsedTranslations(): array
+    {
+        $translations = [];
+
+        foreach ($this->viewFileHelper->getRootViewFilePaths() as $viewFile) {
+            try {
+                $parserNodes = $this->parser->parseFile($viewFile);
+
+                $translations[$viewFile] = $this->processNodes($parserNodes);
+            } catch (ParserErrorsException) {
+                continue;
+            }
+        }
+
+        return $translations;
+    }
+
+    /**
+     * @param Node\Stmt[] $nodes
+     *
+     * @return string[]
+     */
+    private function processNodes(array $nodes): array
+    {
+        $nodes = array_filter($nodes, static function (Node $node): bool {
+            return $node instanceof Node\Stmt\InlineHTML;
+        });
+
+        if (count($nodes) === 0) {
+            return [];
+        }
+
+        $translations = [];
+
+        foreach ($nodes as $node) {
+            preg_match_all(self::TRANSLATION_REGEX, $node->value, $matches, PREG_SET_ORDER, 0);
+
+            $translations = array_merge($translations, array_map(static function (array $match): array {
+                return [$match[3], 0];
+            }, $matches));
+        }
+
+        return $translations;
+    }
+}

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -26,7 +26,7 @@ final class UsedTranslationViewCollector
     {
     }
 
-    /** @return string[] */
+    /** @return array<string, array{0: string, 1: int}[]> */
     public function getUsedTranslations(): array
     {
         $translations = [];
@@ -47,7 +47,7 @@ final class UsedTranslationViewCollector
     /**
      * @param Node\Stmt[] $nodes
      *
-     * @return string[]
+     * @return array{0: string, 1: int}[]
      */
     private function processNodes(array $nodes): array
     {

--- a/src/Collectors/UsedViewInAnotherViewCollector.php
+++ b/src/Collectors/UsedViewInAnotherViewCollector.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Collectors;
 
 use Larastan\Larastan\Support\ViewFileHelper;
+use Larastan\Larastan\Support\ViewParser;
 use PhpParser\Node;
-use PHPStan\Parser\Parser;
-use PHPStan\Parser\ParserErrorsException;
 
 use function array_filter;
 use function array_map;
@@ -22,7 +21,7 @@ final class UsedViewInAnotherViewCollector
     /** @see https://regex101.com/r/OyHHCY/1 */
     private const VIEW_NAME_REGEX = '/@(extends|include(If|Unless|When|First)?)(\(.*?([\'"])(.*?)([\'"])([),]))/m';
 
-    public function __construct(private Parser $parser, private ViewFileHelper $viewFileHelper)
+    public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {
     }
 
@@ -30,14 +29,11 @@ final class UsedViewInAnotherViewCollector
     public function getUsedViews(): array
     {
         $usedViews = [];
-        foreach ($this->viewFileHelper->getAllViewFilePaths() as $viewFile) {
-            try {
-                $parserNodes = $this->parser->parseFile($viewFile);
 
-                $usedViews = array_merge($usedViews, $this->processNodes($parserNodes));
-            } catch (ParserErrorsException) {
-                continue;
-            }
+        foreach ($this->viewFileHelper->getAllViewFilePaths() as $viewFile) {
+            $parserNodes = $this->viewParser->getNodes($viewFile);
+
+            $usedViews = array_merge($usedViews, $this->processNodes($parserNodes));
         }
 
         return $usedViews;

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Rules;
 
-use Illuminate\Contracts\Translation\Translator as TranslatorContract;
-use Illuminate\Translation\Translator;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
 use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
@@ -17,17 +17,28 @@ use PHPStan\Node\CollectedDataNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\Finder\SplFileInfo;
 
 use function array_key_exists;
+use function array_keys;
+use function array_map;
 use function array_merge;
+use function in_array;
+use function is_dir;
+use function json_decode;
+use function lang_path;
 
 /** @implements Rule<CollectedDataNode> */
 final class NoMissingTranslationsRule implements Rule
 {
     use HasContainer;
 
-    public function __construct(private UsedTranslationViewCollector $usedTranslationViewCollector)
-    {
+    /** @param string[] $translationDirectories */
+    public function __construct(
+        private UsedTranslationViewCollector $usedTranslationViewCollector,
+        private Filesystem $filesystem,
+        private array $translationDirectories,
+    ) {
     }
 
     public function getNodeType(): string
@@ -38,6 +49,8 @@ final class NoMissingTranslationsRule implements Rule
     /** @return RuleError[] */
     public function processNode(Node $node, Scope $scope): array
     {
+        $paths = $this->translationDirectories ?: [lang_path()];
+
         /** @var array<string, array{0: string, 1: int}[]>[] $collectors */
         $collectors = [
             $node->get(UsedTranslationFunctionCollector::class),
@@ -45,6 +58,32 @@ final class NoMissingTranslationsRule implements Rule
             $node->get(UsedTranslationFacadeCollector::class),
             $this->usedTranslationViewCollector->getUsedTranslations(),
         ];
+
+        $availableTranslations = [];
+
+        foreach ($paths as $path) {
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            $files = $this->filesystem->allFiles($path);
+
+            $translations = array_map(function (SplFileInfo $file): array {
+                $translations = [];
+
+                if ($file->getExtension() === 'php') {
+                    $translations = Arr::dot([
+                        $file->getFilenameWithoutExtension() => $this->filesystem->getRequire($file->getPathname()),
+                    ]);
+                } elseif ($file->getExtension() === 'json') {
+                    $translations = json_decode($this->filesystem->get($file->getPathname()), true);
+                }
+
+                return array_keys($translations);
+            }, $files);
+
+            $availableTranslations = array_merge($availableTranslations, ...$translations);
+        }
 
         $usedTranslations = [];
 
@@ -58,14 +97,11 @@ final class NoMissingTranslationsRule implements Rule
             }
         }
 
-        /** @var Translator $translator */
-        $translator = $this->resolve(TranslatorContract::class);
-
         $errors = [];
 
         foreach ($usedTranslations as $file => $translations) {
             foreach ($translations as [$translation, $line]) {
-                if ($translator->has($translation)) {
+                if (in_array($translation, $availableTranslations, true)) {
                     continue;
                 }
 

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -10,7 +10,6 @@ use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
 use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
 use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
-use Larastan\Larastan\Concerns\HasContainer;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -31,8 +30,6 @@ use function lang_path;
 /** @implements Rule<CollectedDataNode> */
 final class NoMissingTranslationsRule implements Rule
 {
-    use HasContainer;
-
     /** @param string[] $translationDirectories */
     public function __construct(
         private UsedTranslationViewCollector $usedTranslationViewCollector,

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Illuminate\Contracts\Translation\Translator as TranslatorContract;
+use Illuminate\Translation\Translator;
+use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
+use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
+use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
+use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
+use Larastan\Larastan\Concerns\HasContainer;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function array_key_exists;
+use function array_merge;
+
+/** @implements Rule<CollectedDataNode> */
+final class NoMissingTranslationsRule implements Rule
+{
+    use HasContainer;
+
+    public function __construct(private UsedTranslationViewCollector $usedTranslationViewCollector)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /** @return RuleError[] */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $collectors = [
+            $node->get(UsedTranslationFunctionCollector::class),
+            $node->get(UsedTranslationTranslatorCollector::class),
+            $node->get(UsedTranslationFacadeCollector::class),
+            $this->usedTranslationViewCollector->getUsedTranslations(),
+        ];
+
+        $usedTranslations = [];
+
+        foreach ($collectors as $collector) {
+            foreach ($collector as $file => $translations) {
+                if (! array_key_exists($file, $usedTranslations)) {
+                    $usedTranslations[$file] = [];
+                }
+
+                $usedTranslations[$file] = array_merge($usedTranslations[$file], $translations);
+            }
+        }
+
+        /** @var Translator $translator */
+        $translator = $this->resolve(TranslatorContract::class);
+
+        $errors = [];
+
+        foreach ($usedTranslations as $file => $translations) {
+            foreach ($translations as [$translation, $line]) {
+                if ($translator->has($translation)) {
+                    continue;
+                }
+
+                $errors[] = RuleErrorBuilder::message('Translation "' . $translation . '" has not been found.')
+                    ->file($file)
+                    ->line($line)
+                    ->identifier('larastan.missingTranslations')
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -38,6 +38,7 @@ final class NoMissingTranslationsRule implements Rule
     /** @return RuleError[] */
     public function processNode(Node $node, Scope $scope): array
     {
+        /** @var array<string, array{0: string, 1: int}[]>[] $collectors */
         $collectors = [
             $node->get(UsedTranslationFunctionCollector::class),
             $node->get(UsedTranslationTranslatorCollector::class),

--- a/src/Support/ViewFileHelper.php
+++ b/src/Support/ViewFileHelper.php
@@ -11,6 +11,7 @@ use PHPStan\File\FileHelper;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
+use SplFileInfo;
 
 use function array_merge;
 use function array_values;
@@ -44,23 +45,21 @@ final class ViewFileHelper
         $this->viewDirectories = $viewDirectories; // @phpstan-ignore-line
     }
 
+    public function getRootViewFilePaths(): Generator
+    {
+        $finder = $this->resolve(ViewFactory::class)->getFinder();
+
+        foreach ($finder->getPaths() as $path) {
+            foreach ($this->getViews($path) as $view) {
+                yield $view->getPathname();
+            }
+        }
+    }
+
     public function getAllViewFilePaths(): Generator
     {
         foreach ($this->viewDirectories as $viewDirectory) {
-            $absolutePath = $this->fileHelper->absolutizePath($viewDirectory);
-
-            if (! is_dir($absolutePath)) {
-                continue;
-            }
-
-            $views = iterator_to_array(
-                new RegexIterator(
-                    new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                    '/\.blade\.php$/i',
-                ),
-            );
-
-            foreach ($views as $view) {
+            foreach ($this->getViews($viewDirectory) as $view) {
                 yield $view->getPathname();
             }
         }
@@ -69,20 +68,7 @@ final class ViewFileHelper
     public function getAllViewNames(): Generator
     {
         foreach ($this->viewDirectories as $viewDirectory) {
-            $absolutePath = $this->fileHelper->absolutizePath($viewDirectory);
-
-            if (! is_dir($absolutePath)) {
-                continue;
-            }
-
-            $views = iterator_to_array(
-                new RegexIterator(
-                    new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                    '/\.blade\.php$/i',
-                ),
-            );
-
-            foreach ($views as $view) {
+            foreach ($this->getViews($viewDirectory) as $view) {
                 if (str_contains($view->getPathname(), 'views' . DIRECTORY_SEPARATOR . 'vendor') || str_contains($view->getPathname(), 'views' . DIRECTORY_SEPARATOR . 'errors')) {
                     continue;
                 }
@@ -92,5 +78,22 @@ final class ViewFileHelper
                 yield str_replace([DIRECTORY_SEPARATOR, '.blade.php'], ['.', ''], $viewName[1]);
             }
         }
+    }
+
+    /** @return SplFileInfo[] */
+    protected function getViews(string $path): array
+    {
+        $absolutePath = $this->fileHelper->absolutizePath($path);
+
+        if (! is_dir($absolutePath)) {
+            return [];
+        }
+
+        return iterator_to_array(
+            new RegexIterator(
+                new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
+                '/\.blade\.php$/i',
+            ),
+        );
     }
 }

--- a/src/Support/ViewParser.php
+++ b/src/Support/ViewParser.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Support;
+
+use PhpParser\Node\Stmt;
+use PHPStan\Parser\Parser;
+use PHPStan\Parser\ParserErrorsException;
+
+use function array_key_exists;
+
+final class ViewParser
+{
+    /** @var array<string, Stmt[]> */
+    protected array $nodes = [];
+
+    public function __construct(private Parser $parser)
+    {
+    }
+
+    /** @return Stmt[] */
+    public function getNodes(string $path): array
+    {
+        if (! array_key_exists($path, $this->nodes)) {
+            $this->nodes[$path] = $this->parseFile($path);
+        }
+
+        return $this->nodes[$path];
+    }
+
+    /** @return Stmt[] */
+    protected function parseFile(string $path): array
+    {
+        try {
+            return $this->parser->parseFile($path);
+        } catch (ParserErrorsException) {
+            return [];
+        }
+    }
+}

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
+use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
+use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
+use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
+use Larastan\Larastan\Rules\NoMissingTranslationsRule;
+use Larastan\Larastan\Support\ViewFileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<NoMissingTranslationsRule> */
+class NoMissingTranslationsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        $viewFileHelper = new ViewFileHelper([], $this->getFileHelper());
+
+        return new NoMissingTranslationsRule(new UsedTranslationViewCollector(
+            $this->getContainer()->getService('currentPhpVersionSimpleDirectParser'),
+            $viewFileHelper,
+        ));
+    }
+
+    /** @return array<Collector<Node, mixed>> */
+    protected function getCollectors(): array
+    {
+        return [
+            new UsedTranslationFunctionCollector(),
+            new UsedTranslationTranslatorCollector(),
+            new UsedTranslationFacadeCollector(),
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/Translation.php'], [
+            [
+                'Translation "messages.test" has not been found.',
+                18,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                19,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                20,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                25,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                26,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                31,
+            ],
+            [
+                'Translation "messages.test" has not been found.',
+                32,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/phpstan-rules.neon',
+        ];
+    }
+}

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Rules;
 
+use Illuminate\Filesystem\Filesystem;
 use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
 use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
@@ -23,7 +24,7 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
         return new NoMissingTranslationsRule(new UsedTranslationViewCollector(
             $this->getContainer()->getService('currentPhpVersionSimpleDirectParser'),
             $viewFileHelper,
-        ));
+        ), new Filesystem(), []);
     }
 
     /** @return array<Collector<Node, mixed>> */

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -11,6 +11,7 @@ use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
 use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
 use Larastan\Larastan\Rules\NoMissingTranslationsRule;
 use Larastan\Larastan\Support\ViewFileHelper;
+use Larastan\Larastan\Support\ViewParser;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -19,12 +20,10 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
+        $viewParser     = new ViewParser($this->getContainer()->getService('currentPhpVersionSimpleDirectParser'));
         $viewFileHelper = new ViewFileHelper([], $this->getFileHelper());
 
-        return new NoMissingTranslationsRule(new UsedTranslationViewCollector(
-            $this->getContainer()->getService('currentPhpVersionSimpleDirectParser'),
-            $viewFileHelper,
-        ), new Filesystem(), []);
+        return new NoMissingTranslationsRule(new UsedTranslationViewCollector($viewParser, $viewFileHelper), new Filesystem(), []);
     }
 
     /** @return array<Collector<Node, mixed>> */

--- a/tests/Rules/UnusedViewsRuleTest.php
+++ b/tests/Rules/UnusedViewsRuleTest.php
@@ -12,6 +12,7 @@ use Larastan\Larastan\Collectors\UsedViewInAnotherViewCollector;
 use Larastan\Larastan\Collectors\UsedViewMakeCollector;
 use Larastan\Larastan\Rules\UnusedViewsRule;
 use Larastan\Larastan\Support\ViewFileHelper;
+use Larastan\Larastan\Support\ViewParser;
 use PhpParser\Node;
 use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
@@ -22,15 +23,13 @@ class UnusedViewsRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
+        $viewParser     = new ViewParser($this->getContainer()->getService('currentPhpVersionSimpleDirectParser'));
         $viewFileHelper = new ViewFileHelper([
             __DIR__ . '/../application/resources/views',
             __DIR__ . '/../../vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/views',
         ], $this->getFileHelper());
 
-        return new UnusedViewsRule(new UsedViewInAnotherViewCollector(
-            $this->getContainer()->getService('currentPhpVersionSimpleDirectParser'),
-            $viewFileHelper,
-        ), $viewFileHelper);
+        return new UnusedViewsRule(new UsedViewInAnotherViewCollector($viewParser, $viewFileHelper), $viewFileHelper);
     }
 
     /** @return array<Collector<Node, mixed>> */

--- a/tests/Rules/data/Translation.php
+++ b/tests/Rules/data/Translation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Translation\Translator;
+
+class Translation
+{
+    public function translate(Translator $translator): void
+    {
+        __('messages.foo');
+        trans('messages.foo');
+        trans_choice('messages.foo', 1);
+
+        __('messages.test');
+        trans('messages.test');
+        trans_choice('messages.test', 1);
+
+        $translator->get('messages.bar');
+        $translator->choice('messages.bar', 1);
+
+        $translator->get('messages.test');
+        $translator->choice('messages.test', 1);
+
+        Lang::get('messages.baz');
+        Lang::choice('messages.baz', 1);
+
+        Lang::get('messages.test');
+        Lang::choice('messages.test', 1);
+    }
+}

--- a/tests/Rules/data/Translation.php
+++ b/tests/Rules/data/Translation.php
@@ -30,5 +30,8 @@ class Translation
 
         Lang::get('messages.test');
         Lang::choice('messages.test', 1);
+
+        __('foo bar baz');
+        __('messages.nested.key');
     }
 }

--- a/tests/application/resources/lang/en.json
+++ b/tests/application/resources/lang/en.json
@@ -1,0 +1,3 @@
+{
+    "foo bar baz": "Foo Bar Baz"
+}

--- a/tests/application/resources/lang/en/messages.php
+++ b/tests/application/resources/lang/en/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'foo' => 'Foo',
+    'bar' => 'Bar',
+    'baz' => 'Baz',
+];

--- a/tests/application/resources/lang/en/messages.php
+++ b/tests/application/resources/lang/en/messages.php
@@ -4,4 +4,8 @@ return [
     'foo' => 'Foo',
     'bar' => 'Bar',
     'baz' => 'Baz',
+
+    'nested' => [
+        'key' => 'value',
+    ],
 ];


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

I've added the `NoMissingTranslationsRule` to automatically check if all used translations are available. This pull request has been heavily inspired by #1456.

This pull request resolves issue #1822.

Curious about your thoughts!

**Changes**

By setting the option `checkMissingTranslations` to `true`, the rule will automatically check if all used translations exist.

It will check the following:

* Helper methods `__`, `trans` and `trans_choice`.
* Methods `get` and `choice` on the `Translator` class itself.
* Methods `get` and `choice` on the `Lang` facade.
* All of the above within views, including Blade directives.

**Breaking changes**

No breaking changes have been introduced. The rule is disabled by default.