### PR TITLE
fix: undefined array key internal error when view path has trailing slash

### DIFF
--- a/src/Support/ViewFileHelper.php
+++ b/src/Support/ViewFileHelper.php
@@ -19,6 +19,7 @@ use function count;
 use function explode;
 use function is_dir;
 use function iterator_to_array;
+use function rtrim;
 use function str_contains;
 use function str_replace;
 
@@ -76,7 +77,7 @@ final class ViewFileHelper
                     continue;
                 }
 
-                $viewName = explode($viewDirectory . DIRECTORY_SEPARATOR, $view->getPathname());
+                $viewName = explode(rtrim($viewDirectory, '/\\') . DIRECTORY_SEPARATOR, $view->getPathname());
 
                 yield str_replace([DIRECTORY_SEPARATOR, '.blade.php'], ['.', ''], $viewName[1]);
             }

--- a/tests/Rules/UnusedViewsRuleTest.php
+++ b/tests/Rules/UnusedViewsRuleTest.php
@@ -25,7 +25,7 @@ class UnusedViewsRuleTest extends RuleTestCase
     {
         $viewParser     = new ViewParser($this->getContainer()->getService('currentPhpVersionSimpleDirectParser'));
         $viewFileHelper = new ViewFileHelper([
-            __DIR__ . '/../application/resources/views',
+            __DIR__ . '/../application/resources/views/',
             __DIR__ . '/../../vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/views',
         ], $this->getFileHelper());
 


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Fixes the following internal error when running `UnusedViewsRule`:
```php
Undefined array key 1 while running CollectedDataNode rule Larastan\Larastan\Rules\UnusedViewsRule
```

The error occurs when a service provider registers views using a path with a trailing slash:
```php
$this->loadViewsFrom(__DIR__.'/resources/views/', 'some-namespace');
//                                            ↑
```

Real-world example: [jeremykenedy/laravel-logger/src/LaravelLoggerServiceProvider.php#L80](https://github.com/jeremykenedy/laravel-logger/blob/21402b998ce3eb40b266cbb0abf093f69d86b5b7/src/LaravelLoggerServiceProvider.php#L80)


Laravel does not normalize trailing slashes when storing namespace hints, so `$finder->getHints()` can return paths with a trailing separator. This causes the `explode()` delimiter in `getAllViewNames()` to never match, leaving `$viewName` without an index `1`:
```php
array:1 [
  0 => "C:\***\vendor\jeremykenedy\laravel-logger\src/resources/views\forms\clear-activity-log.blade.php"
] // vendor\larastan\larastan\src\Support\ViewFileHelper.php:84
```


The fix normalizes `$viewDirectory` with `rtrim` before constructing the explode delimiter, guarding against both `/` and `\` separators.

```php
array:2 [
  0 => ""
  1 => "forms\clear-activity-log.blade.php"
] // vendor\larastan\larastan\src\Support\ViewFileHelper.php:81
```


**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->

_none._