### PR TITLE
[3.x] Add support for translation groups

### DIFF
--- a/src/Rules/NoMissingTranslationsRule.php
+++ b/src/Rules/NoMissingTranslationsRule.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Rules;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Larastan\Larastan\Collectors\UsedTranslationFacadeCollector;
 use Larastan\Larastan\Collectors\UsedTranslationFunctionCollector;
@@ -24,6 +23,7 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function in_array;
+use function is_array;
 use function is_dir;
 use function json_decode;
 use function lang_path;
@@ -78,18 +78,20 @@ final class NoMissingTranslationsRule implements Rule
                         ->slice(1, -1) // Trim locale and filename
                         ->join('/');
 
-                    $key = strlen($prefix) > 0
+                    $root = strlen($prefix) > 0
                         ? $prefix . '/' . $file->getFilenameWithoutExtension()
                         : $file->getFilenameWithoutExtension();
 
-                    $translations = Arr::dot([
-                        $key => $this->filesystem->getRequire($file->getPathname()),
-                    ]);
+                    $array = $this->filesystem->getRequire($file->getPathname());
+
+                    $translations = array_merge([$root], $this->keys($array, $root));
                 } elseif ($file->getExtension() === 'json') {
-                    $translations = json_decode($this->filesystem->get($file->getPathname()), true);
+                    $translations = array_keys(
+                        json_decode($this->filesystem->get($file->getPathname()), true),
+                    );
                 }
 
-                return array_keys($translations);
+                return $translations;
             }, $files);
 
             $availableTranslations = array_merge($availableTranslations, ...$translations);
@@ -124,5 +126,29 @@ final class NoMissingTranslationsRule implements Rule
         }
 
         return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     *
+     * @return string[]
+     */
+    protected function keys(array $array, string $prefix): array
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            $newKey = $prefix . '.' . $key;
+
+            $results[] = $newKey;
+
+            if (! is_array($value)) {
+                continue;
+            }
+
+            $results = array_merge($results, $this->keys($value, $newKey));
+        }
+
+        return $results;
     }
 }

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -69,7 +69,7 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
             ],
             [
                 'Translation "sub/lines.farewell" has not been found.',
-                38,
+                40,
             ],
         ]);
     }

--- a/tests/Rules/data/Translation.php
+++ b/tests/Rules/data/Translation.php
@@ -32,6 +32,8 @@ class Translation
         Lang::choice('messages.test', 1);
 
         __('foo bar baz');
+        __('messages');
+        __('messages.nested');
         __('messages.nested.key');
 
         Lang::get('sub/lines.greeting');


### PR DESCRIPTION
- [x] Added or updated tests

Resolves #2368

**Introduction**

In the `NoMissingTranslationsRule` class we make use of the `Arr::dot` method to transform the translations into a single array. As the array is flattened, the keys of translations that contain an array are skipped. Only the lowest level is added, as expected.

See the example below.

```php
// messages.php

return [
    'colors' => [
        'red' => 'Red',
        'green' => 'Green',
        'blue' => 'Blue',
    ],
];
```

Using the `Arr::dot` method with the filename will transform the array into the following keys:

```php
[
    'messages.colors.red',
    'messages.colors.green',
    'messages.colors.blue',
];
```

The translation `__('messages.colors')` will fail as it is not in the list. I've added a new method that will append the keys containing arrays. The file itself will also be added.

```php
[
    'messages',
    'messages.colors',
    'messages.colors.red',
    'messages.colors.green',
    'messages.colors.blue',
];
```

**Changes**

I've added support for translation groups.

**Breaking changes**

No breaking changes have been introduced.