### PR TITLE
fix: request->server() returns float|int|list<string>|string

### DIFF
--- a/stubs/common/Http/InteractsWithInput.stub
+++ b/stubs/common/Http/InteractsWithInput.stub
@@ -30,7 +30,7 @@ trait InteractsWithInput
      * @template TDefault
      * @param  string|null  $key
      * @param  TDefault  $default
-     * @return ($key is null ? array<string, string> : string|TDefault)
+     * @return ($key is null ? array<string, float|int|list<string>|string> : float|int|list<string>|string|TDefault)
      */
     public function server($key = null, $default = null);
 }

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -18,9 +18,9 @@ function test(Request $request): void
     assertType('(object|string|null)', $request->route('foo'));
     assertType('(object|string)', $request->route('foo', 'bar'));
 
-    assertType('array<string, string>', $request->server());
-    assertType('string|null', $request->server('foo'));
-    assertType('5|string', $request->server('foo', 5));
+    assertType('array<string, float|int|list<string>|string>', $request->server());
+    assertType('float|int|list<string>|string|null', $request->server('foo'));
+    assertType('float|int|list<string>|string', $request->server('foo', 5));
 
     assertType('array', $request->post());
     assertType('(array|string|null)', $request->post('foo'));


### PR DESCRIPTION
Hello!

Turns out that `$request->server()` can return ints, floats, or even a list of strings (argv) when running in cli


Thanks!