### PR TITLE
Improve type inference for MySQL `ENUM` types in squashed migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "iamcal/sql-parser": "^0.6.0",
+        "iamcal/sql-parser": "^0.7.0",
         "illuminate/console": "^11.44.2 || ^12.4.1",
         "illuminate/container": "^11.44.2 || ^12.4.1",
         "illuminate/contracts": "^11.44.2 || ^12.4.1",

--- a/src/Properties/Schema/MySqlDataTypeToPhpTypeConverter.php
+++ b/src/Properties/Schema/MySqlDataTypeToPhpTypeConverter.php
@@ -4,18 +4,32 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Properties\Schema;
 
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VerbosityLevel;
+
+use function array_map;
 use function in_array;
 
 final class MySqlDataTypeToPhpTypeConverter
 {
-    /** @param list<lowercase-string> $options */
-    public function convert(string $type, array $options): string
+    /**
+     * @param list<lowercase-string> $options
+     * @param list<string>           $values
+     */
+    public function convert(string $type, array $options, array $values = []): string
     {
         return match ($type) {
             'CHAR', 'VARCHAR', 'TINYTEXT', 'TEXT', 'MEDIUMTEXT', 'LONGTEXT', 'BINARY', 'VARBINARY', 'DATE', 'DATETIME', 'TIMESTAMP', 'TIME', 'TINYBLOB', 'BLOB', 'MEDIUMBLOB', 'JSON' => 'string',
             'BIT', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'INTEGER', 'BIGINT', 'YEAR' => in_array('unsigned', $options, true) ? 'non-negative-int' : 'int',
             'DECIMAL', 'DEC', 'NUMERIC', 'FIXED', 'FLOAT', 'DOUBLE', 'DOUBLE PRECISION', 'REAL' => 'float',
             'BOOL', 'BOOLEAN' => 'bool',
+            'ENUM' => (static function () use ($values): string {
+                return TypeCombinator::union(...array_map(
+                    static fn (string $value): ConstantStringType => new ConstantStringType($value),
+                    $values,
+                ))->describe(VerbosityLevel::value());
+            })(),
             default => 'mixed',
         };
     }

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -78,7 +78,7 @@ final class SquashedMigrationHelper
                 foreach ($definition->columns as $column) {
                     $table->setColumn(new SchemaColumn(
                         $column->name,
-                        $this->converter->convert($column->type, $column->typeOptions),
+                        $this->converter->convert($column->type, $column->typeOptions, $column->values),
                         $column->nullable,
                     ));
                 }

--- a/src/SQL/ColumnDefinition.php
+++ b/src/SQL/ColumnDefinition.php
@@ -6,12 +6,16 @@ namespace Larastan\Larastan\SQL;
 
 final class ColumnDefinition
 {
-    /** @param list<lowercase-string> $typeOptions */
+    /**
+     * @param list<lowercase-string> $typeOptions
+     * @param list<string>           $values
+     */
     public function __construct(
         public string $name,
         public string $type,
         public array $typeOptions,
         public bool $nullable,
+        public array $values = [],
     ) {
     }
 }

--- a/src/SQL/IamcalSqlParser.php
+++ b/src/SQL/IamcalSqlParser.php
@@ -55,6 +55,7 @@ final class IamcalSqlParser implements SqlParser
                     $fieldType,
                     $this->resolveTypeOptions($field),
                     $this->resolveNullable($field),
+                    $field['values'] ?? [],
                 );
             }
 

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -31,8 +31,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
 
         $this->assertCount(1, $tables);
         $this->assertArrayHasKey('accounts', $tables);
-        $this->assertCount(8, $tables['accounts']->columns);
-        $this->assertSame(['id', 'name', 'active', 'description', 'notes', 'profile_text', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
+        $this->assertCount(9, $tables['accounts']->columns);
+        $this->assertSame(['id', 'name', 'active', 'description', 'notes', 'profile_text', 'enum_status', 'created_at', 'updated_at'], array_keys($tables['accounts']->columns));
         $this->assertSame('non-negative-int', $tables['accounts']->columns['id']->readableType);
         $this->assertSame('string', $tables['accounts']->columns['name']->readableType);
         $this->assertSame(false, $tables['accounts']->columns['name']->nullable);
@@ -44,6 +44,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame(true, $tables['accounts']->columns['notes']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['profile_text']->readableType);
         $this->assertSame(false, $tables['accounts']->columns['profile_text']->nullable);
+        $this->assertSame("'active'|'don\'t know'|'inactive'", $tables['accounts']->columns['enum_status']->readableType);
+        $this->assertSame(false, $tables['accounts']->columns['enum_status']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
         $this->assertSame(true, $tables['accounts']->columns['created_at']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['updated_at']->readableType);

--- a/tests/Unit/data/schema/basic_schema/accounts.dump
+++ b/tests/Unit/data/schema/basic_schema/accounts.dump
@@ -14,6 +14,7 @@ CREATE TABLE `accounts` (
   `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `notes` text COLLATE utf8mb4_unicode_ci,
   `profile_text` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enum_status` enum('active','inactive','don''t know') COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

In squashed migrations, MySQL `ENUM` types were previously inferred as `mixed`.
This PR improves type inference so that `ENUM` types are recognized as their exact values, such as `'active'|'inactive'|'don\'t know'`.

> [!NOTE]
> ~Currently, due to an issue in [iamcal/SQLParser](https://github.com/iamcal/SQLParser), MySQL `ENUM` values containing quotes are not correctly recognized, causing the tests to fail.~ 
> ~Once this PR is merged, the issue should be resolved and the tests should pass:~
>
> ~https://github.com/iamcal/SQLParser/pull/32~
>
> The PR has been merged 🎉 

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

Because MySQL `ENUM` types in squashed migrations are no longer inferred as `mixed`, errors that were previously ignored may now be detected.
