### PR TITLE
[3.x] Ignore vendor translations

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -401,6 +401,8 @@ parameters:
 
 This rule will find any untranslated strings in your application. It is primarily meant for applications that make use of the dot syntax like `messages.greet`. If you're using translation strings as keys, this rule may be unnecessary. Enabling this rule may decrease performance as it will scan the available views and translations.
 
+Translations from vendors like `vendor::key` will not be checked.
+
 > **NOTE**: If you store your translations in a database, this rule will not be able to detect them. You should leave this rule disabled in such cases.
 
 ### Examples

--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -27,6 +27,7 @@ use function in_array;
 use function is_dir;
 use function json_decode;
 use function lang_path;
+use function str_contains;
 use function strlen;
 
 use const DIRECTORY_SEPARATOR;
@@ -111,7 +112,7 @@ final class NoMissingTranslationsRule implements Rule
 
         foreach ($usedTranslations as $file => $translations) {
             foreach ($translations as [$translation, $line]) {
-                if (in_array($translation, $availableTranslations, true)) {
+                if (in_array($translation, $availableTranslations, true) || str_contains($translation, '::')) {
                     continue;
                 }
 

--- a/tests/Rules/data/Translation.php
+++ b/tests/Rules/data/Translation.php
@@ -36,5 +36,7 @@ class Translation
 
         Lang::get('sub/lines.greeting');
         Lang::get('sub/lines.farewell');
+
+        __('vendor::key');
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

Resolves  #2360

**Introduction**

All translations containing a vendor prefix like `vendor::key` will fail. This is due to the loading of the available translations reflecting file paths. The *namespace* or *hint* is not taken in account. Adding support for them seems quite the challenge.

The folder name does not necessarily correspond to the *namespace*. We wouldn't be able to know how it's called from a static analysis point of view.

```php
$this->loadTranslationsFrom('...', 'This Is My Namespace!');

__('This Is My Namespace!::messages.greeting');
```

Next up, as stated on the [documentation](https://laravel.com/docs/12.x/localization#overriding-package-language-files) of Laravel, the files may only contain overrides.

> Within this file, you should only define the translation strings you wish to override.

This means that we must merge the original translations from the package vendor as well.

All things considered, it would take quite some effort to implement vendor prefixes. Either automatically or introduce additional configuration to specify the used namespaces. I think scoping the rule for local translations would be the best option.

Wondering what you think!

**Changes**

Translations that include `::` will be ignored.

**Breaking changes**

No breaking changes have been introduced.