### PR TITLE
Bump phpstan to 2.1.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^11.44.2 || ^12.4.1",
         "illuminate/pipeline": "^11.44.2 || ^12.4.1",
         "illuminate/support": "^11.44.2 || ^12.4.1",
-        "phpstan/phpstan": "^2.1.32"
+        "phpstan/phpstan": "^2.1.34"
     },
     "require-dev": {
         "doctrine/coding-standard": "^13",


### PR DESCRIPTION
Bump phpstan: https://github.com/phpstan/phpstan/releases/tag/2.1.34

This new version brings nice performance improvements.