### PR TITLE
feat: Add stubs for Cache facade

### DIFF
--- a/stubs/common/Cache/CacheManager.stub
+++ b/stubs/common/Cache/CacheManager.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Cache;
+
+/**
+ * @mixin \Illuminate\Cache\Repository
+ * @mixin \Illuminate\Contracts\Cache\LockProvider
+ */
+class CacheManager implements \Illuminate\Contracts\Cache\Factory {}

--- a/stubs/common/Cache/Repository.stub
+++ b/stubs/common/Cache/Repository.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Cache;
+
+/**
+ * @mixin \Illuminate\Contracts\Cache\Store
+ * @implements \ArrayAccess<string, mixed>
+ */
+class Repository implements \ArrayAccess, \Illuminate\Contracts\Cache\Store {}

--- a/stubs/common/Contracts/Cache.stub
+++ b/stubs/common/Contracts/Cache.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Contracts\Cache;
+
+interface Factory {}
+
+interface LockProvider {}
+
+interface Store {}
+
+interface Repository {}

--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -13,6 +13,12 @@ abstract class Facade {}
 class Redis {}
 
 /**
+ * @mixin \Illuminate\Cache\CacheManager
+ * @mixin \Illuminate\Cache\Repository
+ */
+class Cache extends Facade {}
+
+/**
  * @mixin \Illuminate\Database\DatabaseManager
  * @mixin \Illuminate\Database\Connection
  * @mixin \Illuminate\Database\ConnectionInterface

--- a/tests/Type/data/facades-l12-20.php
+++ b/tests/Type/data/facades-l12-20.php
@@ -3,6 +3,7 @@
 namespace FacadesL1220;
 
 use App\DummyFacade;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -17,4 +18,15 @@ use function PHPStan\Testing\assertType;
 function test(): void
 {
     assertType('Illuminate\Support\Collection<(int|string), mixed>', Config::collection('foo.bar'));
+
+    assertType('Illuminate\Contracts\Cache\Repository', Cache::driver());
+    assertType('\'123\'', Cache::remember(
+        key: 'cache-key',
+        ttl: 60,
+        callback: static fn (): string => '123',
+    ));
+    assertType('int', Cache::rememberForever(
+        key: 'cache-key',
+        callback: static fn (): int => 123,
+    ));
 }

--- a/tests/Type/data/facades-l12-20.php
+++ b/tests/Type/data/facades-l12-20.php
@@ -25,7 +25,7 @@ function test(): void
         ttl: 60,
         callback: static fn (): string => '123',
     ));
-    assertType('int', Cache::rememberForever(
+    assertType('123', Cache::rememberForever(
         key: 'cache-key',
         callback: static fn (): int => 123,
     ));

--- a/tests/Type/data/facades-l12-41.php
+++ b/tests/Type/data/facades-l12-41.php
@@ -2,17 +2,9 @@
 
 namespace FacadesL1241;
 
-use App\DummyFacade;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Redis;
-use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Storage;
 
-use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 
 function test(): void
@@ -33,4 +25,14 @@ function test(): void
     assertType('Illuminate\Http\Client\Promises\LazyPromise', Http::timeout(30)->async()->get('https://example.test'));
     assertType('Illuminate\Http\Client\Promises\LazyPromise', Http::withHeaders(['X-Foo' => 'bar'])->async()->post('https://example.test'));
 
+    assertType('Illuminate\Contracts\Cache\Repository', Cache::driver());
+    assertType('\'123\'', Cache::remember(
+        key: 'cache-key',
+        ttl: 60,
+        callback: static fn (): string => '123',
+    ));
+    assertType('123', Cache::rememberForever(
+        key: 'cache-key',
+        callback: static fn (): int => 123,
+    ));
 }

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -3,6 +3,7 @@
 namespace Facades;
 
 use App\DummyFacade;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -66,4 +67,14 @@ function test(): void
     assertType('GuzzleHttp\Promise\PromiseInterface', Http::timeout(30)->async()->get('https://example.test'));
     assertType('GuzzleHttp\Promise\PromiseInterface', Http::withHeaders(['X-Foo' => 'bar'])->async()->post('https://example.test'));
 
+    assertType('Illuminate\Contracts\Cache\Repository', Cache::driver());
+    assertType('\'123\'', Cache::remember(
+        key: 'cache-key',
+        ttl: 60,
+        callback: static fn (): string => '123',
+    ));
+    assertType('int', Cache::rememberForever(
+        key: 'cache-key',
+        callback: static fn (): int => 123,
+    ));
 }

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -73,7 +73,7 @@ function test(): void
         ttl: 60,
         callback: static fn (): string => '123',
     ));
-    assertType('int', Cache::rememberForever(
+    assertType('123', Cache::rememberForever(
         key: 'cache-key',
         callback: static fn (): int => 123,
     ));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Issue**

When using the following code:

```php
Route::get('/', static function (): void {
    $result = \Illuminate\Support\Facades\Cache::remember(
        key: 'test',
        ttl: 60,
        callback: static fn (): string => '123',
    );

    dump(str_contains($result, '1'));
});
```

It will result in the following phpstan error:

```txt
 ------ ------------------------------------------------------------------------------
  Line   web.php
 ------ ------------------------------------------------------------------------------
  14     Parameter #1 $haystack of function str_contains expects string, mixed given.
         🪪  argument.type
 ------ ------------------------------------------------------------------------------
```

This is fixed by adding the Cache facade to the stub files of Larastan.

**Changes**

Will give you the proper return types when using cache functions using the facade.

**Breaking changes**

Not that I know of, but if I've missing anything please let me know!
