### PR TITLE
[3.x] Make regex for UsedTranslationViewCollector lazy

### DIFF
--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -18,8 +18,8 @@ use const PREG_SET_ORDER;
 
 final class UsedTranslationViewCollector
 {
-    /** @see https://regex101.com/r/ksUgGz/1 */
-    private const TRANSLATION_REGEX = '/[^\w](trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*)\k{quote}[\),]/m';
+    /** @see https://regex101.com/r/akPfPj/1 */
+    private const TRANSLATION_REGEX = '/[^\w](trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/m';
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {


### PR DESCRIPTION
Resolves #2367

**Changes**

I've changed `*` to `*?` in order to make the regex *lazy*. By doing so, the pattern will match as few characters as possible, stopping at the correct quote.

> **Note**: The linked regex101.com example does not seem to show the issue.

**Example**

```html
<input placeholder="@lang('a.b')" value="{{ old('email') }}">
Using *                    ---------------------------
Using *?                   ---
```

**Breaking changes**

No breaking changes have been introduced.