### PR TITLE
[3.x] Improve blade view parsing for `NoMissingTranslationsRule`

### DIFF
--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -9,8 +9,10 @@ use Larastan\Larastan\Support\ViewParser;
 use PhpParser\Node;
 
 use function array_filter;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
+use function assert;
 use function count;
 use function preg_match_all;
 use function str_replace;
@@ -81,6 +83,10 @@ final class UsedTranslationViewCollector
             preg_match_all(self::TRANSLATION_REGEX, $node->value, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE, 0);
 
             $translations = array_merge($translations, array_map(function (array $match) use ($node): array {
+                assert(array_key_exists(0, $match));
+                assert(array_key_exists('quote', $match));
+                assert(array_key_exists('string', $match));
+
                 return [
                     $this->unescapeMatch($match),
                     $this->matchLine($match, $node),

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -13,6 +13,7 @@ use function array_map;
 use function array_merge;
 use function count;
 use function preg_match_all;
+use function str_replace;
 
 use const PREG_SET_ORDER;
 
@@ -59,11 +60,19 @@ final class UsedTranslationViewCollector
         foreach ($nodes as $node) {
             preg_match_all(self::TRANSLATION_REGEX, $node->value, $matches, PREG_SET_ORDER, 0);
 
-            $translations = array_merge($translations, array_map(static function (array $match): array {
-                return [$match[3], 0];
+            $translations = array_merge($translations, array_map(function (array $match): array {
+                return [$this->unescapeMatch($match), 0];
             }, $matches));
         }
 
         return $translations;
+    }
+
+    /** @param array{quote: array{string, int}, string: array{string, int}} $match */
+    private function unescapeMatch(array $match): string
+    {
+        $quote = $match['quote'][0];
+
+        return str_replace('\\' . $quote, $quote, $match['string'][0]);
     }
 }

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -23,7 +23,7 @@ use const PREG_SET_ORDER;
 final class UsedTranslationViewCollector
 {
     /** @see https://regex101.com/r/akPfPj/1 */
-    private const TRANSLATION_REGEX = '/(?<!\w)(trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/m';
+    private const TRANSLATION_REGEX = '/(?<!\w)(trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/im';
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -23,7 +23,7 @@ use const PREG_SET_ORDER;
 final class UsedTranslationViewCollector
 {
     /** @see https://regex101.com/r/akPfPj/1 */
-    private const TRANSLATION_REGEX = '/[^\w](trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/m';
+    private const TRANSLATION_REGEX = '/(?<!\w)(trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/m';
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -22,8 +22,24 @@ use const PREG_SET_ORDER;
 
 final class UsedTranslationViewCollector
 {
-    /** @see https://regex101.com/r/ukW3jd/1 */
-    private const TRANSLATION_REGEX = '/(?<!\w)(trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/im';
+    /** @see https://regex101.com/r/xFN4fv/1 */
+    private const TRANSLATION_REGEX = <<<'REGEXP'
+    /
+        (
+            (
+                (?<!\w)
+                (trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|__|\$t)
+            )
+            |
+            (@lang|@choice)
+        )
+        \(
+        (?P<quote>['"])
+        (?P<string>(\\.|(?!(?P=quote))[^\\\\])*?)
+        (?P=quote)
+        [),]
+    /mix
+    REGEXP;
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -22,7 +22,7 @@ use const PREG_SET_ORDER;
 
 final class UsedTranslationViewCollector
 {
-    /** @see https://regex101.com/r/akPfPj/1 */
+    /** @see https://regex101.com/r/ukW3jd/1 */
     private const TRANSLATION_REGEX = '/(?<!\w)(trans|trans_choice|Lang::get|Lang::choice|Lang::trans|Lang::transChoice|@lang|@choice|__|\$t)\((?P<quote>[\'"])(?P<string>(?:\\k{quote}|(?!\k{quote}).)*?)\k{quote}[\),]/im';
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -14,7 +14,10 @@ use function array_merge;
 use function count;
 use function preg_match_all;
 use function str_replace;
+use function substr;
+use function substr_count;
 
+use const PREG_OFFSET_CAPTURE;
 use const PREG_SET_ORDER;
 
 final class UsedTranslationViewCollector
@@ -58,10 +61,13 @@ final class UsedTranslationViewCollector
         $translations = [];
 
         foreach ($nodes as $node) {
-            preg_match_all(self::TRANSLATION_REGEX, $node->value, $matches, PREG_SET_ORDER, 0);
+            preg_match_all(self::TRANSLATION_REGEX, $node->value, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE, 0);
 
-            $translations = array_merge($translations, array_map(function (array $match): array {
-                return [$this->unescapeMatch($match), 0];
+            $translations = array_merge($translations, array_map(function (array $match) use ($node): array {
+                return [
+                    $this->unescapeMatch($match),
+                    $this->matchLine($match, $node),
+                ];
             }, $matches));
         }
 
@@ -74,5 +80,13 @@ final class UsedTranslationViewCollector
         $quote = $match['quote'][0];
 
         return str_replace('\\' . $quote, $quote, $match['string'][0]);
+    }
+
+    /** @param array{0: array{string, int}} $match */
+    private function matchLine(array $match, Node\Stmt\InlineHTML $node): int
+    {
+        $stringUntilMatch = substr($node->value, 0, $match[0][1]);
+
+        return $node->getStartLine() + substr_count($stringUntilMatch, "\n");
     }
 }

--- a/src/Collectors/UsedTranslationViewCollector.php
+++ b/src/Collectors/UsedTranslationViewCollector.php
@@ -14,6 +14,7 @@ use function array_merge;
 use function count;
 use function preg_match_all;
 use function str_replace;
+use function stripcslashes;
 use function substr;
 use function substr_count;
 
@@ -95,7 +96,17 @@ final class UsedTranslationViewCollector
     {
         $quote = $match['quote'][0];
 
-        return str_replace('\\' . $quote, $quote, $match['string'][0]);
+        $string = $match['string'][0];
+
+        if ($quote === '"') {
+            $string = str_replace("\\'", "\\\\'", $string);
+            $string = stripcslashes($string); // supports all escape sequences except Unicode
+        } else {
+            $string = str_replace('\\\\', '\\', $string);
+            $string = str_replace("\\'", "'", $string);
+        }
+
+        return $string;
     }
 
     /** @param array{0: array{string, int}} $match */

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -12,6 +12,8 @@ use Larastan\Larastan\Collectors\UsedTranslationViewCollector;
 use Larastan\Larastan\Rules\NoMissingTranslationsRule;
 use Larastan\Larastan\Support\ViewFileHelper;
 use Larastan\Larastan\Support\ViewParser;
+use PhpParser\Node\Expr\CallLike;
+use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -26,7 +28,7 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
         return new NoMissingTranslationsRule(new UsedTranslationViewCollector($viewParser, $viewFileHelper), new Filesystem(), []);
     }
 
-    /** @return array<Collector<Node, mixed>> */
+    /** @return array<Collector<CallLike, mixed>> */
     protected function getCollectors(): array
     {
         return [

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -38,7 +38,45 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
 
     public function testRule(): void
     {
+        /** @see ../application/resources/views/translations.blade.php */
+        $errorsFromBladeFile = [
+            ['Translation "lang.get" has not been found.', 26],
+            ['Translation "lang.choice" has not been found.', 27],
+            ['Translation "lang.trans" has not been found.', 28],
+            ['Translation "lang.transChoice" has not been found.', 29],
+
+            ['Translation "a.b" has not been found.', 31],
+            ['Translation "a.b.c" has not been found.', 32],
+            ['Translation "a_b.c-d" has not been found.', 33],
+            ['Translation "a.b" has not been found.', 34],
+            ['Translation "a.b!" has not been found.', 35],
+            ['Translation "a.translate me!" has not been found.', 36],
+            ['Translation "a.über~" has not been found.', 37],
+            ['Translation "app.i\\\'m" has not been found.', 38],
+            ['Translation "app.i\'m" has not been found.', 39],
+            ['Translation "app.\\"ok\\"" has not been found.', 40],
+            ['Translation "app."ok"" has not been found.', 41],
+            ['Translation "a.b" has not been found.', 42],
+
+            ['Translation "directive.lang" has not been found.', 44],
+            ['Translation "directive.choice" has not been found.', 45],
+
+            ['Translation "surrounded.by.text" has not been found.', 47],
+            ['Translation "surrounded.by.html.tags" has not been found.', 48],
+
+            ['Translation "trans.uppercase" has not been found.', 50],
+            ['Translation "object.instance.method" has not been found.', 51],
+            ['Translation "dollar.t" has not been found.', 52],
+            ['Translation "double.underscore.helper.function" has not been found.', 53],
+
+            ['Translation "lang.in.html.attribute" has not been found.', 55],
+            ['Translation "lang.with.extra.paramater" has not been found.', 56],
+            ['Translation "lang.in.blade.comment" has not been found.', 57],
+            ['Translation "lang.in.html.comment" has not been found.', 58],
+        ];
+
         $this->analyse([__DIR__ . '/data/Translation.php'], [
+            ...$errorsFromBladeFile,
             [
                 'Translation "messages.test" has not been found.',
                 18,

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -17,6 +17,8 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
+use const PHP_EOL;
+
 /** @extends RuleTestCase<NoMissingTranslationsRule> */
 class NoMissingTranslationsRuleTest extends RuleTestCase
 {
@@ -77,6 +79,12 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
             ['Translation "lang.in.html.comment" has not been found.', 58],
             ['Translation "and.a.simple.translation.afterwards" has not been found.', 59],
             ['Translation "lang.with.prefix" has not been found.', 60],
+
+            ['Translation "lang.with.new' . "\n" . 'line.char" has not been found.', 71],
+            ['Translation "lang.spanning' . PHP_EOL . 'multiple.lines" has not been found.', 72],
+            ['Translation "lang.with.a.back\\slash.single.quotes" has not been found.', 74],
+            ['Translation "lang.with.a.back\\slash.double.quotes" has not been found.', 75],
+            ['Translation "lang.with.a.hex.char" has not been found.', 76],
         ];
 
         $this->analyse([__DIR__ . '/data/Translation.php'], [

--- a/tests/Rules/NoMissingTranslationsRuleTest.php
+++ b/tests/Rules/NoMissingTranslationsRuleTest.php
@@ -75,6 +75,8 @@ class NoMissingTranslationsRuleTest extends RuleTestCase
             ['Translation "lang.with.extra.paramater" has not been found.', 56],
             ['Translation "lang.in.blade.comment" has not been found.', 57],
             ['Translation "lang.in.html.comment" has not been found.', 58],
+            ['Translation "and.a.simple.translation.afterwards" has not been found.', 59],
+            ['Translation "lang.with.prefix" has not been found.', 60],
         ];
 
         $this->analyse([__DIR__ . '/data/Translation.php'], [

--- a/tests/Rules/data/FooController.php
+++ b/tests/Rules/data/FooController.php
@@ -76,3 +76,8 @@ function routeView(): void
 {
     Route::view('/welcome', 'route-view');
 }
+
+function dummyTranslationView()
+{
+    return view('translations');
+}

--- a/tests/Rules/data/Translation.php
+++ b/tests/Rules/data/Translation.php
@@ -40,5 +40,9 @@ class Translation
         Lang::get('sub/lines.farewell');
 
         __('vendor::key');
+
+        __('messages.You\'re beautiful');
+
+        __('messages.A.Key.With.Dots.');
     }
 }

--- a/tests/application/resources/lang/en/messages.php
+++ b/tests/application/resources/lang/en/messages.php
@@ -8,4 +8,8 @@ return [
     'nested' => [
         'key' => 'value',
     ],
+
+    'You\'re beautiful' => 'Du bist schön',
+
+    'A.Key.With.Dots.' => 'A key with dots.',
 ];

--- a/tests/application/resources/lang/en/messages.php
+++ b/tests/application/resources/lang/en/messages.php
@@ -12,4 +12,14 @@ return [
     'You\'re beautiful' => 'Du bist schön',
 
     'A.Key.With.Dots.' => 'A key with dots.',
+
+    "with.new\nline.char" => 'Message with multi-line char,',
+
+    'spanning
+multiple.lines' => 'Message spanning multiple lines.',
+
+    'with.a.back\\slash.single.quotes' => 'Message with a backslash.',
+    "with.a.back\\slash.double.quotes" => 'Message with a backslash.',
+
+    "with.\x61.hex.char" => 'Message with a hex char.',
 ];

--- a/tests/application/resources/views/translations.blade.php
+++ b/tests/application/resources/views/translations.blade.php
@@ -66,3 +66,18 @@ Should not match:
 {{ Method1trans('method.1.trans') }}
 {{ some_other_method_trans('some.other.method.trans') }}
 {{ trans('trans.with.concatenated.string' . $object->property) }}
+
+Keys with special characters:
+@lang("lang.with.new\nline.char")
+@lang('lang.spanning
+multiple.lines')
+@lang('lang.with.a.back\\slash.single.quotes')
+@lang("lang.with.a.back\\slash.double.quotes")
+@lang("lang.with.\x61.hex.char")
+
+@lang("messages.with.new\nline.char")
+@lang('messages.spanning
+multiple.lines')
+@lang('messages.with.a.back\\slash.single.quotes')
+@lang("messages.with.a.back\\slash.double.quotes")
+@lang("messages.with.\x61.hex.char")

--- a/tests/application/resources/views/translations.blade.php
+++ b/tests/application/resources/views/translations.blade.php
@@ -56,6 +56,8 @@ Test:@lang('surrounded.by.text')!
 <p>@lang('lang.with.extra.paramater', ['name' => config('app.name')])</p>
 {{-- @lang('lang.in.blade.comment') --}}
 <!-- @lang('lang.in.html.comment') -->
+@lang('translation.with.a.'.$variable) @lang('and.a.simple.translation.afterwards')
+test@lang('lang.with.prefix')
 
 Should not match:
 {{ trans($variableInsteadOfString) }}

--- a/tests/application/resources/views/translations.blade.php
+++ b/tests/application/resources/views/translations.blade.php
@@ -1,0 +1,66 @@
+@lang('messages.foo')
+@choice('messages.foo')
+{{ __('messages.foo') }}
+{{ trans('messages.foo') }}
+{{ trans_choice('messages.foo', 1) }}
+{{ Lang::get('messages.foo') }}
+{{ Lang::choice('messages.foo', 1) }}
+{{ Lang::trans('messages.foo', 1) }}
+{{ Lang::transChoice('messages.foo', 1) }}
+
+@lang('foo bar baz');
+@lang('messages');
+@lang('messages.nested');
+@lang('messages.nested.key');
+
+@lang('sub/lines.greeting');
+
+@lang('vendor::key');
+
+@lang('messages.You\'re beautiful');
+
+@lang('messages.A.Key.With.Dots.');
+
+More regex tests:
+
+{{ Lang::get('lang.get') }}
+{{ Lang::choice('lang.choice', 1) }}
+{{ Lang::trans('lang.trans') }} {{-- removed in Laravel 6+ --}}
+{{ Lang::transChoice('lang.transChoice', 2) }} {{-- removed in Laravel 6+ --}}
+
+{{ trans('a.b') }}
+{{ trans('a.b.c') }}
+{{ trans('a_b.c-d') }}
+{{ trans('a.b', [1,2]) }}
+{{ trans('a.b!') }}
+{{ trans('a.translate me!') }}
+{{ trans('a.über~') }}
+{{ trans("app.i\'m") }}
+{{ trans('app.i\'m') }}
+{{ trans('app.\"ok\"') }}
+{{ trans("app.\"ok\"") }}
+{{ trans_choice('a.b', 1) }}
+
+@lang('directive.lang')
+@choice('directive.choice', 1)
+
+Test:@lang('surrounded.by.text')!
+<b>@lang('surrounded.by.html.tags')</b>
+
+{{ TRANS('trans.uppercase') }}
+{{ $object->trans('object.instance.method') }}
+{{ $t('dollar.t') }}
+{{ __('double.underscore.helper.function') }}
+
+<input type="email" placeholder="@lang('lang.in.html.attribute')" value="{{ $email ?? old('email') }}" required autofocus>
+<p>@lang('lang.with.extra.paramater', ['name' => config('app.name')])</p>
+{{-- @lang('lang.in.blade.comment') --}}
+<!-- @lang('lang.in.html.comment') -->
+
+Should not match:
+{{ trans($variableInsteadOfString) }}
+{{ trans() }}
+{{ differentMethodTrans('different.method.trans') }}
+{{ Method1trans('method.1.trans') }}
+{{ some_other_method_trans('some.other.method.trans') }}
+{{ trans('trans.with.concatenated.string' . $object->property) }}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

- **fix**: Fixes false-positives for translations keys with escaped quotes (e.g. `You\'re beautiful`).
- **feat**: Now outputs the actual line numbers for missing translations in blade files.
- **feat**: Now correctly detects translations at the very beginning of a blade file.
- **feat**: Now matches method and function names case-insensitive, just like the PHP language.
- **test**: Adds test cases for translation keys with escaped quotes and dots.
- **test**: Adds test cases for translations in blade files.


**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

_none._


**Comparison**

Before:
```md
 ------ ---------------------------------------------------------- 
  Line   resources\views\errors\404.blade.php                      
 ------ ---------------------------------------------------------- 
  0      Translation "You\'re beautiful" has not been found.       
         🪪  larastan.missingTranslations                          
         at resources/views/errors/404.blade.php:0                 
  0      Translation "errors.error_404_title" has not been found.  
         🪪  larastan.missingTranslations                          
         at resources/views/errors/404.blade.php:0                 
 ------ ---------------------------------------------------------- 
```

After:
```md
 ------ ---------------------------------------------------------- 
  Line   resources\views\errors\404.blade.php                      
 ------ ----------------------------------------------------------           
  11     Translation "errors.error_404_title" has not been found.  
         🪪  larastan.missingTranslations                          
         at resources/views/errors/404.blade.php:11                
 ------ ---------------------------------------------------------- 
```