### PR TITLE
[3.x] Narrow HasEvents::dispatchesEvents

### DIFF
--- a/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
+++ b/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HasEvents
+{
+    /**
+     * The event map for the model.
+     *
+     * Allows for object-based events for native Eloquent events.
+     *
+     * @var array<string, class-string>
+     */
+    protected $dispatchesEvents = [];
+
+    /**
+     * Get the event map for the model.
+     *
+     * @return array<string, class-string>
+     */
+    public function dispatchesEvents();
+}

--- a/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
+++ b/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-/** @phpstan-require-extends Model */
+/** @phpstan-require-extends \Illuminate\Database\Eloquent\Model */
 trait HasEvents
 {
     /**

--- a/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
+++ b/stubs/common/Database/Eloquent/Concerns/HasEvents.stub
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+/** @phpstan-require-extends Model */
 trait HasEvents
 {
     /**

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -39,6 +39,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/facades.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/gate-facade.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/has-events.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/helpers.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/higher-order-collection-proxy-methods.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/model-factories.php');

--- a/tests/Type/data/has-events.php
+++ b/tests/Type/data/has-events.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Helpers;
+
+use App\Account;
+
+use function PHPStan\Testing\assertType;
+
+function test(): void
+{
+    assertType('array<string, class-string>', (new Account)->dispatchesEvents());
+}


### PR DESCRIPTION
- [✅] Added or updated tests
- [N/A] Documented user facing changes

This PR narrows the type of `HasEvents` property `dispatchesEvents` from `array<array-key, mixed>` to `array<string, class-string>`. It also narrows the getter for this property.
