### PR TITLE
[3.x] Use explicit nullable types

### DIFF
--- a/stubs/common/Attribute.stub
+++ b/stubs/common/Attribute.stub
@@ -31,7 +31,7 @@ class Attribute
      * @param  (callable(TMakeSet, array<string, mixed>): mixed)|null  $set
      * @return Attribute<TMakeGet, TMakeSet>
      */
-    public static function make(callable $get = null, callable $set = null);
+    public static function make(?callable $get = null, ?callable $set = null);
 
     /**
      * Create a new attribute accessor.

--- a/stubs/common/Conditionable.stub
+++ b/stubs/common/Conditionable.stub
@@ -17,7 +17,7 @@ trait Conditionable
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return (TWhenReturnType is void|null ? $this : TWhenReturnType)
      */
-    public function when($value, callable $callback = null, callable $default = null);
+    public function when($value, ?callable $callback = null, ?callable $default = null);
 
     /**
      * Apply the callback if the given "value" is (or resolves to) falsy.
@@ -30,5 +30,5 @@ trait Conditionable
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return (TUnlessReturnType is void|null ? $this : TUnlessReturnType)
      */
-    public function unless($value, callable $callback = null, callable $default = null);
+    public function unless($value, ?callable $callback = null, ?callable $default = null);
 }

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -144,7 +144,7 @@ class Builder
      * @param  (\Closure(): TValue)|null  $callback
      * @return TModel|TValue
      */
-    public function firstOr($columns = ['*'], \Closure $callback = null);
+    public function firstOr($columns = ['*'], ?\Closure $callback = null);
 
     /**
      * Attempt to create the record. If a unique constraint violation occurs, attempt to find the matching record.

--- a/stubs/common/Foundation/Http/FormRequest.stub
+++ b/stubs/common/Foundation/Http/FormRequest.stub
@@ -11,7 +11,7 @@ class FormRequest
      *
      * @return ($keys is null ? \Illuminate\Support\ValidatedInput : array<string, mixed>)
      */
-    public function safe(array $keys = null);
+    public function safe(?array $keys = null);
 
     /**
      * Get the validated data from the request.

--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -154,7 +154,7 @@ function __($key = null, $replace = [], $locale = null) {}
  * @param  ?callable(TValue): TReturn  $callback
  * @return ($callback is null ? mixed : ($value is null ? null : TReturn))
  */
-function optional($value = null, callable $callback = null) {}
+function optional($value = null, ?callable $callback = null) {}
 
 /**
  * Transform the given value if it is present.

--- a/stubs/common/Validation/Validator.stub
+++ b/stubs/common/Validation/Validator.stub
@@ -11,5 +11,5 @@ class Validator
      *
      * @return ($keys is null ? \Illuminate\Support\ValidatedInput : array<string, mixed>)
      */
-    public function safe(array $keys = null);
+    public function safe(?array $keys = null);
 }


### PR DESCRIPTION
After making changes to the stub files, running Larastan for the first time on PHP 8.4 causes deprecation notices.

```
Deprecated in PHP 8.4: Parameter #1 $get (callable) is implicitly nullable via default value null.
```

This pull request has been made to resolve them.

**Changes**

I've changed the implicitly nullable parameters to be explicitly nullable. Note that the types themselves have already been updated in Laravel.

**Breaking changes**

No breaking changes have been introduced. Marking parameters explicitly as nullable won't break existing code.