### PR TITLE
Add autowired to Filesystem in extension.neon

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -668,6 +668,7 @@ services:
 
     -
         class: Illuminate\Filesystem\Filesystem
+        autowired: self
 
 rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule


### PR DESCRIPTION
Resolves #2361

Also see issue https://github.com/bladestan/bladestan/issues/166

**Introduction**

In version [v3.7.0](https://github.com/larastan/larastan/releases/tag/v3.7.0) the service `Illuminate\Filesystem\Filesystem` has been added to the configuration file. Additional extensions like [bladestan](https://github.com/bladestan/bladestan) have already registered this class, causing issues with dependency injection.

This process is documented on [doc.nette.org](https://doc.nette.org/en/dependency-injection/autowiring):

> To be able to use autowiring, there must be exactly one service of each type in the container. If there were more, autowiring wouldn't know which one to pass and would throw an exception

To solve this, a preference can be set using the `autowired` attribute. Note that multiple `autowired` attributes will cause the same issue.

Alternatively, users may configure their own `phpstan.neon` by adding the following content:

```neon
...

services:
    -
        class: Illuminate\Filesystem\Filesystem
        autowired: self
```

This, of course, may not be desirable.

**Changes**

I've added `autowired: self` to the `Illuminate\Filesystem\Filesystem` service configuration.

I'm not quite sure if this should be added to Larastan as it works out of the box. Happy to hear your thoughts!

**Breaking changes**

No breaking changes have been introduced.