### PR TITLE
[3.x] Add Larastan Filesystem

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -667,7 +667,8 @@ services:
         class: Larastan\Larastan\Rules\ConfigCollectionRule
 
     -
-        class: Illuminate\Filesystem\Filesystem
+        class: Larastan\Larastan\Support\Filesystem
+        autowired: self
 
 rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Rules;
 
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
 use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
 use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
+use Larastan\Larastan\Support\Filesystem;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Support;
+
+use Illuminate\Filesystem\Filesystem as BaseFilesystem;
+
+final class Filesystem extends BaseFilesystem
+{
+}

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -6,6 +6,7 @@ namespace Larastan\Larastan\Support;
 
 use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 
+/** @internal */
 final class Filesystem extends BaseFilesystem
 {
 }

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Rules;
 
-use Illuminate\Filesystem\Filesystem;
 use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
 use Larastan\Larastan\Collectors\UsedTranslationTranslatorCollector;
 use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
 use Larastan\Larastan\Rules\NoMissingTranslationsRule;
+use Larastan\Larastan\Support\Filesystem;
 use Larastan\Larastan\Support\ViewFileHelper;
 use Larastan\Larastan\Support\ViewParser;
 use PHPStan\Rules\Rule;


### PR DESCRIPTION
Resolves #2361

Also see issue https://github.com/bladestan/bladestan/issues/166

This is an alternative approach to https://github.com/larastan/larastan/pull/2365

**Introduction**

In version [v3.7.0](https://github.com/larastan/larastan/releases/tag/v3.7.0) the service `Illuminate\Filesystem\Filesystem` has been added to the configuration file. Additional extensions like [bladestan](https://github.com/bladestan/bladestan) have already registered this class, causing issues with dependency injection.

This process is documented on [doc.nette.org](https://doc.nette.org/en/dependency-injection/autowiring):

> To be able to use autowiring, there must be exactly one service of each type in the container. If there were more, autowiring wouldn't know which one to pass and would throw an exception

By adding a separate Larastan class, the extension won't be affected by other extensions.

**Changes**

I've added a `Filesystem` class that extends `Illuminate\Filesystem\Filesystem` and will only be autowired to itself and not the parent class(es).

**Breaking changes**

No breaking changes have been introduced.