### PR TITLE
feat: return Response type for synchronous HTTP client calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -666,6 +666,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: Larastan\Larastan\ReturnTypes\PendingRequestDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: Larastan\Larastan\Rules\NoAuthFacadeInRequestScopeRule
 
     -

--- a/src/ReturnTypes/PendingRequestDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/PendingRequestDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+use function in_array;
+
+final class PendingRequestDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    private const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'send'];
+
+    public function getClass(): string
+    {
+        return PendingRequest::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), self::HTTP_METHODS, true);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        // Check if async() was called in the method chain
+        if ($this->hasAsyncInChain($methodCall)) {
+            // Return null to use the original return type (Response|PromiseInterface)
+            return null;
+        }
+
+        // Synchronous call - return Response only
+        return new ObjectType(Response::class);
+    }
+
+    private function hasAsyncInChain(MethodCall $methodCall): bool
+    {
+        $current = $methodCall->var;
+
+        while ($current instanceof MethodCall) {
+            if ($current->name instanceof Identifier && $current->name->name === 'async') {
+                return true;
+            }
+
+            $current = $current->var;
+        }
+
+        return false;
+    }
+}

--- a/tests/Type/PendingRequestReturnTypeExtensionTest.php
+++ b/tests/Type/PendingRequestReturnTypeExtensionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class PendingRequestReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /** @return iterable<mixed> */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/pending-request-return-types.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        mixed ...$args,
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../extension.neon'];
+    }
+}

--- a/tests/Type/data/pending-request-return-types.php
+++ b/tests/Type/data/pending-request-return-types.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PendingRequestReturnTypes;
+
+use Illuminate\Http\Client\PendingRequest;
+
+use function PHPStan\Testing\assertType;
+
+function testSyncCalls(PendingRequest $request): void
+{
+    assertType('Illuminate\Http\Client\Response', $request->get('https://example.com'));
+    assertType('Illuminate\Http\Client\Response', $request->post('https://example.com', []));
+    assertType('Illuminate\Http\Client\Response', $request->put('https://example.com', []));
+    assertType('Illuminate\Http\Client\Response', $request->patch('https://example.com', []));
+    assertType('Illuminate\Http\Client\Response', $request->delete('https://example.com'));
+    assertType('Illuminate\Http\Client\Response', $request->head('https://example.com'));
+    assertType('Illuminate\Http\Client\Response', $request->send('GET', 'https://example.com'));
+}
+
+function testChainedSyncCalls(PendingRequest $request): void
+{
+    assertType('Illuminate\Http\Client\Response', $request->timeout(30)->get('https://example.com'));
+    assertType('Illuminate\Http\Client\Response', $request->withHeaders(['X-Foo' => 'bar'])->post('https://example.com', []));
+}
+
+function testAsyncCalls(PendingRequest $request): void
+{
+    // async() calls should return the union type (we return null to use original)
+    assertType('GuzzleHttp\Promise\PromiseInterface|Illuminate\Http\Client\Response', $request->async()->get('https://example.com'));
+    assertType('GuzzleHttp\Promise\PromiseInterface|Illuminate\Http\Client\Response', $request->async()->post('https://example.com', []));
+}


### PR DESCRIPTION
## Summary
- Adds a `DynamicMethodReturnTypeExtension` for `PendingRequest` that returns `Response` for synchronous HTTP calls
- For async calls (with `async()` in the method chain), the original `Response|PromiseInterface` union type is preserved
- Fixes false positive PHPStan errors when calling `Response`-specific methods on synchronous HTTP requests

## Problem
Laravel 12.40.0 introduced `FluentPromise` which changed HTTP methods (`get`, `post`, `put`, `patch`, `delete`, `head`, `send`) to return `Response|PromiseInterface`. This causes errors like:

```
Call to an undefined method GuzzleHttp\Promise\PromiseInterface|Illuminate\Http\Client\Response::failed()
```

## Test plan
- [x] Added type inference tests for sync calls returning `Response`
- [x] Added type inference tests for async calls returning `Response|PromiseInterface`
- [x] All existing tests pass

Fixes #2411

🤖 Generated with [Claude Code](https://claude.com/claude-code)