### PR TITLE
fix: allow null values in trans replacements

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -128,7 +128,7 @@ function view($view = null, $data = [], $mergeData = []) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar>  $replace
+ * @param  array<string, scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : mixed)
  */
@@ -138,7 +138,7 @@ function trans($key = null, $replace = [], $locale = null) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar>  $replace
+ * @param  array<string, scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? null : mixed)
  */


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Make `null` an allowed value for the "replacements" array in `trans()` and `__()` helpers. 

This is supported by Laravel intentionally, judging by this PR, which explicitly added handling for `null` values when migrating to a newer PHP version: https://github.com/laravel/framework/pull/42216

**Breaking changes**

None, completely backwards compatible.
