### PR TITLE
[3.x] fix: nullability detection for TEXT and some other column types

### DIFF
--- a/src/SQL/IamcalSqlParser.php
+++ b/src/SQL/IamcalSqlParser.php
@@ -8,6 +8,7 @@ use iamcal\SQLParser as VendorIamcalSqlParser;
 use iamcal\SQLParserSyntaxException;
 
 use function array_key_exists;
+use function in_array;
 use function is_array;
 use function is_string;
 
@@ -79,11 +80,7 @@ final class IamcalSqlParser implements SqlParser
         return $result;
     }
 
-    /**
-     * @param array<string, mixed> $field
-     *
-     * @return bool
-     */
+    /** @param array<string, mixed> $field */
     private function resolveNullable(array $field): bool
     {
         // If the parser explicitly captured NULL / NOT NULL, trust it.
@@ -93,17 +90,24 @@ final class IamcalSqlParser implements SqlParser
 
         // Types where MySQL generally omits DEFAULT NULL in SHOW CREATE TABLE,
         // but the column is still nullable unless NOT NULL is explicitly present.
-        if (in_array($type, [
-            'TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT',
-            'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB',
+        return in_array($field['type'], [
+            'TEXT',
+            'TINYTEXT',
+            'MEDIUMTEXT',
+            'LONGTEXT',
+            'BLOB',
+            'TINYBLOB',
+            'MEDIUMBLOB',
+            'LONGBLOB',
             'JSON',
-            'GEOMETRY', 'POINT', 'LINESTRING', 'POLYGON',
-            'MULTIPOINT', 'MULTILINESTRING', 'MULTIPOLYGON', 'GEOMETRYCOLLECTION',
-        ], true)) {
-            return true;
-        }
-
-        // Without explicit metadata, assume NOT nullable.
-        return false;
+            'GEOMETRY',
+            'POINT',
+            'LINESTRING',
+            'POLYGON',
+            'MULTIPOINT',
+            'MULTILINESTRING',
+            'MULTIPOLYGON',
+            'GEOMETRYCOLLECTION',
+        ], true);
     }
 }

--- a/src/SQL/IamcalSqlParser.php
+++ b/src/SQL/IamcalSqlParser.php
@@ -53,7 +53,7 @@ final class IamcalSqlParser implements SqlParser
                     $fieldName,
                     $fieldType,
                     $this->resolveTypeOptions($field),
-                    $field['null'] ?? false,
+                    $this->resolveNullable($field),
                 );
             }
 
@@ -77,5 +77,33 @@ final class IamcalSqlParser implements SqlParser
         }
 
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     *
+     * @return bool
+     */
+    private function resolveNullable(array $field): bool
+    {
+        // If the parser explicitly captured NULL / NOT NULL, trust it.
+        if (isset($field['null'])) {
+            return $field['null'];
+        }
+
+        // Types where MySQL generally omits DEFAULT NULL in SHOW CREATE TABLE,
+        // but the column is still nullable unless NOT NULL is explicitly present.
+        if (in_array($type, [
+            'TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT',
+            'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB',
+            'JSON',
+            'GEOMETRY', 'POINT', 'LINESTRING', 'POLYGON',
+            'MULTIPOINT', 'MULTILINESTRING', 'MULTIPOLYGON', 'GEOMETRYCOLLECTION',
+        ], true)) {
+            return true;
+        }
+
+        // Without explicit metadata, assume NOT nullable.
+        return false;
     }
 }

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -31,14 +31,23 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
 
         $this->assertCount(1, $tables);
         $this->assertArrayHasKey('accounts', $tables);
-        $this->assertCount(6, $tables['accounts']->columns);
-        $this->assertSame(['id', 'name', 'active', 'description', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
+        $this->assertCount(8, $tables['accounts']->columns);
+        $this->assertSame(['id', 'name', 'active', 'description', 'notes', 'profile_text', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
         $this->assertSame('non-negative-int', $tables['accounts']->columns['id']->readableType);
         $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
+        $this->assertSame(false, $tables['accounts']->columns['name']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['active']->readableType);
+        $this->assertSame(false, $tables['accounts']->columns['active']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['description']->readableType);
+        $this->assertSame(true, $tables['accounts']->columns['description']->nullable);
+        $this->assertSame('string', $tables['accounts']->columns['notes']->readableType);
+        $this->assertSame(true, $tables['accounts']->columns['notes']->nullable);
+        $this->assertSame('string', $tables['accounts']->columns['profile_text']->readableType);
+        $this->assertSame(false, $tables['accounts']->columns['profile_text']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
+        $this->assertSame(true, $tables['accounts']->columns['created_at']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);
+        $this->assertSame(true, $tables['accounts']->columns['updated_at']->nullable);
     }
 
     #[Test]

--- a/tests/Unit/data/schema/basic_schema/accounts.dump
+++ b/tests/Unit/data/schema/basic_schema/accounts.dump
@@ -12,6 +12,8 @@ CREATE TABLE `accounts` (
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `active` varchar(1) COLLATE utf8mb4_unicode_ci NOT NULL,
   `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `notes` text COLLATE utf8mb4_unicode_ci,
+  `profile_text` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Let's imagine there is a nullable `forms.autoresponse` column with `TEXT` type. Currently PHPStan assigns `string` type, while it should assign `string|null` instead, because the column is nullable. 

This leads to false reports like this in our project:

```
 ------ ------------------------------------------------------------------ 
  39     Property App\Models\Form::$autoresponse (string) does not accept  
         null.                                                             
         🪪  assign.propertyType                                           
 ------ ------------------------------------------------------------------ 
```

This happens because currently PHPStan defaults to `false` for "nullable" if `iamcal\SQLParser` doesn't include `'null'` key for `$field`. This happens for TEXT and some other types which you can see in "Files changed" tab.

This PR fixes this issue.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
