### PR TITLE
feat: add optional phpMyAdmin SQL parser integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,32 @@ jobs:
           version="${{ matrix.laravel }}"
           version="${version%%.*}.0"
           tests/laravel-test.sh "$version"
+
+  tests-phpmyadmin:
+    name: "With PHPMyAdmin parser"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.3"
+          extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
+          tools: "composer:v2"
+          coverage: "none"
+
+      - name: "Check Composer configuration"
+        run: "composer validate"
+
+      - name: "Install dependencies"
+        run: |
+          composer require --dev phpmyadmin/sql-parser:^5.9 --no-interaction --no-progress
+
+      - name: "Check PSR-4 mapping"
+        run: "composer dump-autoload --optimize --strict-psr"
+
+      - name: "Execute unit tests"
+        run: "composer run-script test:unit"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "phpunit/phpunit": "^10.5.35 || ^11.5.15"
     },
     "suggest": {
-        "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+        "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+        "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -49,8 +49,10 @@ parameters:
 
 ### PostgreSQL
 
-The package used to parse the schema dumps, [iamcal/sql-parser](https://github.com/iamcal/sql-parser), is primarily focused on the MySQL dialect.
+The default package used to parse the schema dumps, [iamcal/sql-parser](https://github.com/iamcal/sql-parser), is primarily focused on the MySQL dialect.
 It can read (or rather, try to read) PostgreSQL dumps provided they are in the *plain text (and not the 'custom') format*, but the mileage may vary as problems have been noted with timestamp columns and lengthy parse time on more complicated dumps.
+
+If you install [phpmyadmin/sql-parser](https://github.com/phpmyadmin/sql-parser) (tested with `^5.9`), Larastan will automatically switch to that parser at runtime with no additional configuration. When the package is missing or cannot be loaded, Larastan silently falls back to the bundled parser. If the switch does not occur, verify that Composer autoloads have been regenerated (`composer dump-autoload`) and that only one version of `phpmyadmin/sql-parser` is present in your dependency tree.
 
 The viable options for PostgreSQL at the moment are:
 1. Use the [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) package to write PHPDocs directly to the Models. 

--- a/extension.neon
+++ b/extension.neon
@@ -455,6 +455,19 @@ services:
             parser: @currentPhpVersionSimpleDirectParser
             reflectionProvider: @reflectionProvider
 
+    iamcalSqlParser:
+        class: Larastan\Larastan\SQL\IamcalSqlParser
+        autowired: false
+
+    sqlParserFactory:
+        class: Larastan\Larastan\SQL\SqlParserFactory
+        arguments:
+            iamcalSqlParser: @iamcalSqlParser
+
+    sqlParser:
+        type: Larastan\Larastan\SQL\SqlParser
+        factory: [@sqlParserFactory, create]
+
     -
         class: Larastan\Larastan\Properties\SquashedMigrationHelper
         arguments:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,6 +97,66 @@ parameters:
 			path: src/Rules/UselessConstructs/NoUselessWithFunctionCallsRule.php
 
 		-
+			rawMessage: Access to property $name on an unknown class PhpMyAdmin\SqlParser\Components\CreateDefinition.
+			identifier: class.notFound
+			count: 2
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Access to property $name on an unknown class PhpMyAdmin\SqlParser\Statements\CreateStatement.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Access to property $options on an unknown class PhpMyAdmin\SqlParser\Components\CreateDefinition.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Access to property $statements on an unknown class PhpMyAdmin\SqlParser\Parser.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Access to property $type on an unknown class PhpMyAdmin\SqlParser\Components\CreateDefinition.
+			identifier: class.notFound
+			count: 2
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Caught class PhpMyAdmin\SqlParser\Exceptions\ParserException not found.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Class PhpMyAdmin\SqlParser\Components\CreateDefinition not found.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Class PhpMyAdmin\SqlParser\Statements\CreateStatement not found.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: Instantiated class PhpMyAdmin\SqlParser\Parser not found.
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
+			rawMessage: 'Parameter $definition of method Larastan\Larastan\SQL\PhpMyAdminSqlParser::isNullable() has invalid type PhpMyAdmin\SqlParser\Components\CreateDefinition.'
+			identifier: class.notFound
+			count: 1
+			path: src/SQL/PhpMyAdminSqlParser.php
+
+		-
 			rawMessage: Implementing PHPStan\Type\CompoundType is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.
 			identifier: phpstanApi.interface
 			count: 1

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Properties;
 
-use iamcal\SQLParser;
-use iamcal\SQLParserSyntaxException;
 use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
+use Larastan\Larastan\SQL\SqlParser;
+use Larastan\Larastan\SQL\SqlParserFailure;
 use PHPStan\File\FileHelper;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -17,8 +17,6 @@ use function array_key_exists;
 use function database_path;
 use function file_get_contents;
 use function glob;
-use function is_array;
-use function is_bool;
 use function is_dir;
 use function iterator_to_array;
 use function ksort;
@@ -30,6 +28,7 @@ final class SquashedMigrationHelper
         private array $schemaPaths,
         private FileHelper $fileHelper,
         private MySqlDataTypeToPhpTypeConverter $converter,
+        private SqlParser $sqlParser,
         private bool $disableSchemaScan,
     ) {
     }
@@ -64,37 +63,27 @@ final class SquashedMigrationHelper
             }
 
             try {
-                $parser                      = new SQLParser();
-                $parser->throw_on_bad_syntax = true; // @phpcs:ignore
-                $tableDefinitions            = $parser->parse($fileContents);
-            } catch (SQLParserSyntaxException) {
+                $tableDefinitions = $this->sqlParser->parseTables($fileContents);
+            } catch (SqlParserFailure) {
                 // TODO: re-throw the exception with a clear message?
                 continue;
             }
 
             foreach ($tableDefinitions as $definition) {
-                if (array_key_exists($definition['name'], $tables)) {
+                if (array_key_exists($definition->name, $tables)) {
                     continue;
                 }
 
-                if (! is_array($definition['fields'])) {
-                    continue;
-                }
-
-                $table = new SchemaTable($definition['name']);
-                foreach ($definition['fields'] as $field) {
-                    if ($field['name'] === null || $field['type'] === null) {
-                        continue;
-                    }
-
+                $table = new SchemaTable($definition->name);
+                foreach ($definition->columns as $column) {
                     $table->setColumn(new SchemaColumn(
-                        $field['name'],
-                        $this->converter->convert($field['type']),
-                        $this->isNullable($field),
+                        $column->name,
+                        $this->converter->convert($column->type),
+                        $column->nullable,
                     ));
                 }
 
-                $tables[$definition['name']] = $table;
+                $tables[$definition->name] = $table;
             }
         }
 
@@ -125,19 +114,5 @@ final class SquashedMigrationHelper
         }
 
         return $schemaFiles;
-    }
-
-    /** @param  array<string, string|bool|null> $definition */
-    private function isNullable(array $definition): bool
-    {
-        if (! array_key_exists('null', $definition)) {
-            return false;
-        }
-
-        if (is_bool($definition['null'])) {
-            return $definition['null'];
-        }
-
-        return false;
     }
 }

--- a/src/SQL/ColumnDefinition.php
+++ b/src/SQL/ColumnDefinition.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+final class ColumnDefinition
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public bool $nullable,
+    ) {
+    }
+}

--- a/src/SQL/IamcalSqlParser.php
+++ b/src/SQL/IamcalSqlParser.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+use iamcal\SQLParser as VendorIamcalSqlParser;
+use iamcal\SQLParserSyntaxException;
+
+use function array_key_exists;
+use function is_array;
+use function is_bool;
+use function is_string;
+
+final class IamcalSqlParser implements SqlParser
+{
+    /** @inheritDoc */
+    public function parseTables(string $sql): array
+    {
+        $parser                      = new VendorIamcalSqlParser();
+        $parser->throw_on_bad_syntax = true; // @phpcs:ignore
+
+        try {
+            $tableDefinitions = $parser->parse($sql);
+        } catch (SQLParserSyntaxException $exception) {
+            throw SqlParserFailure::create('Failed to parse SQL schema with iamcal/sql-parser.', $exception);
+        }
+
+        $tables = [];
+        foreach ($tableDefinitions as $definition) {
+            $tableName = $definition['name'] ?? null;
+            if (! is_string($tableName)) {
+                continue;
+            }
+
+            $fields = $definition['fields'] ?? null;
+            if (! is_array($fields)) {
+                continue;
+            }
+
+            $columns = [];
+            foreach ($fields as $field) {
+                $fieldName = $field['name'] ?? null;
+                if (! is_string($fieldName)) {
+                    continue;
+                }
+
+                $fieldType = $field['type'] ?? null;
+                if (! is_string($fieldType)) {
+                    continue;
+                }
+
+                $columns[] = new ColumnDefinition(
+                    $fieldName,
+                    $fieldType,
+                    $this->resolveNullableFlag($field),
+                );
+            }
+
+            $tables[] = new TableDefinition($tableName, $columns);
+        }
+
+        return $tables;
+    }
+
+    /** @param array<string, mixed> $field */
+    private function resolveNullableFlag(array $field): bool
+    {
+        if (! array_key_exists('null', $field)) {
+            return false;
+        }
+
+        $nullFlag = $field['null'];
+
+        if (is_bool($nullFlag)) {
+            return $nullFlag;
+        }
+
+        if (is_string($nullFlag)) {
+            return $nullFlag === 'YES';
+        }
+
+        return false;
+    }
+}

--- a/src/SQL/PhpMyAdminSqlParser.php
+++ b/src/SQL/PhpMyAdminSqlParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+use PhpMyAdmin\SqlParser\Components\CreateDefinition;
+use PhpMyAdmin\SqlParser\Exceptions\ParserException;
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statements\CreateStatement;
+
+use function array_filter;
+use function is_array;
+
+final class PhpMyAdminSqlParser implements SqlParser
+{
+    /** @inheritDoc */
+    public function parseTables(string $sql): array
+    {
+        try {
+            $parser = new Parser($sql);
+        } catch (ParserException $exception) {
+            throw SqlParserFailure::create('Failed to parse SQL schema with phpmyadmin/sql-parser.', $exception);
+        }
+
+        $createStatements = array_filter(
+            $parser->statements,
+            static fn (object $statement): bool => $statement instanceof CreateStatement
+                && $statement->name?->table !== null,
+        );
+
+        $tables = [];
+
+        foreach ($createStatements as $statement) {
+            $tableName = $statement->name->table;
+
+            if (! is_array($statement->fields)) {
+                continue;
+            }
+
+            $columns = [];
+
+            foreach ($statement->fields as $field) {
+                if (! $field instanceof CreateDefinition) {
+                    continue;
+                }
+
+                if ($field->name === null || $field->type === null) {
+                    continue;
+                }
+
+                $columns[] = new ColumnDefinition(
+                    $field->name,
+                    $field->type->name,
+                    $this->isNullable($field),
+                );
+            }
+
+            $tables[] = new TableDefinition($tableName, $columns);
+        }
+
+        return $tables;
+    }
+
+    /** @param CreateDefinition $definition */
+    private function isNullable(object $definition): bool
+    {
+        return ! $definition->options?->has('NOT NULL');
+    }
+}

--- a/src/SQL/PhpMyAdminSqlParser.php
+++ b/src/SQL/PhpMyAdminSqlParser.php
@@ -18,7 +18,7 @@ final class PhpMyAdminSqlParser implements SqlParser
     public function parseTables(string $sql): array
     {
         try {
-            $parser = new Parser($sql);
+            $parser = new Parser($sql, true);
         } catch (ParserException $exception) {
             throw SqlParserFailure::create('Failed to parse SQL schema with phpmyadmin/sql-parser.', $exception);
         }

--- a/src/SQL/SqlParser.php
+++ b/src/SQL/SqlParser.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+interface SqlParser
+{
+    /**
+     * @return list<TableDefinition>
+     *
+     * @throws SqlParserFailure
+     */
+    public function parseTables(string $sql): array;
+}

--- a/src/SQL/SqlParserFactory.php
+++ b/src/SQL/SqlParserFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+use Closure;
+
+use function class_exists;
+
+final class SqlParserFactory
+{
+    private SqlParser|null $cachedParser = null;
+
+    /** @var Closure():bool */
+    private Closure $phpMyAdminDetector;
+
+    public function __construct(
+        private readonly IamcalSqlParser $iamcalSqlParser,
+        callable|null $phpMyAdminDetector = null,
+    ) {
+        if ($phpMyAdminDetector !== null) {
+            $this->phpMyAdminDetector = Closure::fromCallable($phpMyAdminDetector);
+        } else {
+            $this->phpMyAdminDetector = static fn (): bool => class_exists('PhpMyAdmin\\SqlParser\\Parser');
+        }
+    }
+
+    public function create(): SqlParser
+    {
+        if ($this->cachedParser !== null) {
+            return $this->cachedParser;
+        }
+
+        if ($this->isPhpMyAdminParserAvailable()) {
+            $this->cachedParser = new PhpMyAdminSqlParser();
+        } else {
+            $this->cachedParser = $this->iamcalSqlParser;
+        }
+
+        return $this->cachedParser;
+    }
+
+    private function isPhpMyAdminParserAvailable(): bool
+    {
+        return ($this->phpMyAdminDetector)();
+    }
+}

--- a/src/SQL/SqlParserFailure.php
+++ b/src/SQL/SqlParserFailure.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+use RuntimeException;
+use Throwable;
+
+final class SqlParserFailure extends RuntimeException
+{
+    public static function create(string $message, Throwable|null $previous = null): self
+    {
+        return new self($message, previous: $previous);
+    }
+}

--- a/src/SQL/TableDefinition.php
+++ b/src/SQL/TableDefinition.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\SQL;
+
+final class TableDefinition
+{
+    /** @param list<ColumnDefinition> $columns */
+    public function __construct(
+        public string $name,
+        public array $columns,
+    ) {
+    }
+}

--- a/tests/Unit/SQL/PhpMyAdminSqlParserTest.php
+++ b/tests/Unit/SQL/PhpMyAdminSqlParserTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SQL;
+
+use Larastan\Larastan\SQL\PhpMyAdminSqlParser;
+use Larastan\Larastan\SQL\SqlParserFailure;
+use PhpMyAdmin\SqlParser\Parser;
+use PHPUnit\Framework\TestCase;
+
+use function class_exists;
+
+final class PhpMyAdminSqlParserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(Parser::class)) {
+            $this->markTestSkipped('phpmyadmin/sql-parser is not installed.');
+
+            return;
+        }
+    }
+
+    public function testItMapsCreateTableStatementsToTableDefinitions(): void
+    {
+        $parser = new PhpMyAdminSqlParser();
+
+        $sql = <<<'SQL'
+CREATE TABLE `accounts` (
+    `id` INT NOT NULL,
+    `name` VARCHAR(255)
+);
+SQL;
+
+        $tables = $parser->parseTables($sql);
+
+        $this->assertCount(1, $tables);
+        $table = $tables[0];
+
+        $this->assertSame('accounts', $table->name);
+        $this->assertCount(2, $table->columns);
+
+        $this->assertSame('id', $table->columns[0]->name);
+        $this->assertSame('INT', $table->columns[0]->type);
+        $this->assertFalse($table->columns[0]->nullable);
+
+        $this->assertSame('name', $table->columns[1]->name);
+        $this->assertSame('VARCHAR', $table->columns[1]->type);
+        $this->assertTrue($table->columns[1]->nullable);
+    }
+
+    public function testItWrapsParserExceptions(): void
+    {
+        $this->expectException(SqlParserFailure::class);
+
+        $parser = new PhpMyAdminSqlParser();
+        $parser->parseTables('NOT A VALID SQL');
+    }
+}

--- a/tests/Unit/SQL/SqlParserFactoryTest.php
+++ b/tests/Unit/SQL/SqlParserFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SQL;
+
+use Larastan\Larastan\SQL\IamcalSqlParser;
+use Larastan\Larastan\SQL\PhpMyAdminSqlParser;
+use Larastan\Larastan\SQL\SqlParserFactory;
+use PHPUnit\Framework\TestCase;
+
+final class SqlParserFactoryTest extends TestCase
+{
+    public function testFactoryReturnsDefaultParserWhenOptionalUnavailable(): void
+    {
+        $defaultParser = new IamcalSqlParser();
+
+        $factory = new SqlParserFactory(
+            $defaultParser,
+            static fn (): bool => false,
+        );
+
+        $this->assertSame($defaultParser, $factory->create());
+    }
+
+    public function testFactoryReturnsAdapterWhenOptionalAvailable(): void
+    {
+        $defaultParser = new IamcalSqlParser();
+
+        $factory = new SqlParserFactory(
+            $defaultParser,
+            static fn (): bool => true,
+        );
+
+        $parser = $factory->create();
+
+        $this->assertInstanceOf(PhpMyAdminSqlParser::class, $parser);
+        $this->assertSame($parser, $factory->create());
+    }
+}

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit;
 
 use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
 use Larastan\Larastan\Properties\SquashedMigrationHelper;
-use Larastan\Larastan\SQL\IamcalSqlParser;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -24,7 +23,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/basic_schema'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
-            new IamcalSqlParser(),
+            self::getContainer()->getService('sqlParser'),
             false,
         );
 
@@ -49,7 +48,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_for_same_table'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
-            new IamcalSqlParser(),
+            self::getContainer()->getService('sqlParser'),
             false,
         );
 
@@ -74,7 +73,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/basic_schema_with_sql_extension'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
-            new IamcalSqlParser(),
+            self::getContainer()->getService('sqlParser'),
             false,
         );
 
@@ -99,7 +98,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
-            new IamcalSqlParser(),
+            self::getContainer()->getService('sqlParser'),
             false,
         );
 
@@ -133,12 +132,18 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
-            new IamcalSqlParser(),
+            self::getContainer()->getService('sqlParser'),
             true,
         );
 
         $tables = $schemaParser->initializeTables();
 
         $this->assertSame([], $tables);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../phpstan-tests.neon'];
     }
 }

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
 use Larastan\Larastan\Properties\SquashedMigrationHelper;
+use Larastan\Larastan\SQL\IamcalSqlParser;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,6 +24,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/basic_schema'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
+            new IamcalSqlParser(),
             false,
         );
 
@@ -47,6 +49,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_for_same_table'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
+            new IamcalSqlParser(),
             false,
         );
 
@@ -71,6 +74,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/basic_schema_with_sql_extension'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
+            new IamcalSqlParser(),
             false,
         );
 
@@ -95,6 +99,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
+            new IamcalSqlParser(),
             false,
         );
 
@@ -128,6 +133,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
             self::getContainer()->getByType(FileHelper::class),
             new MySqlDataTypeToPhpTypeConverter(),
+            new IamcalSqlParser(),
             true,
         );
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Support `phpmyadmin/sql-parser` as an optional SQL parser.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
