### PR TITLE
fix: type inference for MySQL `ENUM` types in squashed migrations

### DIFF
--- a/src/Properties/Schema/MySqlDataTypeToPhpTypeConverter.php
+++ b/src/Properties/Schema/MySqlDataTypeToPhpTypeConverter.php
@@ -28,7 +28,7 @@ final class MySqlDataTypeToPhpTypeConverter
                 return TypeCombinator::union(...array_map(
                     static fn (string $value): ConstantStringType => new ConstantStringType($value),
                     $values,
-                ))->describe(VerbosityLevel::value());
+                ))->describe(VerbosityLevel::precise());
             })(),
             default => 'mixed',
         };

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -44,7 +44,7 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
         $this->assertSame(true, $tables['accounts']->columns['notes']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['profile_text']->readableType);
         $this->assertSame(false, $tables['accounts']->columns['profile_text']->nullable);
-        $this->assertSame("'active'|'don\'t know'|'inactive'", $tables['accounts']->columns['enum_status']->readableType);
+        $this->assertSame("'a very long string that exceeds the ConstantStringType DESCRIBE_LIMIT'|'active'|'don\'t know'|'inactive'", $tables['accounts']->columns['enum_status']->readableType);
         $this->assertSame(false, $tables['accounts']->columns['enum_status']->nullable);
         $this->assertSame('string', $tables['accounts']->columns['created_at']->readableType);
         $this->assertSame(true, $tables['accounts']->columns['created_at']->nullable);

--- a/tests/Unit/data/schema/basic_schema/accounts.dump
+++ b/tests/Unit/data/schema/basic_schema/accounts.dump
@@ -14,7 +14,7 @@ CREATE TABLE `accounts` (
   `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `notes` text COLLATE utf8mb4_unicode_ci,
   `profile_text` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `enum_status` enum('active','inactive','don''t know') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enum_status` enum('active','inactive','don''t know','a very long string that exceeds the ConstantStringType DESCRIBE_LIMIT') COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

This is a follow-up PR to #2434.

**Changes**

Use `VerbosityLevel::precise()` instead of `VerbosityLevel::value()` when describing `ENUM` values from squashed migrations. This prevents long enum values from being truncated by `ConstantStringType::DESCRIBE_LIMIT`.

Truncated enum strings could lead to incorrect analysis results such as:

```md
 ------ -------------------------------------------------------------------------------------------------------
  Line   lib\SchedulingV1.php
 ------ -------------------------------------------------------------------------------------------------------
  738    Strict comparison using === between 'disable_stop…'|'keep_schedule'|'stop_schedule' and
         'disable_stop…' will always evaluate to false.
         🪪  identical.alwaysFalse
         ✏️  C:\xampp\htdocs\bidX\lib\SchedulingV1.php:738
```

**Tests**

Added a test verifying that long enum values are preserved.

```php
\PHPStan\dumpType($accounts->enum_status);
```

```diff
- `'a very long string…'|'active'|'don\'t know'|'inactive'`
+ `'a very long string that exceeds the ConstantStringType DESCRIBE_LIMIT'|'active'|'don\'t know'|'inactive'`
```

**Breaking changes**

None.
